### PR TITLE
Revert grunt-contrib-handlebars to ~0.5.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "grunt-concurrent": "~1.0.0",
     "grunt-contrib-connect": "~0.9.0",
     "grunt-contrib-copy": "~0.7.0",
-    "grunt-contrib-handlebars": "~0.9.2",
+    "grunt-contrib-handlebars": "~0.5.11",
     "grunt-contrib-less": "~1.0.0",
     "grunt-contrib-requirejs": "~0.4.4",
     "grunt-contrib-watch": "~0.6.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "grunt-concurrent": "~1.0.0",
     "grunt-contrib-connect": "~0.9.0",
     "grunt-contrib-copy": "~0.7.0",
-    "grunt-contrib-handlebars": "~0.5.11",
+    "grunt-contrib-handlebars": "~0.8.0",
     "grunt-contrib-less": "~1.0.0",
     "grunt-contrib-requirejs": "~0.4.4",
     "grunt-contrib-watch": "~0.6.1",


### PR DESCRIPTION
Can't run course with the current handlebars version