### PR TITLE
Make sure focus goes to component state if both buttons are disabled

### DIFF
--- a/src/core/js/views/buttonsView.js
+++ b/src/core/js/views/buttonsView.js
@@ -63,6 +63,16 @@ define(function() {
             if (changedAttribute === 'correct') {
 				//disable submit button on correct (i.e. no model answer)
                 this.$('.buttons-action').a11y_cntrl_enabled(false);
+
+                if (!this.model.get("_canShowFeedback")) {
+                    if (!this.$el.is(".no-state")) {
+                        //if no feedback, complete correct and has state, force focus to component state
+                        _.defer(_.bind(function() {
+                            $("." + this.model.get("_id") + " .accessibility-state [tabindex]").focusNoScroll();
+                        }, this));
+                    }
+                }
+
             } else {
                 switch(changedAttribute) {
                 case "showCorrectAnswer": case "hideCorrectAnswer":


### PR DESCRIPTION
This is a problem when you get questions right in the assessment where there is no feedback button. The submit button becomes disabled and the focus cannot move to the next element in its parent.

Have forced focus to go to component-state element if available.