### PR TITLE
Resolves #636 - Corrects component _layout attribute issue

### DIFF
--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -148,6 +148,21 @@ define(function (require) {
                 childrenCollection = new Backbone.Collection(children);
             }
 
+            if (this.get('_type') == 'block' && childrenCollection.length == 2) {
+                // Components may have a 'left' or 'right' _layout, 
+                // so ensure they appear in the correct order
+                if (childrenCollection.models[0].get('_layout') !== 'left') {
+                    var tempCollection = new Backbone.Collection();
+
+                    // Reverse the order of the component models to correct it
+                    tempCollection.add(childrenCollection.models[1]);
+                    tempCollection.add(childrenCollection.models[0]);
+
+                    // Reset the childrenCollection
+                    childrenCollection = tempCollection;
+                }
+            }
+
             this.set("_children", childrenCollection);
 
             // returns a collection of children

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -148,19 +148,13 @@ define(function (require) {
                 childrenCollection = new Backbone.Collection(children);
             }
 
-            if (this.get('_type') == 'block' && childrenCollection.length == 2) {
+            if (this.get('_type') == 'block' && childrenCollection.length == 2
+                && childrenCollection.models[0].get('_layout') !== 'left') {
                 // Components may have a 'left' or 'right' _layout, 
                 // so ensure they appear in the correct order
-                if (childrenCollection.models[0].get('_layout') !== 'left') {
-                    var tempCollection = new Backbone.Collection();
-
-                    // Reverse the order of the component models to correct it
-                    tempCollection.add(childrenCollection.models[1]);
-                    tempCollection.add(childrenCollection.models[0]);
-
-                    // Reset the childrenCollection
-                    childrenCollection = tempCollection;
-                }
+                // Re-order component models to correct it
+                childrenCollection.comparator = '_layout';
+                childrenCollection.sort();
             }
 
             this.set("_children", childrenCollection);


### PR DESCRIPTION
This patch resolves the issue with precedence in that the ordering of the components.json could overide the _layout attribute.  This change assumes that a _layout of "left" should appear first.  In mobile views, if this was not handled in the theme this was not the case.