### PR TITLE
Move theme less to last in grunt concat

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -99,11 +99,11 @@ module.exports = function(grunt) {
         concat: {
             less: {
                 src: [
-                    'src/core/less/*.less', 
-                    'src/theme/**/*.less', 
-                    'src/menu/**/*.less', 
-                    'src/components/**/*.less', 
-                    'src/extensions/**/*.less'
+                    'src/core/less/*.less',
+                    'src/menu/**/*.less',
+                    'src/components/**/*.less',
+                    'src/extensions/**/*.less',
+                    'src/theme/**/*.less'
                 ],
                 dest: 'src/less/adapt.less'
             }


### PR DESCRIPTION
Fixes Jira issue ABU-309. Github issue#466.

Theme needs to be last otherwise you can’t override the css in the components/extensions/core etc.
