### PR TITLE
Hard/soft reset implementation

### DIFF
--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -13,7 +13,9 @@ define(function (require) {
 
         defaults: {
             _canShowFeedback: true,
+            _canReset: false,
             _isComplete: false,
+            _isInteractionComplete: false,
             _isEnabled: true,
             _isResetOnRevisit: false,
             _isAvailable: true,
@@ -55,13 +57,36 @@ define(function (require) {
             if (this._children) {
                 Adapt[this._children].on({
                     "change:_isReady": this.checkReadyStatus,
-                    "change:_isComplete": this.checkCompletionStatus
+                    "change:_isComplete": this.checkCompletionStatus,
+                    "change:_isInteractionComplete": this.checkInteractionCompletionStatus
                 }, this);
             }
             this.init();
         },
 
         init: function() {},
+
+        reset: function(type, force) {
+            if (!this.get("_canReset") && !force) return;
+
+            type = type || true;
+            
+            switch (type) {
+            case "hard": case true:
+                this.set({
+                    _isEnabled: true,
+                    _isComplete: false,
+                    _isInteractionComplete: false,
+                });
+                break;
+            case "soft": 
+                this.set({
+                    _isEnabled: true,
+                    _isInteractionComplete: false
+                });
+                break;
+            }
+        },
 
         checkReadyStatus: function () {
             // Filter children based upon whether they are available
@@ -77,8 +102,25 @@ define(function (require) {
             var availableChildren = new Backbone.Collection(this.getChildren().where({_isAvailable: true}));
             // Check if any return _isComplete:false
             // If not - set this model to _isComplete: true
-            if (availableChildren.findWhere({_isComplete: false})) return;
+            if (availableChildren.findWhere({_isComplete: false})) {
+                //cascade reset to menu
+                this.set({_isComplete:false});
+                return;
+            }
             this.set({_isComplete: true});
+        },
+
+        checkInteractionCompletionStatus: function () {
+            // Filter children based upon whether they are available
+            var availableChildren = new Backbone.Collection(this.getChildren().where({_isAvailable: true}));
+            // Check if any return _isInteractionComplete:false
+            // If not - set this model to _isInteractionComplete: true
+            if (availableChildren.findWhere({_isInteractionComplete: false})) {
+                //cascade reset to menu
+                this.set({_isInteractionComplete:false});
+                return;
+            }
+            this.set({_isInteractionComplete: true});
         },
 
         findAncestor: function (ancestors) {

--- a/src/core/js/models/componentModel.js
+++ b/src/core/js/models/componentModel.js
@@ -25,7 +25,7 @@ define(function(require) {
 
             type = type || true;
 
-            this.constructor.__super__.reset.call(this, type, force);
+            AdaptModel.prototype.reset.call(this, type, force);
             
             if (this.get("_isQuestionType")) {
                 var attempts = this.get('_attempts');

--- a/src/core/js/models/componentModel.js
+++ b/src/core/js/models/componentModel.js
@@ -19,6 +19,25 @@ define(function(require) {
         		}
             }
     	},
+
+        reset: function(type, force) {
+            if (!this.get("_canReset") && !force) return;
+
+            type = type || true;
+
+            this.constructor.__super__.reset.call(this, type, force);
+            
+            if (this.get("_isQuestionType")) {
+                var attempts = this.get('_attempts');
+                this.set({
+                    _attemptsLeft: attempts,
+                    _isCorrect: false,
+                    _isSubmitted: false,
+                    _buttonState: 'submit'
+                });
+            }
+        },
+
         _parent:'blocks',
     	_siblings:'components'
     });

--- a/src/core/js/models/courseModel.js
+++ b/src/core/js/models/courseModel.js
@@ -26,7 +26,8 @@ define(function(require) {
         setupListeners: function() {
             Adapt[this._children].on({
                 "change:_isReady": this.checkReadyStatus,
-                "change:_isComplete": this.checkCompletionStatus
+                "change:_isComplete": this.checkCompletionStatus,
+                "change:_isInteractionComplete": this.checkInteractionCompletionStatus
             }, this);
         },
 

--- a/src/core/js/views/adaptView.js
+++ b/src/core/js/views/adaptView.js
@@ -60,6 +60,20 @@ define(function(require) {
         setCompletionStatus: function() {
             if (this.model.get('_isVisible')) {
                 this.model.set('_isComplete', true);
+                this.model.set('_isInteractionComplete', true);
+            }
+        },
+
+        resetCompletionStatus: function(type) {
+            if (!this.model.get("_canReset")) return;
+            
+            var descendantComponents = this.model.findDescendants('components');
+            if (descendantComponents.length === 0) {
+                this.model.reset(type);
+            } else {
+                descendantComponents.each(function(model) {
+                    model.reset(type);
+                });
             }
         },
 

--- a/src/core/js/views/buttonsView.js
+++ b/src/core/js/views/buttonsView.js
@@ -64,12 +64,12 @@ define(function() {
         },
 
         updateAttemptsCount: function(model, changedAttribute) {
-            var isComplete = this.model.get('_isComplete');
+            var isInteractionComplete = this.model.get('_isInteractionComplete');
             var attemptsLeft = (this.model.get('_attemptsLeft')) ? this.model.get('_attemptsLeft') : this.model.get('_attempts')
             var isCorrect = this.model.get('_isCorrect');
             var shouldDisplayAttempts = this.model.get('_shouldDisplayAttempts');
             var attemptsString;                        
-            if (!isComplete && attemptsLeft != 0) {
+            if (!isInteractionComplete && attemptsLeft != 0) {
                 attemptsString = attemptsLeft + " ";
                 if (attemptsLeft > 1) {
                     attemptsString += this.model.get('_buttons').remainingAttemptsText;

--- a/src/core/js/views/questionView.js
+++ b/src/core/js/views/questionView.js
@@ -69,27 +69,21 @@ define(function(require) {
             // If reset is enabled set defaults
             // Call blank method for question to handle
             if (isResetOnRevisit) {
-                var attempts = this.model.get('_attempts');
-                this.model.set({
-                    _isEnabled: true,
-                    _attemptsLeft: attempts,
-                    _isCorrect: false,
-                    _isComplete: false,
-                    _isSubmitted: false,
-                    _buttonState: 'submit'
-                });
-                // Defer is added to allow the component to render
+
+                this.model.reset(isResetOnRevisit, true);
+
+                 // Defer is added to allow the component to render
                 _.defer(_.bind(function() {
-                    this.resetQuestionOnRevisit();
+                   this.resetQuestionOnRevisit(isResetOnRevisit);
                 }, this));
 
             } else {
 
                 // If complete - display users answer
                 // or reset the question if not complete
-                var isComplete = this.model.get('_isComplete');
+                var isInteractionComplete = this.model.get('_isInteractionComplete');
 
-                if (isComplete) {
+                if (isInteractionComplete) {
                     this.model.set('_buttonState', 'hideCorrectAnswer');
                     // Defer is added to allow the component to render
                     _.defer(_.bind(function() {
@@ -109,7 +103,7 @@ define(function(require) {
         },
 
         // Used by the question to reset the question when revisiting the component
-        resetQuestionOnRevisit: function() {},
+        resetQuestionOnRevisit: function(type) {},
 
         // Calls default methods to setup on questions
         setupDefaultSettings: function() {
@@ -309,12 +303,12 @@ define(function(require) {
         // _buttonState on the model which buttonsView listens to
         updateButtons: function() {
 
-            var isComplete = this.model.get('_isComplete');
+            var isInteractionComplete = this.model.get('_isInteractionComplete');
             var isCorrect = this.model.get('_isCorrect');
             var isEnabled = this.model.get('_isEnabled');
             var buttonState = this.model.get('_buttonState');
 
-            if (isComplete) {
+            if (isInteractionComplete) {
                 if (isCorrect || !this.model.get('_canShowModelAnswer')) {
                     this.model.set('_buttonState', 'complete');
                 } else {


### PR DESCRIPTION
Each model has two new attributes. _canReset and _isInteractionComplete.

_canReset stops a component from being reset by default. 

Each model has a new function called ‘reset’ which takes two parameters ‘type’ and ‘force’. 
Type can be ‘hard’/true or ‘soft’. 
The optional ‘force’ parameter over-rides the behaviour of _canReset. 
This function will only be performed on the model on which it is called.

_isInteractionComplete and _isComplete now cascade from component to page on both true and false. i.e. if a component is set to _isInteractionComplete: false, then its parents will cascade accordingly down to menu level in the same way it does if _isComplete: true.

Each view has a new function called ‘resetCompletionStatus’ which takes a single parameter ‘type’. 
Type can be ‘hard’/true, ‘soft’. 
This function performs a reset on its highest children. When enacted at a page level it will reset all of the components within that page. These component statuses will then cascade downward according to the cascade behaviour above.

checkIfResetOnRevisit will now force the reset function from the model.
checkIfResetOnRevisit can take model attributes values such as _resetOnRevisit: ‘hard’/true or ‘soft’ keeping its original behaviour intact.

The visual states of the buttons and attempts calculations are dependent upon the _isInteractionComplete attribute instead of the _isComplete attribute.
