### PR TITLE
Hotfix develop/636 -- two fixes around getChildren()

### DIFF
--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -152,7 +152,7 @@ define(function (require) {
 
                 returnedDescedants = new Backbone.Collection(flattenedDescendants);
 
-                if (children.models[0]._children === descendants) {
+                if (children.models.length === 0 || children.models[0]._children === descendants) {
                     return;
                 } else {
                     allDescendants = [];
@@ -168,8 +168,16 @@ define(function (require) {
 
         getChildren: function () {
             if (this.get("_children")) return this.get("_children");
-            var children = Adapt[this._children].where({_parentId: this.get("_id")});
-            var childrenCollection = new Backbone.Collection(children);
+
+            var childrenCollection;
+
+            if (!this._children) {
+                childrenCollection = new Backbone.Collection();
+            } else {
+                var children = Adapt[this._children].where({_parentId: this.get("_id")});
+                childrenCollection = new Backbone.Collection(children);
+            }
+
             this.set("_children", childrenCollection);
 
             // returns a collection of children

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -178,6 +178,21 @@ define(function (require) {
                 childrenCollection = new Backbone.Collection(children);
             }
 
+            if (this.get('_type') == 'block' && childrenCollection.length == 2) {
+                // Components may have a 'left' or 'right' _layout, 
+                // so ensure they appear in the correct order
+                if (childrenCollection.models[0].get('_layout') !== 'left') {
+                    var tempCollection = new Backbone.Collection();
+
+                    // Reverse the order of the component models to correct it
+                    tempCollection.add(childrenCollection.models[1]);
+                    tempCollection.add(childrenCollection.models[0]);
+
+                    // Reset the childrenCollection
+                    childrenCollection = tempCollection;
+                }
+            }
+
             this.set("_children", childrenCollection);
 
             // returns a collection of children

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -178,19 +178,13 @@ define(function (require) {
                 childrenCollection = new Backbone.Collection(children);
             }
 
-            if (this.get('_type') == 'block' && childrenCollection.length == 2) {
+            if (this.get('_type') == 'block' && childrenCollection.length == 2
+                && childrenCollection.models[0].get('_layout') !== 'left') {
                 // Components may have a 'left' or 'right' _layout, 
                 // so ensure they appear in the correct order
-                if (childrenCollection.models[0].get('_layout') !== 'left') {
-                    var tempCollection = new Backbone.Collection();
-
-                    // Reverse the order of the component models to correct it
-                    tempCollection.add(childrenCollection.models[1]);
-                    tempCollection.add(childrenCollection.models[0]);
-
-                    // Reset the childrenCollection
-                    childrenCollection = tempCollection;
-                }
+                // Re-order component models to correct it
+                childrenCollection.comparator = '_layout';
+                childrenCollection.sort();
             }
 
             this.set("_children", childrenCollection);


### PR DESCRIPTION
Two fixes:
* Check for `undefined` (cherry-picked from master)
* Fix for #636 