### PR TITLE
Minor fix for issue#466

### DIFF
--- a/src/core/less/base.less
+++ b/src/core/less/base.less
@@ -96,7 +96,7 @@
 .loading {
     width: 100%;
     height: 100%;
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     z-index: 5000;


### PR DESCRIPTION
Stops loading image scrolling off page in iOS7 etc.
