### PR TITLE
Unknown platform fix

### DIFF
--- a/src/core/js/device.js
+++ b/src/core/js/device.js
@@ -64,13 +64,14 @@ define(function(require) {
 
         if (platform.indexOf("Win") != -1) {
             return "Windows";
-        }
-        else if (platform.indexOf("Mac") != -1) {
+        } else if (platform.indexOf("Mac") != -1) {
             return "Mac";
-        }
-        else if (platform.indexOf("Linux") != -1) {
+        } else if (platform.indexOf("Linux") != -1) {
             return "Linux";
         }
+        
+        return "PlatformUnknown";
+
     }
 
     var browserString = browser + " version-" + version + " OS-" + OS;


### PR DESCRIPTION
Allows the devices platform to be identified as 'PlatformUnknown' when 'Windows', 'Mac' and 'Linux' aren't specified.

In the case of Windows Mobile 8.1, "ARM" is the platform name (which is rather non-specific, all things considered) https://developer.mozilla.org/en-US/docs/Web/API/NavigatorID/platform