### PR TITLE
Adds a check for _children being undefined

### DIFF
--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -122,7 +122,7 @@ define(function (require) {
 
                 returnedDescedants = new Backbone.Collection(flattenedDescendants);
 
-                if (children.models[0]._children === descendants) {
+                if (children.models.length === 0 || children.models[0]._children === descendants) {
                     return;
                 } else {
                     allDescendants = [];
@@ -138,8 +138,16 @@ define(function (require) {
 
         getChildren: function () {
             if (this.get("_children")) return this.get("_children");
-            var children = Adapt[this._children].where({_parentId: this.get("_id")});
-            var childrenCollection = new Backbone.Collection(children);
+
+            var childrenCollection;
+
+            if (!this._children) {
+                childrenCollection = new Backbone.Collection();
+            } else {
+                var children = Adapt[this._children].where({_parentId: this.get("_id")});
+                childrenCollection = new Backbone.Collection(children);
+            }
+
             this.set("_children", childrenCollection);
 
             // returns a collection of children


### PR DESCRIPTION
This resolves a potential issue with findDecendants() and getChildren() as
this property does not exist on components.  

Resolves #592. 