### PR TITLE
Accessibility fixes

### DIFF
--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -253,6 +253,10 @@ define(function(require) {
             _.delay(function() {
                 //ENABLED DOCUMENT READING
                 $.a11y_on(true, '#wrapper');
+
+                //DO NOT FOCUS IF USER HAS ALREADY INTERACTED
+                if ($.a11y.userInteracted) return;
+
                 if (Adapt.location._currentId) {
                     //required to stop JAWS from auto reading content in IE
                     var currentModel = Adapt.findById(Adapt.location._currentId);
@@ -328,6 +332,12 @@ define(function(require) {
 
             //IF NOT TAB KEY, RETURN
             if (event.which !== 9) return;
+
+            //ENABLE DOCUMENT READING
+            $.a11y_on(true);
+
+            //DO NOT REDIRECT IF USER HAS ALREADY INTERACTED
+            if ($.a11y.userInteracted) return;
 
             //IF INITIAL TAB NOT CAPTURED AND ACCESSIBILITY NOT ON, RETURN
             if ( Accessibility.isEnabled() && Accessibility._hasTabPosition ) return;

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -361,6 +361,8 @@ define(function(require) {
             $.a11y.options.focusOffsetBottom = bottomoffset;
             $.a11y.options.OS = Adapt.device.OS.toLowerCase();     
             $.a11y.options.isTouchDevice = Modernizr.touch;
+
+            $.a11y.ready();
         }
 
     }, Backbone.Events);

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -1,3 +1,4 @@
+//jQuery.a11y 16/04/2015 https://github.com/cgkineo/jquery.a11y/
 (function($, window, undefined) {
 
     var nativeSpaceElements = "textarea, input[type='text']";

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -1,4 +1,3 @@
-//https://github.com/cgkineo/jquery.a11y Mar 12, 2015
 (function($, window, undefined) {
 
     var nativeSpaceElements = "textarea, input[type='text']";
@@ -16,11 +15,6 @@
 
 
     var $documentActiveElement;
-
-
-    $('body').on("mousedown", focusableElements, function(event) { //IPAD TOUCH-DOWN FOCUS FIX FOR BUTTONS
-        $documentActiveElement = $(event.currentTarget);
-    });
 
     if (!String.prototype.trim) { //IE8 Fix
       (function() {
@@ -61,9 +55,10 @@
     var scrollToFocus = function(event) {
         $documentActiveElement = $(event.target);
 
-        if ($.a11y.options.isOn === false && !$documentActiveElement.is("#a11y-selected")) $("#a11y-selected").focusNoScroll();
+        if ($.a11y.options.isOn === false && !$documentActiveElement.is("#a11y-focuser")) $("#a11y-focuser").focusNoScroll();
         //console.log ("Focused on:")
         //console.log($documentActiveElement);
+
         var readText;
         if ($(event.target).attr("aria-labelledby")) {
             var label = $("#"+$(event.target).attr("aria-labelledby"));
@@ -133,6 +128,29 @@
             //TURN SPACE INTO CLICK
             $(event.target).trigger("click");
         }
+    };
+
+    //IPAD TOUCH-DOWN FOCUS FIX FOR BUTTONS
+    var captureActiveElementOnClick =  function(event) {
+        $documentActiveElement = $(event.currentTarget);
+        if ($documentActiveElement.is(nativeEnterElements)) {
+            //Capture that the user has interacted with a native form element
+            $.a11y.userInteracted = true;
+        }
+    };
+
+    //INFORM ABOUT USER INTERACTION
+    var captureInitialScroll = function() {
+        setTimeout(function() {
+            $(window).one("scroll", function() {
+                $.a11y.userInteracted = true;
+            });
+        }, 500);
+    };
+
+    var setupInteractionListeners = function() {
+        $('body').on("mousedown", focusableElements, captureActiveElementOnClick);
+        captureInitialScroll();
     };
 
     //MAKES AN ELEMENT TABBABLE
@@ -319,6 +337,7 @@
     };
     $.a11y.focusStack = [];
 
+    $.a11y.ready = setupInteractionListeners;
 
     //REAPPLY ON SIGNIFICANT VIEW CHANGES
     $.a11y_update = function() {
@@ -335,6 +354,7 @@
             //ADDS TAB GUARG EVENT HANDLER
             reattachFocusGuard();
         }
+
     };
 
 //TOGGLE ACCESSIBILITY


### PR DESCRIPTION
Stop redirecting the tab key to the accessibility button if the user has scrolled or entered a native form element. 

@brian-learningpool This is a fix for stopping the tab key augmentation after a normal interaction.