### PR TITLE
Adds event trigger when no items found in drawer

### DIFF
--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -62,6 +62,7 @@ define(function(require) {
 		checkIfDrawerIsAvailable: function() {
 			if(this.collection.length == 0) {
 				$('.navigation-drawer-toggle-button').addClass('display-none');
+				Adapt.trigger('drawer:noItems');
 			}
 		},
 


### PR DESCRIPTION
Triggers an application wide event to indicate that no items are present in the drawer. Useful if an extension is appended to be the bottom item in the drawer, rather than being added to the Drawer Collection. The [Kineo Search extension](https://github.com/cgkineo/adapt-search) (which we're hoping to push to contrib status) has a dependency on this event. 
