### PR TITLE
BUGFIX: Load jquery after require to allow for other libraries to require jquery

### DIFF
--- a/src/core/js/scriptLoader.js
+++ b/src/core/js/scriptLoader.js
@@ -13,17 +13,7 @@
         return false;
     })();
 
-    //2. Load requirejs
-    function loadRequireJS() {
-        Modernizr.load([
-            {
-                load: "libraries/require.js",
-                complete: loadJQuery
-            }
-        ]);
-    }
-
-    //3. Load jquery
+    //2. Load jquery
     function loadJQuery() {
         Modernizr.load([
             {
@@ -35,12 +25,12 @@
         ]);
     }
 
-    //4. Load adapt
+    //3. Load adapt
     function loadAdapt() {
         Modernizr.load("adapt/js/adapt.min.js");
     }
 
-    //1. Load foundation libraries, json2, consoles
+    //1. Load foundation libraries, json2, consoles, requirejs
     Modernizr.load([
         {
             test: window.JSON,
@@ -48,8 +38,11 @@
         },
         {
             test: window.console == undefined,
-            yep: 'libraries/consoles.js',
-            complete: loadRequireJS
+            yep: 'libraries/consoles.js'
+        },
+        {
+            load: "libraries/require.js",
+            complete: loadJQuery
         }
     ]);
 

--- a/src/core/js/scriptLoader.js
+++ b/src/core/js/scriptLoader.js
@@ -13,30 +13,43 @@
         return false;
     })();
 
-    //Load foundation libraries, json2, consoles, swfObject
+    //2. Load requirejs
+    function loadRequireJS() {
+        Modernizr.load([
+            {
+                load: "libraries/require.js",
+                complete: loadJQuery
+            }
+        ]);
+    }
+
+    //3. Load jquery
+    function loadJQuery() {
+        Modernizr.load([
+            {
+                test: IE == 8,
+                yep: 'libraries/jquery.js',
+                nope: 'libraries/jquery.v2.js',
+                complete: loadAdapt
+            }
+        ]);
+    }
+
+    //4. Load adapt
+    function loadAdapt() {
+        Modernizr.load("adapt/js/adapt.min.js");
+    }
+
+    //1. Load foundation libraries, json2, consoles
     Modernizr.load([
         {
             test: window.JSON,
             nope: 'libraries/json2.js'
         },
         {
-            test: IE == 8,
-            yep: 'libraries/jquery.js',
-            nope: 'libraries/jquery.v2.js'
-        },
-        {
             test: window.console == undefined,
             yep: 'libraries/consoles.js',
-            complete: function() {
-
-                //Inject require js for dependency loading
-                yepnope.injectJs("libraries/require.js", function () { 
-                }, {
-                    type:"text/javascript",
-                    language:"javascript",
-                    "data-main":"adapt/js/adapt.min.js"
-                }, 5000);
-            }
+            complete: loadRequireJS
         }
     ]);
 


### PR DESCRIPTION
@hrajotia it didn't work sometimes on a fast connection as it was before.

jquery would load before require and would not be available to scrollTo, velocity, backbone etc. 

it would works sometimes as jquery is a larger file than require and so require would load and execute before jquery, allowing jquery to 'define' itself and therefore allow jquery to be available to the other libraries.

i've rewritten so that it goes, json2, consoles, require (wait for load), jquery (wait for load), adapt