### PR TITLE
if_value_equals doesn't pass context back

### DIFF
--- a/src/core/js/helpers.js
+++ b/src/core/js/helpers.js
@@ -23,7 +23,7 @@ define(function(require){
                 if (value === text) {
                     return block.fn(this);
                 } else {
-                    return block.inverse();
+                    return block.inverse(this);
                 }
             }
         };


### PR DESCRIPTION
if_value_equals helper does not pass context back when returning
block.inverse.

fixes #530