### PR TITLE
Fix for IE11, adding a class (ie) to html element.

### DIFF
--- a/src/core/js/device.js
+++ b/src/core/js/device.js
@@ -84,7 +84,8 @@ define(function(require) {
     Adapt.device.browser = browser ? browser.toLowerCase() : "";
     Adapt.device.version = version ? version.toLowerCase() : "";
     Adapt.device.OS = OS ? OS.toLowerCase() : "";
-    
+    browserString = browserString.replace("Internet Explorer", "ie");
+
     $("html").addClass(browserString);
     
 });


### PR DESCRIPTION
On ie browsers, adapt should give a class name (ie) to the html element, but in ie 11 latest adapt gives a class(internet explorer) to the html element, This fix will catch (internet explorer) in the string and replace it with (ie).