### PR TITLE
Fix for leftover ie8 opacity filter

### DIFF
--- a/src/core/js/views/pageView.js
+++ b/src/core/js/views/pageView.js
@@ -30,7 +30,12 @@ define(function(require) {
                     $('.loading').hide();
                     $(window).scrollTop(0);
                     Adapt.trigger('pageView:ready', this);
-                    this.$el.velocity({'opacity': 1}, 'fast');
+                    var styleOptions = { opacity: 1 };
+                    if ($('html').is(".ie8")) {
+                        this.$el.css(styleOptions)
+                    } else {
+                        this.$el.velocity(styleOptions, 'fast');
+                    }
                     $(window).scroll();
                 }, this));
             }


### PR DESCRIPTION
With a filter=opactiy(1) on the page, ie8 has to filter each video frame and so causes a 100% processor problem.