### PR TITLE
Fix for "Components that are already inview do not fire the inview event"

### DIFF
--- a/src/core/js/views/pageView.js
+++ b/src/core/js/views/pageView.js
@@ -27,9 +27,9 @@ define(function(require) {
         isReady: function() {
             _.defer(_.bind(function() {
                 $('.loading').hide();
-                $(window).scroll();
                 Adapt.trigger('pageView:ready', this);
                 this.$el.animate({'opacity': 1}, 'fast');
+                $(window).scroll();
             }, this));
         }
         


### PR DESCRIPTION
This moved the scroll() event down from before PageReady to after
