### PR TITLE
This feature adds the Grunt build process for plugins

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,4 @@
+{
+    "directory" : "src/components",
+    "registry"  : "http://adapt-bower-repository.herokuapp.com/"
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,77 @@
+module.exports = function(grunt) {
+    require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+        less: {
+            dist: {
+                    files: {
+                            'build/adapt/css/adapt.css' : 'src/**/*.less'
+                    }
+            },
+            options:{
+                compress:true
+            }
+        },
+        handlebars: {
+            compile: {
+                options: {
+                    namespace:"Handlebars.templates",
+                    processName: function(filePath) {
+                        var newFilePath = filePath.split("/");
+                        newFilePath = newFilePath[newFilePath.length - 1].replace(/\.[^/.]+$/, "");
+                        return  newFilePath;
+                    },
+                    partialRegex: /^part_/,
+                    partialsPathRegex: /\/partials\//
+                },
+                files: {
+                    "build/templates/templates.js": "src/**/*.handlebars"
+                }
+            }
+        },
+        bower: {
+            target: {
+                rjsConfig: './config.js',
+                options: {
+                    baseUrl: 'src'
+                }
+            }
+        },
+        'requirejs-bundle': {
+            components: {
+                src: 'src/components/',
+                dest: 'src/components.js'
+            },
+            extensions: {
+                src: 'src/extensions/',
+                dest: 'src/extensions.js'
+            },
+            menu: {
+                src: 'src/menu/',
+                dest: 'src/menu.js'
+            },
+            theme: {
+                src: 'src/theme/',
+                dest: 'src/theme.js'
+            }
+        },
+        requirejs: {
+            compile: {
+                options: {
+                    name: "core/js/app",
+                    baseUrl: "src",
+                    mainConfigFile: "./config.js",
+                    out: "./build/adapt/js/adapt.min.js"
+                }
+            }
+        },
+        watch: {
+            files: ['src/**/*.less', 'src/**/*.handlebars'],
+            tasks: ['less', 'handlebars']
+        }
+    });
+        
+    grunt.registerTask('default',['less', 'handlebars', 'watch']);
+    grunt.registerTask('build',['less', 'handlebars', 'bower', 'requirejs-bundle', 'requirejs']);
+};

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,17 @@
+{
+  "name": "my-adapt-course",
+  "version": "0.0.0",
+  "authors": [
+    "AdaptLearning"
+  ],
+  "main": "build/index.html",
+  "license": "GPLv3",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "test"
+  ],
+  "dependencies": {
+  }
+}

--- a/config.js
+++ b/config.js
@@ -1,0 +1,33 @@
+require.config({
+    paths: {
+        jquery: 'core/js/libraries/jquery.v2',
+        underscore: 'core/js/libraries/underscore',
+        backbone: 'core/js/libraries/backbone',
+        modernizr: 'core/js/libraries/modernizr',
+        handlebars: 'core/js/libraries/handlebars',
+        imageReady: 'core/js/libraries/imageReady',
+        inview: 'core/js/libraries/inview',
+        scrollTo: 'core/js/libraries/scrollTo',
+        coreJS: 'core/js',
+        coreViews: 'core/js/views',
+        templates: '../build/templates/templates'
+    },
+    shim: {
+        jquery: [
+
+        ],
+        backbone: {
+            deps: [
+                'core/js/libraries/underscore',
+                'core/js/libraries/jquery.v2'
+            ],
+            exports: 'Backbone'
+        },
+        underscore: {
+            exports: '_'
+        },
+        handlebars: {
+            exports: 'Handlebars'
+        }
+    }
+});

--- a/package.json
+++ b/package.json
@@ -16,6 +16,17 @@
     "url": "https://github.com/adaptlearning/adapt_framework/issues"
   },
   "devDependencies": {
-    "mocha": "~1.13.0"
+    "mocha": "~1.13.0",
+    "matchdep": "~0.3.0",
+    "grunt": "~0.4.1",
+    "grunt-contrib-less": "~0.7.0",
+    "grunt-contrib-handlebars": "~0.5.11",
+    "grunt-contrib-watch": "~0.5.1",
+    "grunt-contrib-requirejs": "~0.4.1",
+    "grunt-contrib-connect": "~0.3.0",
+    "grunt-concurrent": "~0.3.0",
+    "grunt-open": "~0.2.2",
+    "grunt-bower-requirejs": "~0.7.1",
+    "grunt-requirejs-bundle": "~0.0.4"
   }
 }

--- a/src/core/js/app.js
+++ b/src/core/js/app.js
@@ -1,0 +1,2 @@
+/*globals define*/
+define(['components', 'extensions', 'menu', 'theme'], function () {});


### PR DESCRIPTION
The plugin system uses Bower to locate and install the files. All plugins must
be defined as AMD modules using the define function
i.e. define(name, deps, factory)

The following grunt tasks compile the less/css, handlebars into the build
directory:-

```
grunt-contrib-less
grunt-contrib-handlebars
```

Then there is a [custom task](https://github.com/cajones/grunt-requirejs-bundle) to scan for plugins and bundle the into a single amd module, this is 

```
grunt-requirejs-bundle
```

This is followed by

```
grunt-bower-requirejs
```

a [yeoman task](https://github.com/yeoman/grunt-bower-requirejs) that inspects bower packages and
wires-up the packages main js file with requirejs.

Finally we can run grunt-contrib-requirejs to compile the prepared modules.
