### PR TITLE
ABU-640: Notify and Drawer

### DIFF
--- a/src/core/js/notify.js
+++ b/src/core/js/notify.js
@@ -87,12 +87,6 @@ define(function(require) {
 		var notify = new NotifyView({
 			model: new NotifyModel(notifyObject)
 		});
-
-		var element = notify.$(".notify-popup");
-
-		/*ALLOWS POPUP MANAGER TO CONTROL FOCUS*/
-		Adapt.trigger('popup:opened', element);
-		element.a11y_focus();
 		
 	};
 

--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -97,7 +97,6 @@ define(function(require) {
             //only trigger popup:opened if drawer is visible, pass popup manager drawer element
             if (!this._isVisible) {
                 Adapt.trigger('popup:opened', this.$el);
-
                 this._isVisible = true;
             }
 

--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -325,8 +325,15 @@ define(function(require) {
                     $('html').css({
                         "height": ""
                     });
+
+                    var height = "";
+
+                    if (this._htmlHeight != this._bodyHeight) {
+                        height = this._bodyHeight;
+                    }
+
                     $('body').css({
-                        "height": "",
+                        "height": height,
                         "overflow-y": ""
                     });
                     $('#wrapper').css({

--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -6,203 +6,380 @@
 
 define(function(require) {
 
-	var Backbone = require('backbone');
-	var Adapt = require('coreJS/adapt');
+    var Backbone = require('backbone');
+    var Adapt = require('coreJS/adapt');
 
-	var DrawerView = Backbone.View.extend({
+    var DrawerView = Backbone.View.extend({
 
-		className: 'drawer display-none',
+        className: 'drawer display-none',
+        disableAnimation: false,
 
-		initialize: function() {
-			this._isVisible = false;
-			this.drawerDir = 'right';
-			if(Adapt.config.get('_defaultDirection')=='rtl'){//on RTL drawer on the left
-				this.drawerDir = 'left';
-			}
-			this.listenTo(Adapt, 'navigation:toggleDrawer', this.toggleDrawer);
-			this.listenTo(Adapt, 'drawer:triggerCustomView', this.openCustomView);
-			this.listenToOnce(Adapt, 'adapt:initialize', this.checkIfDrawerIsAvailable);
-			this.listenTo(Adapt, 'drawer:closeDrawer', this.onCloseDrawer);
-			this.listenTo(Adapt, 'remove', this.onCloseDrawer);
-			this.render();
-			this.drawerDuration = Adapt.config.get('_drawer')._duration;
-			this.drawerDuration = (this.drawerDuration) ? this.drawerDuration : 400;
-			// Setup cached selectors
-			this.$wrapper = $('#wrapper');
-		},
+        initialize: function() {
+            this.disableAnimation = $("html").is(".ie8");
+            this._isVisible = false;
+            this.drawerDir = 'right';
+            if(Adapt.config.get('_defaultDirection')=='rtl'){//on RTL drawer on the left
+                this.drawerDir = 'left';
+            }
+            this.listenTo(Adapt, 'navigation:toggleDrawer', this.toggleDrawer);
+            this.listenTo(Adapt, 'drawer:triggerCustomView', this.openCustomView);
+            this.listenToOnce(Adapt, 'adapt:initialize', this.checkIfDrawerIsAvailable);
+            this.listenTo(Adapt, 'drawer:closeDrawer', this.onCloseDrawer);
+            this.listenTo(Adapt, 'remove', this.onCloseDrawer);
+            this.render();
+            this.drawerDuration = Adapt.config.get('_drawer')._duration;
+            this.drawerDuration = (this.drawerDuration) ? this.drawerDuration : 400;
+            // Setup cached selectors
+            this.$wrapper = $('#wrapper');
+        },
 
-		events: {
-			'click .drawer-back': 'onBackButtonClicked',
-			'click .drawer-close':'onCloseDrawer'
-		},
+        events: {
+            'click .drawer-back': 'onBackButtonClicked',
+            'click .drawer-close':'onCloseDrawer'
+        },
 
-		render: function() {
-			var template = Handlebars.templates['drawer']
-			$(this.el).html(template({_globals: Adapt.course.get("_globals")})).appendTo('body');
-			var shadowTemplate = Handlebars.templates['shadow'];
-			$(shadowTemplate()).appendTo('body');
-			// Set defer on post render
-			_.defer(_.bind(function() {
-				this.postRender();
-			}, this));
-			return this;
-		},
+        render: function() {
+            var template = Handlebars.templates['drawer']
+            $(this.el).html(template({_globals: Adapt.course.get("_globals")})).appendTo('body');
+            var shadowTemplate = Handlebars.templates['shadow'];
+            $(shadowTemplate()).appendTo('body');
+            // Set defer on post render
+            _.defer(_.bind(function() {
+                this.postRender();
+            }, this));
+            return this;
+        },
 
-		// Set tabindex for select elements
-		postRender: function() {
-			this.$('a, button, input, select, textarea').attr('tabindex', -1);
-		},
+        // Set tabindex for select elements
+        postRender: function() {
+            this.$('a, button, input, select, textarea').attr('tabindex', -1);
+        },
 
-		openCustomView: function(view, hasBackButton) {
-			// Set whether back button should display
-			this._hasBackButton = hasBackButton;
-			this._isCustomViewVisible = true;
-			Adapt.trigger('drawer:empty');
-			this.showDrawer();
-			this.$('.drawer-holder').html(view);
-		},
+        openCustomView: function(view, hasBackButton) {
+            // Set whether back button should display
+            this._hasBackButton = hasBackButton;
+            this._isCustomViewVisible = true;
+            Adapt.trigger('drawer:empty');
+            this.showDrawer();
+            this.$('.drawer-holder').html(view);
+        },
 
-		checkIfDrawerIsAvailable: function() {
-			if(this.collection.length == 0) {
-				$('.navigation-drawer-toggle-button').addClass('display-none');
-				Adapt.trigger('drawer:noItems');
-			}
-		},
+        checkIfDrawerIsAvailable: function() {
+            if(this.collection.length == 0) {
+                $('.navigation-drawer-toggle-button').addClass('display-none');
+                Adapt.trigger('drawer:noItems');
+            }
+        },
 
-		onBackButtonClicked: function(event) {
-			event.preventDefault();
-			this.showDrawer(true);
-		},
+        onBackButtonClicked: function(event) {
+            event.preventDefault();
+            this.showDrawer(true);
+        },
 
-		onCloseDrawer: function(event) {
-			if (event) {
-				event.preventDefault();
-			}
-			this.hideDrawer();
-		},
+        onCloseDrawer: function(event) {
+            if (event) {
+                event.preventDefault();
+            }
+            this.hideDrawer();
+        },
 
-		toggleDrawer: function() {
-			if (this._isVisible && this._isCustomViewVisible === false) {
-				this.hideDrawer();
-			} else {
-				this.showDrawer(true);
-			}
-		},
+        toggleDrawer: function() {
+            if (this._isVisible && this._isCustomViewVisible === false) {
+                this.hideDrawer();
+            } else {
+                this.showDrawer(true);
+            }
+        },
 
-		showDrawer: function(emptyDrawer) {
-			this.$el.removeClass('display-none');
-			//only trigger popup:opened if drawer is visible, pass popup manager drawer element
-			if (!this._isVisible) {
-				Adapt.trigger('popup:opened', this.$el);
-				this._isVisible = true;
-			}
-			var drawerWidth = this.$el.width();
-			// Sets tab index to 0 for all tabbable elements in Drawer
-			this.$('a, button, input, select, textarea').attr('tabindex', 0);
+        showDrawer: function(emptyDrawer) {
 
-			if (emptyDrawer) {
-				this.$('.drawer-back').addClass('display-none');
-				this._isCustomViewVisible = false;
-				this.emptyDrawer();
-				this.renderItems();
-				Adapt.trigger('drawer:openedItemView');
-			} else {
-				if (this._hasBackButton) {
-					this.$('.drawer-back').removeClass('display-none');
-				} else {
-					this.$('.drawer-back').addClass('display-none');
-				}
-				Adapt.trigger('drawer:openedCustomView');
-			}
-			//focus on first tabbable element in drawer
-			this.$el.a11y_focus();
-			_.defer(_.bind(function() {
-				var showEasingAnimation = Adapt.config.get('_drawer')._showEasing;
-				var easing = (showEasingAnimation) ? showEasingAnimation : 'easeOutQuart';
-				var direction={};
-				direction[this.drawerDir]=0;
-				this.$el.velocity(direction, this.drawerDuration, easing);
-				$('#shadow').removeClass('display-none');
-				this.addShadowEvent();
-				Adapt.trigger('drawer:opened');
-			}, this));
-		},
+            this.$el.removeClass('display-none');
+            //only trigger popup:opened if drawer is visible, pass popup manager drawer element
+            if (!this._isVisible) {
+                Adapt.trigger('popup:opened', this.$el);
 
-		emptyDrawer: function() {
-			this.$('.drawer-holder').empty();
-		},
+                this._isVisible = true;
+            }
 
-		renderItems: function() {
-			Adapt.trigger('drawer:empty');
-			this.emptyDrawer();
-			var models = this.collection.models;
-			for (var i = 0, len = models.length; i < len; i++) {
-				var item = models[i];
-				new DrawerItemView({model: item});
-			}
-		},
+            var drawerWidth = this.$el.width();
+            // Sets tab index to 0 for all tabbable elements in Drawer
+            this.$('a, button, input, select, textarea').attr('tabindex', 0);
 
-		hideDrawer: function() {
-			//only trigger popup:closed if drawer is visible
-			if (this._isVisible) {
-			Adapt.trigger('popup:closed');
-				this._isVisible = false;
-			}
+            if (emptyDrawer) {
+                this.$('.drawer-back').addClass('display-none');
+                this._isCustomViewVisible = false;
+                this.emptyDrawer();
+                this.renderItems();
+                Adapt.trigger('drawer:openedItemView');
+            } else {
+                if (this._hasBackButton) {
+                    this.$('.drawer-back').removeClass('display-none');
+                } else {
+                    this.$('.drawer-back').addClass('display-none');
+                }
+                Adapt.trigger('drawer:openedCustomView');
+            }
 
-			var showEasingAnimation = Adapt.config.get('_drawer')._hideEasing;
-			var easing = (showEasingAnimation) ? showEasingAnimation : 'easeOutQuart';
+            //delay drawer animation until after background fadeout animation is complete
+            if (this.disableAnimation) {
 
-			var duration = Adapt.config.get('_drawer')._duration;
-			duration = (duration) ? duration : 400;
+                $('#shadow').removeClass("display-none");
 
-			var direction={};
-			direction[this.drawerDir]=-this.$el.width();
-			this.$el.velocity(direction, this.drawerDuration, easing, _.bind(function() {
-				this.$el.addClass('display-none');
-			}, this));
-			$('#shadow').addClass('display-none');
-			this._isCustomViewVisible = false;
-			this.removeShadowEvent();
-			Adapt.trigger('drawer:closed');
-		},
+                this.disableBodyScrollbars();
 
-		addShadowEvent: function() {
-			$('#shadow').one('click touchstart', _.bind(function() {
-				this.onCloseDrawer();
-			}, this));
-		},
+                var direction={};
+                direction[this.drawerDir]=0;
+                this.$el.css(direction);
+                this.addShadowEvent();
+                Adapt.trigger('drawer:opened');
 
-		removeShadowEvent: function() {
-			$('#shadow').off('click touchstart');
-		}
-	});
+                //focus on first tabbable element in drawer
+                //defer to stop focus jumping content
+                this.$el.a11y_focus();
 
-	var DrawerItemView = Backbone.View.extend({
+            } else {
 
-		className: 'drawer-item',
+                $('#shadow').velocity({opacity:1},{duration:200, begin: function() {
+                        $("#shadow").removeClass("display-none");
+                    }});
 
-		initialize: function() {
-			this.listenTo(Adapt, 'drawer:empty', this.remove);
-			this.render();
-		},
+                this.disableBodyScrollbars();
 
-		events: {
-			'click .drawer-item-open': 'onDrawerItemClicked'
-		},
+                _.delay(_.bind(function() {
+                    
+                    var showEasingAnimation = Adapt.config.get('_drawer')._showEasing;
+                    var easing = (showEasingAnimation) ? showEasingAnimation : 'easeOutQuart';
+                    var direction={};
+                    direction[this.drawerDir]=0;
+                    this.$el.velocity(direction, this.drawerDuration, easing);
+                    this.addShadowEvent();
+                    Adapt.trigger('drawer:opened');
 
-		render: function() {
-			var data = this.model.toJSON();
-			var template = Handlebars.templates['drawerItem']
-			$(this.el).html(template(data)).appendTo('.drawer-holder');
-			return this;
-		},
+                    //focus on first tabbable element in drawer
+                    //defer to stop focus jumping content
+                    this.$el.a11y_focus();
 
-		onDrawerItemClicked: function(event) {
-			event.preventDefault();
-			var eventCallback = this.model.get('eventCallback');
-			Adapt.trigger(eventCallback);
-		}
-	});
+                }, this), 200);
 
-	return DrawerView;
+            }
+        },
+
+        emptyDrawer: function() {
+            this.$('.drawer-holder').empty();
+        },
+
+        renderItems: function() {
+            Adapt.trigger('drawer:empty');
+            this.emptyDrawer();
+            var models = this.collection.models;
+            for (var i = 0, len = models.length; i < len; i++) {
+                var item = models[i];
+                new DrawerItemView({model: item});
+            }
+        },
+
+        hideDrawer: function() {
+            //only trigger popup:closed if drawer is visible
+            if (this._isVisible) {
+                Adapt.trigger('popup:closed');
+                this._isVisible = false;
+            } else {
+                return;
+            }
+
+            if (this.disableAnimation) {
+
+                var direction={};
+                direction[this.drawerDir]=-this.$el.width();
+                this.$el.css(direction).addClass('display-none');
+                
+                this._isCustomViewVisible = false;
+                this.removeShadowEvent();
+
+                this.enableBodyScrollbars();
+
+                $('#shadow').addClass("display-none");
+
+            } else {
+
+                var showEasingAnimation = Adapt.config.get('_drawer')._hideEasing;
+                var easing = (showEasingAnimation) ? showEasingAnimation : 'easeOutQuart';
+
+                var duration = Adapt.config.get('_drawer')._duration;
+                duration = (duration) ? duration : 400;
+
+                var direction={};
+                direction[this.drawerDir]=-this.$el.width();
+                this.$el.velocity(direction, this.drawerDuration, easing, _.bind(function() {
+                    this.$el.addClass('display-none');
+                }, this));
+                
+                this._isCustomViewVisible = false;
+                this.removeShadowEvent();
+
+                this.enableBodyScrollbars();
+
+                //delay background fadeout until after drawer animation is complete
+                _.delay(_.bind(function(){
+                
+                    $('#shadow').velocity({opacity:0}, {duration:200, complete:function() {
+                        $('#shadow').addClass("display-none");
+                    }});
+
+                }, this), duration + 50);
+
+            }
+
+            Adapt.trigger('drawer:closed');
+        },
+
+        addShadowEvent: function() {
+            $('#shadow').one('click touchstart', _.bind(function() {
+                this.onCloseDrawer();
+            }, this));
+        },
+
+        removeShadowEvent: function() {
+            $('#shadow').off('click touchstart');
+        },
+
+        disableBodyScrollbars: function(callback) {
+            this._scrollTop = $(window).scrollTop();
+            this._bodyHeight = $("body").css("height");
+            this._htmlHeight = $("html").css("height");
+
+            if (this.disableAnimation) {
+
+                $('html').css({
+                    "height": "100%"
+                });
+                $('body').css({
+                    "height": "100%",
+                    "overflow-y": "hidden"
+                });
+
+                $('#wrapper').css({
+                    "position": "relative",
+                    "top": "-"+ this._scrollTop +"px"
+                });
+
+            } else {
+
+                $('.page, .menu').velocity({opacity:0}, {duration:1, complete:_.bind(function() {
+
+                    $('.page, .menu').css("visibility", "hidden");              
+                    //wait for renderer to catch-up with fade out
+                    _.delay(_.bind(function(){
+
+                        //this causes the content to jump 
+                        $('html').css({
+                            "height": "100%"
+                        });
+                        $('body').css({
+                            "height": "100%",
+                            "overflow-y": "hidden"
+                        });
+
+                        //puts the content back to where it should be
+                        $('#wrapper').css({
+                            "position": "relative",
+                            "top": "-"+ this._scrollTop +"px"
+                        });
+                        
+                        //wait for renderer to catch-up with jump
+                        _.delay(_.bind(function() {
+                            $('.page, .menu').css("visibility", "visible");
+                            $('.page, .menu').velocity({opacity:1}, {duration:600});
+                        }, this), 50);
+
+                    }, this), 50);
+
+                },this)});
+            }
+            
+        },
+
+        enableBodyScrollbars: function() {
+
+            if (this.disableAnimation) {
+
+                $('html').css({
+                    "height": ""
+                });
+                $('body').css({
+                    "height": "",
+                    "overflow-y": ""
+                });
+                $('#wrapper').css({
+                    "position": "relative",
+                    "top": ""
+                });
+                $(window).scrollTo(this._scrollTop); 
+
+            } else {
+
+                $('.page, .menu').velocity({opacity:0}, {duration:1, complete:_.bind(function() {
+
+                    $('.page, .menu').css("visibility", "hidden");
+
+                    //this causes the content to jump
+                    $('html').css({
+                        "height": ""
+                    });
+                    $('body').css({
+                        "height": "",
+                        "overflow-y": ""
+                    });
+                    $('#wrapper').css({
+                        "position": "relative",
+                        "top": ""
+                    });
+
+                    //wait for renderer to catch-up with jump
+                    _.delay(_.bind(function() {
+
+                        $('.page, .menu').css("visibility", "visible");
+
+                        //puts the content back to where it should be
+                        $(window).scrollTo(this._scrollTop);     
+                        
+                        $('.page, .menu').velocity({opacity:1}, {duration: 300 });
+
+                    }, this), 50);    
+
+                }, this)});
+            }
+
+        }
+
+    });
+
+    var DrawerItemView = Backbone.View.extend({
+
+        className: 'drawer-item',
+
+        initialize: function() {
+            this.listenTo(Adapt, 'drawer:empty', this.remove);
+            this.render();
+        },
+
+        events: {
+            'click .drawer-item-open': 'onDrawerItemClicked'
+        },
+
+        render: function() {
+            var data = this.model.toJSON();
+            var template = Handlebars.templates['drawerItem']
+            $(this.el).html(template(data)).appendTo('.drawer-holder');
+            return this;
+        },
+
+        onDrawerItemClicked: function(event) {
+            event.preventDefault();
+            var eventCallback = this.model.get('eventCallback');
+            Adapt.trigger(eventCallback);
+        }
+    });
+
+    return DrawerView;
 });

--- a/src/core/js/views/notifyView.js
+++ b/src/core/js/views/notifyView.js
@@ -6,102 +6,287 @@
 
 define(function(require) {
 
-	var Adapt = require('coreJS/adapt');
+    var Adapt = require('coreJS/adapt');
 
-	var NotifyView = Backbone.View.extend({
 
-		className: 'notify',
+    var NotifyView = Backbone.View.extend({
 
-		initialize: function() {
-			this.listenTo(Adapt, 'remove', this.remove);
-      		this.listenTo(Adapt, 'device:resize', this.resetNotifySize);
-			//include accessibility globals in notify model
-      		this.model.set('_globals', Adapt.course.get('_globals'));
-			this.render();
-		},
+        className: 'notify',
+        disableAnimation: false,
 
-		events: {
-			'click .notify-popup-alert-button':'onAlertButtonClicked',
-			'click .notify-popup-prompt-button': 'onPromptButtonClicked',
-			'click .notify-popup-done': 'onCloseButtonClicked'
-		},
+        initialize: function() {
+            this.disableAnimation = $("html").is(".ie8");
 
-		render: function() {
-			var data = this.model.toJSON();
+            this.listenTo(Adapt, 'remove', this.remove);
+            this.listenTo(Adapt, 'device:resize', this.resetNotifySize);
+            //include accessibility globals in notify model
+            this.model.set('_globals', Adapt.course.get('_globals'));
+            this.render();
+        },
+
+        events: {
+            'click .notify-popup-alert-button':'onAlertButtonClicked',
+            'click .notify-popup-prompt-button': 'onPromptButtonClicked',
+            'click .notify-popup-done': 'onCloseButtonClicked'
+        },
+
+        render: function() {
+            var data = this.model.toJSON();
             var template = Handlebars.templates['notify'];
+
+            //hide notify
+            this.$el.css("visibility", "hidden");
+
+            //attach popup
             this.$el.html(template(data)).appendTo('body');
+
+            //hide popup
+            this.$('.notify-popup').css("visibility", "hidden");
+
+            //show notify
+            this.$el.css("visibility", "visible");
+
             this.showNotify();
             return this;
-		},
+        },
 
-		onAlertButtonClicked: function(event) {
-			event.preventDefault();
-			//tab index preservation, notify must close before subsequent callback is triggered
-			this.closeNotify();
-			Adapt.trigger(this.model.get('_callbackEvent'), this);
-		},
+        onAlertButtonClicked: function(event) {
+            event.preventDefault();
+            //tab index preservation, notify must close before subsequent callback is triggered
+            this.closeNotify();
+            Adapt.trigger(this.model.get('_callbackEvent'), this);
+        },
 
-		onPromptButtonClicked: function(event) {
-			event.preventDefault();
-			//tab index preservation, notify must close before subsequent callback is triggered
-			this.closeNotify();
-			Adapt.trigger($(event.currentTarget).attr('data-event'));
-		},
+        onPromptButtonClicked: function(event) {
+            event.preventDefault();
+            //tab index preservation, notify must close before subsequent callback is triggered
+            this.closeNotify();
+            Adapt.trigger($(event.currentTarget).attr('data-event'));
+        },
 
-		onCloseButtonClicked: function(event) {
-			event.preventDefault();
-			//tab index preservation, notify must close before subsequent callback is triggered
-			this.closeNotify();
-			Adapt.trigger('notify:closed');
-		},
+        onCloseButtonClicked: function(event) {
+            event.preventDefault();
+            //tab index preservation, notify must close before subsequent callback is triggered
+            this.closeNotify();
+            Adapt.trigger('notify:closed');
+        },
 
-		resetNotifySize: function() {
-			$('.notify-popup').removeAttr('style');
-			this.resizeNotify(true);
-		},
+        resetNotifySize: function() {
+            $('.notify-popup').removeAttr('style');
+            this.resizeNotify();
+        },
 
-		resizeNotify: function(noAnimation) {
-			var windowHeight = $(window).height();
-			var notifyHeight = this.$('.notify-popup').height();
-			var animationSpeed = 400;
-			if (notifyHeight > windowHeight) {
-				this.$('.notify-popup').css({
-					'height':'100%', 
-					'top':0, 
-					'overflow-y': 'scroll', 
-					'-webkit-overflow-scrolling': 'touch',
-					'opacity': 1
-				});
-			} else {
-				if (noAnimation) {
-					var animationSpeed = 0;
-				}
-				this.$('.notify-popup').css({
-					'margin-top': -(notifyHeight/2)-50, 'opacity': 0
-				}).velocity({
-					'margin-top': -(notifyHeight/2), 'opacity':1
-				}, animationSpeed);
-			}
-		},
+        resizeNotify: function() {
+            var windowHeight = $(window).height();
+            var notifyHeight = this.$('.notify-popup').height();
+            if (notifyHeight > windowHeight) {
+                this.$('.notify-popup').css({
+                    'height':'100%', 
+                    'top':0, 
+                    'overflow-y': 'scroll', 
+                    '-webkit-overflow-scrolling': 'touch'
+                });
+            } else {
+                this.$('.notify-popup').css({
+                    'margin-top': -(notifyHeight/2)
+                });
+            }
+        },
 
-		showNotify: function() {
-			this.resizeNotify();
-			this.$('.notify-popup').show();
-			this.$('.notify-shadow').fadeIn('fast');
-			//Set focus to first accessible element
-			this.$('.notify-popup').a11y_focus();
-				
-		},
+        showNotify: function() {
+            //start fading in the shadow
 
-		closeNotify: function (event) {
-			this.$el.fadeOut('fast', _.bind(function() {
-				this.remove();
-			}, this));
-			Adapt.trigger('popup:closed');
-		}
+            if (this.disableAnimation) {
 
-	});
+                this.$('.notify-shadow').css("display", "block");
 
-	return NotifyView;
+            } else {
+
+                this.$('.notify-shadow').velocity({ opacity: 1 }, {duration:200, begin: _.bind(function() {
+                    this.$('.notify-shadow').css("display", "block");
+                }, this)});
+
+            }
+
+            this.disableBodyScrollbars();
+
+            if (this.$("img").length > 0) {
+                this.$el.imageready( _.bind(loaded, this));
+            } else {
+                loaded.call(this);
+            }
+
+            function loaded() {
+                this.resizeNotify();
+
+                if (this.disableAnimation) {
+
+                    this.$('.notify-popup').css("visibility", "visible");
+
+                } else {
+
+                    //delay popup fadein until after background animations
+                    _.delay(_.bind(function() {
+                        
+                        this.$('.notify-popup').velocity({ opacity: 0 }, {duration:0}).velocity({ opacity: 1 }, { duration:200, begin: _.bind(function() {
+                            this.$('.notify-popup').css("visibility", "visible");
+                        }, this) });
+                        
+                        /*ALLOWS POPUP MANAGER TO CONTROL FOCUS*/
+                        Adapt.trigger('popup:opened', this.$el);
+
+                        //set focus to first accessible element
+                        this.$('.notify-popup').a11y_focus();
+
+                    }, this), 200);
+                }
+            }
+
+        },
+
+        closeNotify: function (event) {
+            
+            if (this.disableAnimation) {
+
+                this.$('.notify-popup').css("visibility", "hidden");
+                this.$el.css("visibility", "hidden");
+
+                this.enableBodyScrollbars();
+
+                this.remove();
+
+            } else {
+
+                this.$('.notify-popup').velocity({ opacity: 0 }, {duration:200, complete: _.bind(function() {
+                    this.$('.notify-popup').css("visibility", "hidden");
+                }, this)});
+
+                this.enableBodyScrollbars();
+
+                //delay background fadeout animations until after popup has faded out
+                _.delay(_.bind(function() {
+
+                    this.$('.notify-shadow').velocity({ opacity: 0 }, {duration:300, complete:_.bind(function() {
+                        this.$el.css("visibility", "hidden");
+                        this.remove();
+                    }, this)});
+
+                }, this), 200);
+            }
+
+            Adapt.trigger('popup:closed');
+        },
+
+        disableBodyScrollbars: function(callback) {
+            this._scrollTop = $(window).scrollTop();
+            this._bodyHeight = $("body").css("height");
+            this._htmlHeight = $("html").css("height");
+
+            if (this.disableAnimation) {
+
+                $('html').css({
+                    "height": "100%"
+                });
+                $('body').css({
+                    "height": "100%",
+                    "overflow-y": "hidden"
+                });
+
+                $('#wrapper').css({
+                    "position": "relative",
+                    "top": "-"+ this._scrollTop +"px"
+                });
+
+            } else {
+
+                $('.page, .menu').velocity({opacity:0}, {duration:1, complete:_.bind(function() {
+
+                    $('.page, .menu').css("visibility", "hidden");              
+                    //wait for renderer to catch-up with fade out
+                    _.delay(_.bind(function(){
+
+                        //this causes the content to jump 
+                        $('html').css({
+                            "height": "100%"
+                        });
+                        $('body').css({
+                            "height": "100%",
+                            "overflow-y": "hidden"
+                        });
+
+                        //puts the content back to where it should be
+                        $('#wrapper').css({
+                            "position": "relative",
+                            "top": "-"+ this._scrollTop +"px"
+                        });
+                        
+                        //wait for renderer to catch-up with jump
+                        _.delay(_.bind(function() {
+                            $('.page, .menu').css("visibility", "visible");
+                            $('.page, .menu').velocity({opacity:1}, {duration:600});
+                        }, this), 50);
+
+                    }, this), 50);
+
+                },this)});
+            }
+            
+        },
+
+        enableBodyScrollbars: function() {
+
+            if (this.disableAnimation) {
+
+                $('html').css({
+                    "height": ""
+                });
+                $('body').css({
+                    "height": "",
+                    "overflow-y": ""
+                });
+                $('#wrapper').css({
+                    "position": "relative",
+                    "top": ""
+                });
+                $(window).scrollTo(this._scrollTop); 
+
+            } else {
+
+                $('.page, .menu').velocity({opacity:0}, {duration:1, complete:_.bind(function() {
+
+                    $('.page, .menu').css("visibility", "hidden");
+
+                    //this causes the content to jump
+                    $('html').css({
+                        "height": ""
+                    });
+                    $('body').css({
+                        "height": "",
+                        "overflow-y": ""
+                    });
+                    $('#wrapper').css({
+                        "position": "relative",
+                        "top": ""
+                    });
+
+                    //wait for renderer to catch-up with jump
+                    _.delay(_.bind(function() {
+
+                        $('.page, .menu').css("visibility", "visible");
+
+                        //puts the content back to where it should be
+                        $(window).scrollTo(this._scrollTop);     
+                        
+                        $('.page, .menu').velocity({opacity:1}, {duration: 300 });
+
+                    }, this), 50);    
+
+                }, this)});
+            }
+
+        }
+    });
+
+    return NotifyView;
 
 });

--- a/src/core/js/views/notifyView.js
+++ b/src/core/js/views/notifyView.js
@@ -34,16 +34,13 @@ define(function(require) {
             var data = this.model.toJSON();
             var template = Handlebars.templates['notify'];
 
-            //hide notify
+            //hide notify container
             this.$el.css("visibility", "hidden");
-
-            //attach popup
+            //attach popup + shadow
             this.$el.html(template(data)).appendTo('body');
-
             //hide popup
             this.$('.notify-popup').css("visibility", "hidden");
-
-            //show notify
+            //show notify container
             this.$el.css("visibility", "visible");
 
             this.showNotify();
@@ -94,7 +91,6 @@ define(function(require) {
         },
 
         showNotify: function() {
-            //start fading in the shadow
 
             if (this.disableAnimation) {
 

--- a/src/core/js/views/notifyView.js
+++ b/src/core/js/views/notifyView.js
@@ -256,8 +256,15 @@ define(function(require) {
                     $('html').css({
                         "height": ""
                     });
+
+                    var height = "";
+
+                    if (this._htmlHeight != this._bodyHeight) {
+                        height = this._bodyHeight;
+                    }
+
                     $('body').css({
-                        "height": "",
+                        "height": height,
                         "overflow-y": ""
                     });
                     $('#wrapper').css({


### PR DESCRIPTION
Scrollbars hidden for both drawer and notify to stop background content from scrolling whilst they are open.

Added: Wait for image loading in notify, fixed notify positioning.

Fixed animations for ie9+
No animations for ie8

NOTE: Must fade the page to white in order to hide the scrollbars and prevent the user from seeing a page jump, so have minimized the effect using fadeins.

TEST ON:
iphone4 ios7
ipad mini ios8
android chrome
winxp ie8
win8 ie11 + win8 ie11:ie9 mode
win8 ff
win8 chrome
blackberry
