### PR TITLE
ABU-695: Disable text selection configurable

### DIFF
--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -41,6 +41,8 @@ define(function(require) {
             Adapt.once('app:dataReady', function() {
                 new AccessibilityView();
                 });
+
+            Adapt.on("device:changed", this.setupNoSelect);
         },
 
         setupHelpers: function() {
@@ -380,7 +382,27 @@ define(function(require) {
             $.a11y.options.OS = Adapt.device.OS.toLowerCase();     
             $.a11y.options.isTouchDevice = Modernizr.touch;
 
+            this.setupNoSelect();
+
             $.a11y.ready();
+        },
+
+        setupNoSelect: function() {
+            if (!Adapt.config.get('_accessibility') || !Adapt.config.get('_accessibility')._disableTextSelectOnClasses) return;
+
+            var classes = Adapt.config.get('_accessibility')._disableTextSelectOnClasses.split(" ");
+
+            var isMatch = false;
+            for (var i = 0, item; item = classes[i++];) {
+                if ($('html').is("."+item)) {
+                    isMatch = true;
+                    break;
+                }
+            }
+
+            if (isMatch) $('html').addClass("no-select");
+            else  $('html').removeClass("no-select");
+
         }
 
     }, Backbone.Events);

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -394,7 +394,7 @@ define(function(require) {
 
             var isMatch = false;
             for (var i = 0, item; item = classes[i++];) {
-                if ($('html').is("."+item)) {
+                if ($('html').is(item)) {
                     isMatch = true;
                     break;
                 }

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -400,8 +400,11 @@ define(function(require) {
                 }
             }
 
-            if (isMatch) $('html').addClass("no-select");
-            else  $('html').removeClass("no-select");
+            if (isMatch) {
+                $('html').addClass("no-select");
+            } else  {
+                $('html').removeClass("no-select");
+            }
 
         }
 

--- a/src/core/js/device.js
+++ b/src/core/js/device.js
@@ -19,6 +19,8 @@ define(function(require) {
     Adapt.once('app:dataReady', function() {
         // The theme.json will have been loaded at this point
         Adapt.device.screenSize = checkScreenSize();
+
+        $('html').addClass("size-"+Adapt.device.screenSize);
     });
 
     Adapt.device.screenWidth = $window.width();
@@ -44,6 +46,9 @@ define(function(require) {
 
         if (newScreenSize !== Adapt.device.screenSize) {
             Adapt.device.screenSize = newScreenSize;
+
+            $('html').removeClass("size-small nsize-medium size-large").addClass("size-"+Adapt.device.screenSize);
+
             Adapt.trigger('device:changed', Adapt.device.screenSize);
         }
         

--- a/src/core/js/device.js
+++ b/src/core/js/device.js
@@ -47,7 +47,7 @@ define(function(require) {
         if (newScreenSize !== Adapt.device.screenSize) {
             Adapt.device.screenSize = newScreenSize;
 
-            $('html').removeClass("size-small nsize-medium size-large").addClass("size-"+Adapt.device.screenSize);
+            $('html').removeClass("size-small size-medium size-large").addClass("size-"+Adapt.device.screenSize);
 
             Adapt.trigger('device:changed', Adapt.device.screenSize);
         }

--- a/src/core/less/base.less
+++ b/src/core/less/base.less
@@ -331,3 +331,13 @@
     margin:0 !important;
     line-height: normal !important;
 }
+
+
+.no-select {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}

--- a/src/core/less/reset.less
+++ b/src/core/less/reset.less
@@ -54,11 +54,3 @@ a, button {-webkit-tap-highlight-color: rgba(0,0,0,0.2);}
 	// Fix for iOS devices not displaying icons if hidden then shown
 	-webkit-transform: translateZ(0);
 }
-body {
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-}

--- a/src/course/config.json
+++ b/src/course/config.json
@@ -5,7 +5,8 @@
     "_accessibility": {
         "_isEnabled": false,
         "_shouldSupportLegacyBrowsers": true,
-        "_isTextProcessorEnabled": true
+        "_isTextProcessorEnabled": true,
+        "_disableTextSelectOnClasses": "size-small size-medium size-large"
     },
     "_drawer": {
         "_showEasing": "easeOutQuart",

--- a/src/course/config.json
+++ b/src/course/config.json
@@ -6,7 +6,7 @@
         "_isEnabled": false,
         "_shouldSupportLegacyBrowsers": true,
         "_isTextProcessorEnabled": true,
-        "_disableTextSelectOnClasses": "size-small size-medium size-large"
+        "_disableTextSelectOnClasses": ".size-small .size-medium .size-large"
     },
     "_drawer": {
         "_showEasing": "easeOutQuart",


### PR DESCRIPTION
1. Moved body {} styling to a .no-select {} class.
2. Added 'size-small',  'size-medium' and 'size-large' class for respective device sizes to html tag.
3. Added '_disableTextSelectOnClasses' to config.json in _accessibility: {}
4. Extended accessibility code to compare the classes in the above attribute with the classes on the html tag when the device size changes. The class 'no-select' is added / removed to the html tag when a match is found.
5. By default no text selection is permitted, do we want 'no-select' on just touch devices?