### PR TITLE
Accessibility integration 2

### DIFF
--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -11,61 +11,319 @@ define(function(require) {
     var AccessibilityView = require('coreViews/accessibilityView');
 
     var Accessibility = _.extend({
+        $html: $('html'),
+        $accessibilityInstructions: $("#accessibility-instructions"),
+        $accessibilityToggle: $("#accessibility-toggle"),
+        _tabIndexElements: 'a, button, input, select, textarea, [tabindex]',
+        _hasTabPosition: false,
+        _isLoaded: false,
+        _legacyFocusElements: undefined,
 
-        setupLegacyFocus: function() {
-            var tabIndexElements = 'a, button, input, select, textarea';
-            // Set tabindex of 0 on tabIndexElements, on focus add class of focused, on blur remove class 
-            $(tabIndexElements)
-                .attr('tabindex', 0)
-                .on('focus', function() {
-                    $(this).addClass('focused');
-                })
-                .on('blur', function() {
-                    $(this).removeClass('focused');
+        setupRequiredListeners: function() {
+            //RUN ONCE
+            if (this._isLoaded) return;
+
+            //CAPTURE TAB PRESSES TO DIVERT
+            $('body').on('keyup', this.onKeyUp);
+
+            //CAPTURE ROUTING/NEW DOCUMENT LOADING START AND END
+            this.listenTo(Adapt, 'router:location', this.onNavigationStart);
+            this.listenTo(Adapt, 'pageView:ready menuView:ready router:plugin', this.onNavigationEnd);
+
+            //TRIGGER SETUP ON DATA LOADED AND TOGGLE BUTTON
+            Adapt.once('app:dataLoaded', this.setupAccessibility, Accessibility);
+            Adapt.on('accessibility:toggle', this.setupAccessibility, Accessibility); 
+
+            //SETUP NEW VIEW FOR TOGGLE BUTTON
+            Adapt.once('app:dataReady', function() {
+                new AccessibilityView();
                 });
-            // Set object tab index to -1
-            $('object').attr('tabindex', -1);
         },
 
-        removeLegacyFocus: function() {
+        setupHelpers: function() {
+            //RUN ONCE
+            if (this._isLoaded) return;
 
-            var tabIndexElements = 'a, button, input, select, textarea';
-            $(tabIndexElements).off('focus').off('blur');
+            //MAKE $.a11y_text and $.a11y_normalize IN GLOBAL HANDLEBARS HELPERS a11y_text and a11y_normalize
+            Handlebars.registerHelper('a11y_text', function(text) {
+                return $.a11y_text(text);
+            });
+
+            Handlebars.registerHelper('a11y_normalize', function(text) {
+                return $.a11y_normalize(text);
+            });
 
         },
 
-        setupListeners: function() {
-            // Listen for pageView / menuView ready, set legacyFocus
-            this.listenTo(Adapt, 'pageView:ready menuView:ready', this.setupLegacyFocus);
+        touchDeviceCheck: function() {
+            //SCREEN READER DON@T USE TABBING
+            //FORCE ACCESSIBILITY ON TO RENDER NECESSARY STUFFS FOR TOUCH DEVICE SCREENREADERS
 
+            var isEnabled = this.isEnabled();
+
+            if (!Modernizr.touch || isEnabled) return;
+
+            //If a touch device and not enabled, remove accessibility button and turn on accessibility
+
+            this._isLoaded = true;
+            
+             //Remove button  
+            this.$accessibilityToggle.remove();
+
+            //Force accessibility on
+            Adapt.config.get('_accessibility')._isEnabled = true;
+            Adapt.trigger('accessibility:toggle', true);
+
+        },
+
+        isEnabled: function() {
+            return Adapt.config.get('_accessibility') && Adapt.config.get('_accessibility')._isEnabled;
         },
 
         setupAccessibility: function() {
+            //CALLED ON BUTTON CLICK AND ON DATA LOAD
+
+            this.setupHelpers();
+
+            this.touchDeviceCheck();
+
             // Check if accessibility is enabled
-            if (Adapt.config.get('_accessibility') && Adapt.config.get('_accessibility')._isEnabled) {
-                // If enabled add accessibility class
-                // If legacy enabled run setupListeners()
-                if($('html').addClass('accessibility').hasClass('ie8') && Adapt.config.get('_accessibility')._shouldSupportLegacyBrowsers) {
-                    this.setupLegacyFocus();
-                    this.setupListeners();
-                }
+            var isEnabled = this.isEnabled();
+
+            this.checkTabCapture();
+
+            if (isEnabled) {
+                
+                this.setupDocument();
+                this.setupLegacy();
+                this.setupPopupListeners()
+                this.setupUsageInstructions();
+                this.setupLogging();
+                this.focusInitial();
+
             } else {
-                $('html').removeClass('accessibility');
-                this.removeLegacyFocus();
-                // Stop listeningTo
-                this.stopListening(Adapt, 'pageView:ready menuView:ready', this.setupLegacyFocus);
+
+                this.rollbackDocument();
+                this.rollbackLegacy();
+                this.rollbackPopupListeners();
+                this.rollbackUsageInstructions();
+                this.rollbackLogging();
+            
+                }
+
+
+
+        },
+
+        checkTabCapture: function() {
+            if (!this._isLoaded) return;
+
+            var isEnabled = this.isEnabled();
+            
+            $.a11y( isEnabled );
+
+            if ( isEnabled ) {
+
+                //IF ACCESSIBILTY TURNED ON GOTO FIRST FOCUSABLE ITEM
+                this.focusInitial();
+
+            } else {
+
+                //OTHERWISE ENABLE TAB REDIRECTION TO TOGGLE BUTTON
+                this._hasTabPosition = false;
             }
+        },
+
+        setupDocument: function() {
+            this.$html.addClass('accessibility');
+            $.a11y(true)
+            $.a11y_on(true);
+        },
+
+        rollbackDocument: function() {
+            this.$html.removeClass('accessibility');
+            $.a11y(false)
+            $.a11y_on(false);
+        },
+
+        setupLegacy: function() {
+            //IE8 .focused CLASS AS :focus ISN'T AVAILABLE
+
+            if(!this.$html.hasClass('ie8') || !Adapt.config.get('_accessibility')._shouldSupportLegacyBrowsers) return;
+
+            // If legacy enabled run setupLegacyListeners()
+            this.listenTo(Adapt, 'pageView:ready menuView:ready', this.setupLegacyFocusClasser);
+            this.listenTo(Adapt, 'remove', this.removeLegacyFocusClasser);
+
+        },
+
+        rollbackLegacy: function() {
+
+            if(!this.$html.hasClass('ie8') || !Adapt.config.get('_accessibility')._shouldSupportLegacyBrowsers) return;
+
+            this.stopListening(Adapt, 'pageView:ready menuView:ready', this.setupLegacyFocusClasser);
+            this.stopListening(Adapt, 'remove', this.removeLegacyFocusClasser);
+
+        },
+
+        setupPopupListeners: function() {
+            this.listenTo(Adapt, 'popup:opened popup:closed', this.onPop);
+        },
+
+        rollbackPopupListeners: function() {
+            this.stopListening(Adapt, 'popup:opened popup:closed', this.onPop);
+        },
+
+        setupUsageInstructions: function() {            
+            if (!Adapt.course.get("_globals")._accessibility || !Adapt.course.get("_globals")._accessibility._accessibilityInstructions) {
+                this.$accessibilityInstructions.remove();
+                return;
+            }
+
+            var instructionsList = Adapt.course.get("_accessibility")._accessibilityInstructions;
+
+            var usageInstructions;
+            if (instructionsList[Adapt.device.browser]) {
+                usageInstructions = instructionsList[Adapt.device.browser];
+            } else if (Modernizr.touch) {
+                usageInstructions = instructions.touch || "";
+            } else {
+                usageInstructions = instructions.notouch || "";
+            }
+
+           this.$accessibilityInstructions
+                .once("blur", onFocusInstructions)
+                .html( usageInstructions );
+        },
+
+        rollbackUsageInstructions: function() {
+            if (!Adapt.course.get("_globals")._accessibility || !Adapt.course.get("_globals")._accessibility._accessibilityInstructions) return;
+
+            this.$accessibilityInstructions
+                .off("blur", onFocusInstructions)
+        },
+
+        setupLogging: function() {
+            if (!Adapt.course.get("_globals")._accessibility || !Adapt.course.get("_globals")._accessibility._logReading) return;
+
+            $($.a11y).on("reading", this.onRead);
+        },
+
+        rollbackLogging: function() {
+            if (!Adapt.course.get("_globals")._accessibility || !Adapt.course.get("_globals")._accessibility._logReading) return;
+
+            $($.a11y).off("reading", this.onRead);
+        },
+
+        setupLegacyFocusClasser: function() {
+            this.removeLegacyFocusClasser();
+
+            // On focus add class of focused, on blur remove class 
+            this._legacyFocusElements = $(this._tabIndexElements);
+            this._legacyFocusElements
+                .on('focus', this.onElementFocused)
+                .on('blur', this.onElementBlurred);
+        },
+
+        removeLegacyFocusClasser: function() {
+            if (this._legacyFocusElements === undefined) return;
+
+            //Remove focus and blur events
+            this._legacyFocusElements
+                .off('focus', this.onElementFocused)
+                .off('blur', this.onElementBlurred);
+            this._legacyFocusElements = undefined;
+
+        },
+
+        focusInitial: function() {
+            if (!this.isEnabled()) return;
+
+            this._hasTabPosition = true;
+
+            _.delay(function() {
+                $.a11y_focus();
+            }, 250);
+        },
+
+        onElementFocused: function(event) {
+             $(this).addClass('focused');
+        },
+
+        onElementBlurred: function(event) {
+            $(this).removeClass('focused');
+        },
+
+        onNavigationStart: function() {
+            this._isLoaded = false;
+            //STOP DOCUMENT READING
+            $.a11y_on(false);
+        },
+
+        onNavigationEnd: function() {
+            var isEnabled = this.isEnabled();
+
+            this._isLoaded = true;
+
+            if (isEnabled) {
+                var topOffset = $('.navigation').height()+10;
+                var bottomoffset = 0;
+
+                $.a11y.options.focusOffsetTop = topOffset;
+                $.a11y.options.focusOffsetBottom = bottomoffset;
+                $.a11y.options.OS = Adapt.device.OS.toLowerCase();     
+                $.a11y.options.isTouchDevice = Modernizr.touch;
+                
+                //ENABLED DOCUMENT READING
+                $.a11y_on(true);
+
+                //UPDATE NEW DOCUMENT WITH ARIA_LABEL CONFIGURATIONS ETC
+                $.a11y_update();
+            } else {
+                this.touchDeviceCheck();
+            }
+            
+            //MAKE FOCUS RIGHT
+            this._hasTabPosition = false
+            this.focusInitial();
+
+        },
+
+        onRead: function(event, text) {
+            //OUTPUT READ TEXT TO CONSOLE
+            console.log("READING: " + text);
+        },
+
+        onPop: function() {
+            var isEnabled = this.isEnabled();
+
+            //MAKE SURE POPUP IS CONFIGURED CORRECTLY WITH ARIA LABELS, TABINDEXES ETC
+            if ( isEnabled ) $.a11y_update();
+        },
+
+        onKeyUp: function(event) {
+
+            //IF NOT TAB KEY, RETURN
+            if (event.which !== 9) return;
+
+            //IF INITIAL TAB NOT CAPTURED AND ACCESSIBILITY NOT ON, RETURN
+            if ( Accessibility.isEnabled() && Accessibility._hasTabPosition ) return;
+                   
+            //IF TAB PRESSED, AND TAB REDIRECTION ON, ALWAYS TAB TO ACCESSIBILITY BUTTON ONLY
+            Accessibility.$accessibilityToggle.focus();
+
+        },
+
+        onFocusInstructions: function(event) {
+            //HIDE INSTRUCTIONS FROM TAB WRAP AROUND AFTER LEAVING INSTRUCTIONS
+            if (!Accessibility._hasTabPosition) return;
+            if (!Accessibility._isLoaded) return;
+            $(event.target).addClass("a11y-ignore-focus");
         }
 
     }, Backbone.Events);
 
 
-    Adapt.on('accessibility:toggle', Accessibility.setupAccessibility, Accessibility);
+    Accessibility.setupRequiredListeners();
 
-    Adapt.once('configModel:dataLoaded', Accessibility.setupAccessibility, Accessibility);
-
-    Adapt.once('app:dataReady', function() {
-         new AccessibilityView();
     });
-
-});

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -242,6 +242,7 @@ define(function(require) {
             this._hasTabPosition = true;
 
             _.delay(function() {
+                //ENABLED DOCUMENT READING
                 $.a11y_on(true, '#wrapper');
                 if (Adapt.location._currentId) {
                     //required to stop JAWS from auto reading content in IE
@@ -295,9 +296,6 @@ define(function(require) {
                 $.a11y.options.OS = Adapt.device.OS.toLowerCase();     
                 $.a11y.options.isTouchDevice = Modernizr.touch;
                 
-                //ENABLED DOCUMENT READING
-                $.a11y_on(true);
-
                 //UPDATE NEW DOCUMENT WITH ARIA_LABEL CONFIGURATIONS ETC
                 $.a11y_update();
             } else {

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -242,8 +242,28 @@ define(function(require) {
             this._hasTabPosition = true;
 
             _.delay(function() {
+                $.a11y_on(true, '#wrapper');
+                if (Adapt.location._currentId) {
+                    //required to stop JAWS from auto reading content in IE
+                    var currentModel = Adapt.findById(Adapt.location._currentId);
+                    var alertText = " ";
+                    switch (currentModel.get("_type")) {
+                    case "page":
+                        if (Adapt.course.get("_accessibility") && Adapt.course.get("_accessibility")._ariaLabels && Adapt.course.get("_accessibility")._ariaLabels.pageLoaded) {
+                            alertText = Adapt.course.get("_accessibility")._ariaLabels.pageLoaded;
+                        }
+                        break;
+                    case "menu":
+                        if (Adapt.course.get("_accessibility") && Adapt.course.get("_accessibility")._ariaLabels && Adapt.course.get("_accessibility")._ariaLabels.menuLoaded) {
+                            alertText = Adapt.course.get("_accessibility")._ariaLabels.menuLoaded;
+                        }
+                        break;
+                    }
+                    $.a11y_alert(alertText);
+                }
                 $.a11y_focus();
-            }, 250);
+            }, 1000);
+            
         },
 
         onElementFocused: function(event) {
@@ -256,8 +276,9 @@ define(function(require) {
 
         onNavigationStart: function() {
             this._isLoaded = false;
-            //STOP DOCUMENT READING
-            $.a11y_on(false);
+            //STOP DOCUMENT READING, MOVE FOCUS TO APPROPRIATE LOCATION
+            $.a11y_on(false, '#wrapper');
+            $("#a11y-focuser").focusNoScroll();
         },
 
         onNavigationEnd: function() {

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -186,13 +186,13 @@ define(function(require) {
             if (instructionsList[Adapt.device.browser]) {
                 usageInstructions = instructionsList[Adapt.device.browser];
             } else if (Modernizr.touch) {
-                usageInstructions = instructions.touch || "";
+                usageInstructions = instructionsList.touch || "";
             } else {
-                usageInstructions = instructions.notouch || "";
+                usageInstructions = instructionsList.notouch || "";
             }
 
            this.$accessibilityInstructions
-                .once("blur", onFocusInstructions)
+                .one("blur", this.onFocusInstructions)
                 .html( usageInstructions );
         },
 
@@ -200,7 +200,7 @@ define(function(require) {
             if (!Adapt.course.get("_globals")._accessibility || !Adapt.course.get("_globals")._accessibility._accessibilityInstructions) return;
 
             this.$accessibilityInstructions
-                .off("blur", onFocusInstructions)
+                .off("blur", this.onFocusInstructions)
         },
 
         setupLogging: function() {

--- a/src/core/js/device.js
+++ b/src/core/js/device.js
@@ -74,9 +74,10 @@ define(function(require) {
     }
 
     var browserString = browser + " version-" + version + " OS-" + OS;
-    Adapt.device.browser = browser;
-    Adapt.device.version = version;
-    Adapt.device.OS = OS;
+	/*MAKE DEVICE IDENTIFICATION UNIFORM CASE*/
+    Adapt.device.browser = browser.toLowerCase();
+    Adapt.device.version = version.toLowerCase();
+    Adapt.device.OS = OS.toLowerCase();
     
     $("html").addClass(browserString);
     

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -10,6 +10,7 @@
     var focusableElements = "a,button,input,select,textarea,[tabindex]";
     var hideableElements = ".a11y-hideable";
     var ariaLabelElements = "div[aria-label], span[aria-label]";
+    var ariaLabelElementsFilter = ":not( .a11y-ignore-aria [aria-label] )";
 
 
     var $documentActiveElement;
@@ -362,7 +363,12 @@
         enabled = enabled === undefined ? true : enabled;
         for (var i = 0; i < this.length; i++) {
             var $item = $(this[i]);
-            if (enabled) {
+            if (enabled && $item.is(hideableElements)) {
+                $item.removeAttr("aria-hidden").removeClass("aria-hidden").parents().removeAttr("aria-hidden").removeClass("aria-hidden");
+                if (withDisabled) {
+                    $item.removeAttr("disabled").removeClass("disabled");
+                }
+            } else if (enabled) {
                 $item.attr({
                     tabindex: "0",
                 }).removeAttr("aria-hidden").removeClass("aria-hidden").parents().removeAttr("aria-hidden").removeClass("aria-hidden");
@@ -469,6 +475,8 @@
     };
 
 
+    var ie8TabIndexes = {};
+    var ie8ElementUID = 0;
 //FOCUS RESTRICTION
 
     //ALLOWS FOCUS ON SELECTED ELEMENTS ONLY
@@ -485,6 +493,25 @@
             $elements = $(tabIndexElements).filter(tabIndexElementFilter);
             $hideable = $(hideableElements).filter(tabIndexElementFilter);
         }
+        if ($.a11y.options.OS == "ie8") {
+            $elements.each(function(index, item) {
+                var $item = $(item);
+                
+                var uid;
+                if ($item.a11y_uid == undefined) $item.a11y_uid = "UID" + ++ie8ElementUID;
+                uid = $item.a11y_uid;
+
+                if (storeLastTabIndex) {
+                    if (ie8TabIndexes[uid] === undefined) ie8TabIndexes[uid] = [];
+                    ie8TabIndexes[uid].push( $item.attr('tabindex') || 0 );
+                }
+
+                $item.attr({
+                    'tabindex': -1,
+                    'aria-hidden': true
+                }).addClass("aria-hidden");
+            });
+        } else {
         $elements.each(function(index, item) {
             var $item = $(item);
             if (storeLastTabIndex) {
@@ -496,6 +523,7 @@
                 'aria-hidden': true
             }).addClass("aria-hidden");
         });
+        }
         $hideable.attr("aria-hidden", true).attr("tabindex", "-1").addClass("aria-hidden");
 
         this.find(tabIndexElements).filter(tabIndexElementFilter).attr({
@@ -522,6 +550,27 @@
 
     //RESTORES FOCUS TO PREVIOUS STATE AFTER a11y_popup
     $.a11y_popdown = function() {
+        if ($.a11y.options.OS == "ie8") {
+            $(tabIndexElements).filter(tabIndexElementFilter).each(function(index, item) {
+                var $item = $(item);
+                var pti = 0;
+
+                var uid;
+                if ($item.a11y_uid == undefined) $item.a11y_uid = "UID" + ++ie8ElementUID;
+                uid = $item.a11y_uid;
+
+
+                if (ie8ElementUID[uid] !== undefined && ie8ElementUID[uid].length !== 0) pti = parseInt(ie8ElementUID[uid].pop());
+                if (ie8ElementUID[uid] !== undefined && ie8ElementUID[uid].length > 0) delete ie8ElementUID[uid];
+                
+                $item.attr({
+                    'tabindex': pti
+                })
+
+                if (pti === -1) $item.attr('aria-hidden', true).addClass("aria-hidden");
+                else $item.removeAttr('aria-hidden').removeClass("aria-hidden");;
+            });
+        } else {
         $(tabIndexElements).filter(tabIndexElementFilter).each(function(index, item) {
             var $item = $(item);
             var pti = 0;
@@ -532,6 +581,7 @@
             if (pti === -1) $item.attr('aria-hidden', true).addClass("aria-hidden");
             else $item.removeAttr('aria-hidden').removeClass("aria-hidden");;
         });
+        }
 
         var $activeElement = $.a11y.focusStack.pop();
 
@@ -596,8 +646,6 @@
 
 
 //CONVERT ARIA LABELS
-
-
     //TURNS aria-label ATTRIBUTES INTO SPAN TAGS
     $.fn.a11y_aria_label = function(deep) {
         if (!$.a11y.isOn) return this;
@@ -605,9 +653,9 @@
 
         for (var i = 0; i < this.length; i++) {
             var $item = $(this[i]);
-            if ($item.is(ariaLabelElements)) ariaLabels.push(this[i]);
+            if ($item.not(ariaLabelElementsFilter).is(ariaLabelElements)) ariaLabels.push(this[i]);
             if (deep === true) {
-                var children = $item.find(ariaLabelElements);
+                var children = $item.find(ariaLabelElements).filter(ariaLabelElementsFilter);
                 ariaLabels = ariaLabels.concat(children.toArray());
             }
         }

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -11,6 +11,7 @@
     var hideableElements = ".a11y-hideable";
     var ariaLabelElements = "div[aria-label], span[aria-label]";
     var ariaLabelElementsFilter = ":not( .a11y-ignore-aria [aria-label] )";
+    var parentsFilter = ":not(#wrapper):not(body)";
 
 
     var $documentActiveElement;
@@ -332,13 +333,14 @@
 
 //TOGGLE ACCESSIBILITY
     //MAKES CHILDREN ACCESSIBLE OR NOT
-    $.a11y_on = function(isOn) {
+    $.a11y_on = function(isOn, selector) {
+        selector = selector || 'body';
         isOn = isOn === undefined ? true : isOn;
         if (isOn === false) {
-            $('body').attr("aria-hidden", true);
+            $(selector).attr("aria-hidden", true);
             $.a11y.options.isOn = false;
         } else {
-            $('body').removeAttr("aria-hidden");
+            $(selector).removeAttr("aria-hidden");
             $.a11y.options.isOn = true;
         }
     };
@@ -364,14 +366,14 @@
         for (var i = 0; i < this.length; i++) {
             var $item = $(this[i]);
             if (enabled && $item.is(hideableElements)) {
-                $item.removeAttr("aria-hidden").removeClass("aria-hidden").parents().removeAttr("aria-hidden").removeClass("aria-hidden");
+                $item.removeAttr("aria-hidden").removeClass("aria-hidden").parents(parentsFilter).removeAttr("aria-hidden").removeClass("aria-hidden");
                 if (withDisabled) {
                     $item.removeAttr("disabled").removeClass("disabled");
                 }
             } else if (enabled) {
                 $item.attr({
                     tabindex: "0",
-                }).removeAttr("aria-hidden").removeClass("aria-hidden").parents().removeAttr("aria-hidden").removeClass("aria-hidden");
+                }).removeAttr("aria-hidden").removeClass("aria-hidden").parents(parentsFilter).removeAttr("aria-hidden").removeClass("aria-hidden");
                 if (withDisabled) {
                     $item.removeAttr("disabled").removeClass("disabled");
                 }
@@ -528,8 +530,8 @@
 
         this.find(tabIndexElements).filter(tabIndexElementFilter).attr({
             'tabindex': 0
-        }).removeAttr('aria-hidden').removeClass("aria-hidden").parents().removeAttr('aria-hidden').removeClass("aria-hidden");
-        this.find(hideableElements).filter(tabIndexElementFilter).removeAttr("tabindex").removeAttr('aria-hidden').removeClass("aria-hidden").parents().removeAttr('aria-hidden').removeClass("aria-hidden");        
+        }).removeAttr('aria-hidden').removeClass("aria-hidden").parents(parentsFilter).removeAttr('aria-hidden').removeClass("aria-hidden");
+        this.find(hideableElements).filter(tabIndexElementFilter).removeAttr("tabindex").removeAttr('aria-hidden').removeClass("aria-hidden").parents(parentsFilter).removeAttr('aria-hidden').removeClass("aria-hidden");        
 
         return this;
     };

--- a/src/core/js/notify.js
+++ b/src/core/js/notify.js
@@ -84,11 +84,16 @@ define(function(require) {
 
 		}
 
-		Adapt.trigger('popup:opened');
-
-		new NotifyView({
+		var notify = new NotifyView({
 			model: new NotifyModel(notifyObject)
 		});
+
+		var element = notify.$(".notify-popup");
+
+		/*ALLOWS POPUP MANAGER TO CONTROL FOCUS*/
+		Adapt.trigger('popup:opened', element);
+		element.a11y_focus();
+		
 	};
 
 });

--- a/src/core/js/popupManager.js
+++ b/src/core/js/popupManager.js
@@ -7,27 +7,21 @@
 define(function(require) {
 
     var Adapt = require('coreJS/adapt');
-    var scrollTop = 0;
-    var $activeElement;
-    var tabIndexElements = 'a, button, input, select, textarea';
 
-    Adapt.on('popup:opened', function() {
-    	scrollTop = $(window).scrollTop();
-    	$activeElement = $(document.activeElement);
-        $(tabIndexElements).attr('tabindex', -1);
+    Adapt.on('popup:opened', function($element) {
+
+		//capture currently active element or element specified
+        var $activeElement = $element || $(document.activeElement);
+
+        //save tab indexes
+        $activeElement.a11y_popup();
     });
 
     Adapt.on('popup:closed', function() {
-        $(window).scrollTop(scrollTop);
-        $(tabIndexElements).attr('tabindex', 0);
-        if ($activeElement) {
-            if($activeElement.is(':visible')) {
-                $activeElement.focus();
-            } else {
-                $activeElement.next().focus();
-            }
         	
-    	}
+        //restore tab indexes
+        $.a11y_popdown();
+
     });
 
 });

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -41,6 +41,7 @@ define(function(require) {
             }
             this.updateLocation(pluginLocation);
             Adapt.trigger('router:plugin:' + pluginName, pluginName, location, action);
+            Adapt.trigger('router:plugin', pluginName, location, action);
         },
         
         handleCourse: function() {

--- a/src/core/js/views/accessibilityView.js
+++ b/src/core/js/views/accessibilityView.js
@@ -11,7 +11,7 @@ define(function(require) {
 
     var AccessibilityView = Backbone.View.extend({
 
-        el: '.accessibility-toggle',
+        el: '#accessibility-toggle',
 
         initialize: function() {
             this.render();

--- a/src/core/js/views/buttonsView.js
+++ b/src/core/js/views/buttonsView.js
@@ -50,15 +50,33 @@ define(function() {
 
         onFeedbackMessageChanged: function(model, changedAttribute) {
             if (changedAttribute && this.model.get('_canShowFeedback')) {
-                this.$('.buttons-feedback').attr('disabled', false);
+				//enable feedback button
+                this.$('.buttons-feedback').a11y_cntrl_enabled(true);
+            } else {
+				//disable feedback button
+                this.$('.buttons-feedback').a11y_cntrl_enabled(false)
             }
         },
 
         onButtonStateChanged: function(model, changedAttribute) {
-            if (changedAttribute === 'complete') {
-                this.$('.buttons-action').attr('disabled', true);
+			//use correct instead of complete to signify button state
+            if (changedAttribute === 'correct') {
+				//disable submit button on correct (i.e. no model answer)
+                this.$('.buttons-action').a11y_cntrl_enabled(false);
             } else {
-                this.$('.buttons-action').html(this.model.get('_buttons')["_" + changedAttribute].buttonText);
+                switch(changedAttribute) {
+                case "showCorrectAnswer": case "hideCorrectAnswer":
+					//make model answer button inaccessible but enabled for visual users
+					//	due to inability to represent selected incorrect/correct answers to a screen reader, may need revisiting
+                    this.$('.buttons-action').a11y_cntrl(false).html(this.model.get('_buttons')["_" + changedAttribute].buttonText)
+                    .attr('aria-label', this.model.get('_buttons')["_" + changedAttribute].ariaLabel);
+                    break;
+                default:
+					//enabled button, make accessible and update aria labels and text.
+                    this.$('.buttons-action').a11y_cntrl_enabled(true).html(this.model.get('_buttons')["_" + changedAttribute].buttonText)
+                    .attr('aria-label', this.model.get('_buttons')["_" + changedAttribute].ariaLabel);
+                }
+
             }
             this.updateAttemptsCount();
         },

--- a/src/core/js/views/componentView.js
+++ b/src/core/js/views/componentView.js
@@ -6,6 +6,7 @@
 
 define(function(require) {
 
+    var Adapt = require("coreJS/adapt");
     var AdaptView = require('coreViews/adaptView');
 
     var ComponentView = AdaptView.extend({
@@ -20,6 +21,30 @@ define(function(require) {
             + " nth-child-" + this.options.nthChild;
         },
         
+        initialize: function(){
+			//standard initialization + renderState function
+            AdaptView.prototype.initialize.apply(this, arguments);
+            this.renderState();
+        },
+
+        renderState: function() {
+            if (!Handlebars.partials['state']) return;
+
+			// do not perform if component has .not-accessible class
+            if (this.$el.is(".not-accessible")) return;
+			// do not perform if component has .no-state class
+            if (this.$el.is(".no-state")) return;
+            
+			//remove pre-exisiting states
+            this.$(".accessibility-state").remove();
+			
+            //render and append state partial
+            var rendered = Handlebars.partials['state']( this.model.toJSON() );
+            this.$el.append( $(rendered) );
+            
+            this.listenToOnce(this.model, 'change:_isComplete', this.renderState);
+        },
+
         postRender: function() {}
         
     }, {

--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -75,23 +75,24 @@ define(function(require) {
 			if (event) {
 				event.preventDefault();
 			}
-			this._isVisible = false;
 			this.hideDrawer();
 		},
 
 		toggleDrawer: function() {
 			if (this._isVisible && this._isCustomViewVisible === false) {
-				this._isVisible = false;
 				this.hideDrawer();
 			} else {
-				this._isVisible = true;
 				this.showDrawer(true);
 			}
 		},
 
 		showDrawer: function(emptyDrawer) {
 			this.$el.removeClass('display-none');
-			Adapt.trigger('popup:opened');
+			//only trigger popup:opened if drawer is visible, pass popup manager drawer element
+			if (!this._isVisible) {
+				Adapt.trigger('popup:opened', this.$el);
+				this._isVisible = true;
+			}
 			var drawerWidth = this.$el.width();
 			// Sets tab index to 0 for all tabbable elements in Drawer
 			this.$('a, button, input, select, textarea').attr('tabindex', 0);
@@ -142,7 +143,11 @@ define(function(require) {
 		},
 
 		hideDrawer: function() {
+			//only trigger popup:closed if drawer is visible
+			if (this._isVisible) {
 			Adapt.trigger('popup:closed');
+				this._isVisible = false;
+			}
 
 			var showEasingAnimation = Adapt.config.get('_drawer')._hideEasing;
 			var easing = (showEasingAnimation) ? showEasingAnimation : 'easeOutQuart';

--- a/src/core/js/views/navigationView.js
+++ b/src/core/js/views/navigationView.js
@@ -31,7 +31,7 @@ define(function(require) {
         
         render: function() {
             var template = Handlebars.templates[this.template]
-            this.$el.html(template(Adapt.course.get('_globals')._accessibility._ariaLabels)).appendTo('#wrapper');
+            this.$el.html(template(Adapt.course.get('_globals'))).appendTo('#wrapper');
             _.defer(_.bind(function() {
                 Adapt.trigger('navigationView:postRender', this);
             }, this));

--- a/src/core/js/views/notifyPushView.js
+++ b/src/core/js/views/notifyPushView.js
@@ -16,6 +16,8 @@ define(function(require) {
 			this.listenTo(Adapt, 'notify:pushShown notify:pushRemoved', this.updateIndexPosition);
 			this.listenTo(this.model.collection, 'remove', this.updateIndexPosition);
 			this.listenTo(this.model.collection, 'change:_index', this.updatePushPosition);
+			//include accessibility globals in notify model
+			this.model.set('_globals', Adapt.course.get('_globals'));
 			this.listenTo(Adapt, 'remove', this.remove);
 			this.preRender();
 			this.render();

--- a/src/core/js/views/notifyView.js
+++ b/src/core/js/views/notifyView.js
@@ -15,6 +15,8 @@ define(function(require) {
 		initialize: function() {
 			this.listenTo(Adapt, 'remove', this.remove);
       		this.listenTo(Adapt, 'device:resize', this.resetNotifySize);
+			//include accessibility globals in notify model
+      		this.model.set('_globals', Adapt.course.get('_globals'));
 			this.render();
 		},
 
@@ -34,20 +36,23 @@ define(function(require) {
 
 		onAlertButtonClicked: function(event) {
 			event.preventDefault();
-			Adapt.trigger(this.model.get('_callbackEvent'), this);
+			//tab index preservation, notify must close before subsequent callback is triggered
 			this.closeNotify();
+			Adapt.trigger(this.model.get('_callbackEvent'), this);
 		},
 
 		onPromptButtonClicked: function(event) {
 			event.preventDefault();
-			Adapt.trigger($(event.currentTarget).attr('data-event'));
+			//tab index preservation, notify must close before subsequent callback is triggered
 			this.closeNotify();
+			Adapt.trigger($(event.currentTarget).attr('data-event'));
 		},
 
 		onCloseButtonClicked: function(event) {
 			event.preventDefault();
-			Adapt.trigger('notify:closed');
+			//tab index preservation, notify must close before subsequent callback is triggered
 			this.closeNotify();
+			Adapt.trigger('notify:closed');
 		},
 
 		resetNotifySize: function() {
@@ -83,14 +88,9 @@ define(function(require) {
 			this.resizeNotify();
 			this.$('.notify-popup').show();
 			this.$('.notify-shadow').fadeIn('fast');
-			if(this.model.get('_type') === "popup") {
-				$('.notify-popup-done').focus();
+			//Set focus to first accessible element
+			this.$('.notify-popup').a11y_focus();
 				
-			} else {
-				$('.notify-popup-buttons a').first().focus();
-			}
-			
-			
 		},
 
 		closeNotify: function (event) {

--- a/src/core/js/views/questionView.js
+++ b/src/core/js/views/questionView.js
@@ -211,13 +211,13 @@ define(function(require) {
             // Triggers setCompletionStatus and adds class to widget
             this.checkQuestionCompletion();
             
-            // Used to update buttonsView based upon question state
-            this.updateButtons();
-
             // Used to setup the feedback by checking against 
             // question isCorrect or isPartlyCorrect
             this.setupFeedback();
 
+			// Used to update buttonsView based upon question state
+			// Update buttons happens before showFeedback to preserve tabindexes and after setupFeedback to allow buttons to use feedback attribute
+            this.updateButtons();
             // Used to trigger an event so plugins can display feedback
             this.showFeedback();
 
@@ -315,13 +315,12 @@ define(function(require) {
 
             if (isComplete) {
                 if (isCorrect || !this.model.get('_canShowModelAnswer')) {
-                    this.model.set('_buttonState', 'complete');
-                } else {
-                    if (buttonState === 'submit' || buttonState === 'hideCorrectAnswer'){
+					//use correct instead of complete to signify button state
+                    this.model.set('_buttonState', 'correct');
+                } else if (buttonState === 'submit' || buttonState === 'hideCorrectAnswer'){
                         this.model.set('_buttonState', 'showCorrectAnswer');
-                    } else {
+                } else {
                         this.model.set('_buttonState', 'hideCorrectAnswer');
-                    }
                 }
             } else {
                 if (isEnabled) {

--- a/src/core/less/base.less
+++ b/src/core/less/base.less
@@ -20,12 +20,12 @@
     display:none!important;
 }
 
-.focused, button:focus, select:focus, textarea:focus, a:focus, input:focus + label {
+.focused, *:focus, input:focus + label {
     outline:none;
 }
 
 .accessibility.no-touch {
-    .focused, button:focus, select:focus, textarea:focus, a:focus, input:focus + label {
+    .focused, *:focus, input:focus + label {
         outline: 2px dotted #000;
         & when (@focus-outline) {
             outline: @focus-outline;  
@@ -34,13 +34,12 @@
     }
 }
 
-.accessibility-toggle {
+#accessibility-toggle {
     position: absolute;
     top: -1px;
     left: -25px;
     height: 1px;
     width: 1px;
-    display: none;
     z-index: 0;
     overflow: hidden;
     padding: 0;
@@ -211,6 +210,11 @@
     }
 }
 
+/*TO ALLOW CHILDREN ELEMENTS TO BE POSITIONED ABSOLUTELY*/
+.component { position:relative; }
+.block { position: relative; }
+
+//jquery.a11y start
 /*INVISIBLE ARIA-LABELS*/
 .aria-label {
     position:absolute !important;

--- a/src/index.html
+++ b/src/index.html
@@ -17,6 +17,8 @@
 	</head>
 
 	<body>
+		<a id="accessibility-toggle" class="button a11y-ignore-focus" role="button" href="#" ></a>
+    	<span id="accessibility-instructions" class="aria-label" role="region" tabindex="0"></span>
 		<div id="wrapper">
 		</div>
 	</body>


### PR DESCRIPTION
Traps tab on accessibility button if accessibility isn't on
Adds accessibility instructions for screen readers
Fixes popupmanager and tabindexes on popup/popdown
Wraps tab around to top of page from the bottom
Integrates jquery.a11y into the handlebars templates so that text blocks can become tabbable
Adds accessibility state rendering to componentView (is currently missing the 'state' partial as it needs to be added to theme)
Allows aria-labels to be read across all devices
Expands LESS focus outline to include all focused elements
Maintains and improves .focused class for ie8
Adds _globals to all popup models
Fixes button states, question view, notify and drawer to allow all to become accessible

Next stage is templates, components and extensions.

Had to resubmit  https://github.com/adaptlearning/adapt_framework/pull/527 < PR due to my fork going a bit funny. Apologies.