### PR TITLE
Fixes #550 - theme and menu templates are handled

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -188,7 +188,14 @@ module.exports = function(grunt) {
                     partialsPathRegex: /\/partials\//
                 },
                 files: {
-                    'src/templates/templates.js': 'src/**/*.hbs'
+                    'src/templates/templates.js': 
+                    [
+                        'src/components/**/*.hbs',
+                        'src/core/**/*.hbs',
+                        'src/extensions/**/*.hbs',
+                        'src/menu/<%= menu %>/**/*.hbs',
+                        'src/theme/<%= theme %>/**/*.hbs'
+                    ]
                 }
             }
         },


### PR DESCRIPTION
Previously all Handlebars (*.hbs) template files were pulled in as part of
a build.  This could lead to inconsistent output when more than one theme
or menu was installed in the adapt_framework directory.