### PR TITLE
Fix issue with IOS (Add to home screen)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,6 @@
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<meta content="text/html;charset=utf-8" http-equiv="Content-Type">
 		<meta content="utf-8" http-equiv="encoding">
-		<meta name="apple-mobile-web-app-capable" content="yes"/>
 		<title></title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 		<link href="adapt/css/adapt.css" type="text/css" rel="stylesheet"/>


### PR DESCRIPTION
We noticed an issue on iPad and iPhone, open a course using Safari click add to home screen option, and then click the website icon that is created on the home screen, it will launch the website using Safari, but the course will not open!

It worked once I made this fix , we have the following line of code instead `<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">`.