### PR TITLE
ABU-674: Locking as optional utility

### DIFF
--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -1,15 +1,25 @@
-define(function(require){
+define([
+    'coreModels/lockingModel',
+    'coreHelpers'
+], function(lockingModel, Helpers) {
 
-    var _ = require('underscore');
-    var Backbone = require('backbone');
-    var Helpers = require('coreHelpers');
+    var AdaptModel = Backbone.Model.extend({
 
-    var Adapt = {};
+        defaults: {
+            _canScroll: true //to stop scrollTo behaviour
+        },
+
+        lockedAttributes: {
+            _canScroll: false
+        }
+
+    });
+
+    var Adapt = new AdaptModel();
+
     Adapt.location = {};
     Adapt.componentStore = {};
     var mappedIds = {};
-
-    _.extend(Adapt, Backbone.Events);
 
     Adapt.initialize = _.once(function() {
         Backbone.history.start();
@@ -36,8 +46,11 @@ define(function(require){
 
         if (settings.offset.left === 0) settings.axis = "y";
 
+        if (Adapt.get("_canScroll") !== false) {
         // Trigger scrollTo plugin
         $.scrollTo(selector, settings);
+        }
+
         // Trigger an event after animation
         // 300 milliseconds added to make sure queue has finished
         _.delay(function() {

--- a/src/core/js/app.js
+++ b/src/core/js/app.js
@@ -15,6 +15,7 @@ require([
     'coreModels/blockModel',
     'coreModels/componentModel',
     'coreJS/offlineStorage',
+    'coreModels/lockingModel',
     'velocity',
     'imageReady',
     'inview',

--- a/src/core/js/models/lockingModel.js
+++ b/src/core/js/models/lockingModel.js
@@ -21,7 +21,7 @@ define([
 				this.lockedAttributes[attrName] = !this.defaults[attrName];
 			}
 			var lockingValue = this.lockedAttributes[attrName];
-			var isAttemptingToLock = lockingValue === attrVal;
+			var isAttemptingToLock = (lockingValue === attrVal);
 
 			if (isAttemptingToLock) {
 
@@ -63,8 +63,8 @@ define([
 		},
 
 		isLocking: function(attrName) {
-			var isCheckingGeneralLockingState = attrName === undefined;
-			var isUsingLockedAttributes = this.lockedAttributes !== undefined;
+			var isCheckingGeneralLockingState = (attrName === undefined);
+			var isUsingLockedAttributes = (this.lockedAttributes !== undefined);
 
 			if (isCheckingGeneralLockingState) {
 				return isUsingLockedAttributes;
@@ -110,7 +110,7 @@ define([
 			}
 
 			var lockingAttributeValues = _.values(this._lockedAttributesValues[attrName]);
-			var lockingAttributeValuesSum = _.reduce(lockingAttributeValues, function(memo, value){ return memo + (value ? 1 : 0); }, 0);
+			var lockingAttributeValuesSum = _.reduce(lockingAttributeValues, function(sum, value){ return sum + (value ? 1 : 0); }, 0);
 			
 			return lockingAttributeValuesSum;
 		},

--- a/src/core/js/models/lockingModel.js
+++ b/src/core/js/models/lockingModel.js
@@ -1,0 +1,137 @@
+define([
+	'backbone'
+], function() {
+
+	var set = Backbone.Model.prototype.set;
+
+	_.extend(Backbone.Model.prototype, {
+
+		set: function(attrName, attrVal, options) {
+			var stopProcessing = !this.lockedAttributes || typeof attrName === "object" || typeof attrVal !== "boolean" || !this.isLocking(attrName);
+			if (stopProcessing) return set.apply(this, arguments);
+
+			var isSettingValueForSpecificPlugin = options && options.pluginName;
+			if (!isSettingValueForSpecificPlugin) {
+				console.error("Must supply a pluginName to change a locked attribute");
+				options.pluginName = "compatibility";
+			}
+
+			var pluginName  = options.pluginName;
+			var lockingValue = this.lockedAttributes[attrName] = !this.defaults[attrName];
+			var isAttemptingToLock = lockingValue === attrVal;
+
+			if (isAttemptingToLock) {
+
+				this.setLockValue(attrName, true, {pluginName:pluginName, skipcheck: true});
+
+				//console.log(options.pluginName, "locking", attrName, "on", this.get("_id"));
+				return set.call(this, attrName, lockingValue);
+
+			}
+
+			this.setLockValue(attrName, false, {pluginName:pluginName, skipcheck: true});
+
+			var totalLockValue = this.getLockValue(attrName, {skipcheck: true})
+			//console.log(options.pluginName, "attempting to unlock", attrName, "on", this.get("_id"), "lockValue", totalLockValue, this._lockedAttributesValues[attrName]);
+			if (totalLockValue === 0) {
+				//console.log(options.pluginName, "unlocking", attrName, "on", this.get("_id"));
+				return set.call(this, attrName, !lockingValue);
+			}
+
+			return this;
+
+		},
+
+		setLocking: function(attrName, defaultLockValue) {
+			if (this.isLocking(attrName)) return;
+			if (!this.lockedAttributes) this.lockedAttributes = {};
+			this.lockedAttributes[attrName] = defaultLockValue;
+		},
+
+		unsetLocking: function(attrName) {
+			if (!this.isLocking(attrName)) return;
+			if (!this.lockedAttributes) return;
+			delete this.lockedAttributes[attrName];
+			delete this._lockedAttributesValues[attrName];
+			if (_.keys(this.lockedAttributes).length === 0) {
+				delete this.lockedAttributes;
+				delete this._lockedAttributesValues;
+			}
+		},
+
+		isLocking: function(attrName) {
+			var isCheckingGeneralLockingState = attrName === undefined;
+			var isUsinglockedAttributes = this.lockedAttributes !== undefined;
+
+			if (isCheckingGeneralLockingState) {
+				return isUsinglockedAttributes;
+			}
+
+			if (!isUsinglockedAttributes) return false;
+
+			var isAttributeALockingAttribute = this.lockedAttributes[attrName] !== undefined;
+			if (!isAttributeALockingAttribute) return false;
+
+			if (this._lockedAttributesValues === undefined) {
+				this._lockedAttributesValues = {};
+			}
+
+			if (this._lockedAttributesValues[attrName] === undefined) {
+				this._lockedAttributesValues[attrName] = {};	
+			}
+
+			return true;
+		},
+
+		isLocked: function(attrName, options) {
+			if (!(options && options.skipcheck)) { 
+				var stopProcessing =  !this.isLocking(attrName);
+				if (stopProcessing) return;
+			}
+
+			return this.getLockValue(attrName) > 0;
+		},
+
+		getLockValue: function(attrName, options) {
+			if (!(options && options.skipcheck)) { 
+				var stopProcessing =  !this.isLocking(attrName);
+				if (stopProcessing) return;
+			}
+
+			var isGettingValueForSpecificPlugin = options && options.pluginName;
+			if (isGettingValueForSpecificPlugin) {
+
+				return this._lockedAttributesValues[attrName][options.pluginName] ? 1 : 0;
+			}
+
+			var lockingAttributeValues = _.values(this._lockedAttributesValues[attrName]);
+			var lockingAttributeValuesSum = _.reduce(lockingAttributeValues, function(memo, value){ return memo + (value ? 1 : 0); }, 0);
+			
+			return lockingAttributeValuesSum;
+		},
+
+		setLockValue: function(attrName, value, options) {
+			if (!(options && options.skipcheck)) { 
+				var stopProcessing =  !this.isLocking(attrName);
+				if (stopProcessing) return this;
+			}
+
+			var isSettingValueForSpecificPlugin = options && options.pluginName;
+			if (!isSettingValueForSpecificPlugin) {
+				console.error("Must supply a pluginName to set a locked attribute lock value");
+				options.pluginName = "compatibility";
+			}
+
+			if (value) {
+				this._lockedAttributesValues[attrName][options.pluginName] = value;
+			} else {
+				delete this._lockedAttributesValues[attrName][options.pluginName];
+			}
+
+			return this;
+
+		}
+
+	});
+
+});

--- a/src/core/js/models/lockingModel.js
+++ b/src/core/js/models/lockingModel.js
@@ -9,6 +9,8 @@ define([
 		set: function(attrName, attrVal, options) {
 			var stopProcessing = !this.lockedAttributes || typeof attrName === "object" || typeof attrVal !== "boolean" || !this.isLocking(attrName);
 			if (stopProcessing) return set.apply(this, arguments);
+			
+			options = options || {};
 
 			var isSettingValueForSpecificPlugin = options && options.pluginName;
 			if (!isSettingValueForSpecificPlugin) {

--- a/src/core/js/models/routerModel.js
+++ b/src/core/js/models/routerModel.js
@@ -7,7 +7,12 @@
 
  		defaults: {
  			_canNavigate: true
+ 		},
+
+ 		lockedAttributes: {
+ 			_canNavigate: false
  		}
+ 		
  	});
 
  	return RouterModel;

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -29,7 +29,8 @@ define([
             var args = [].slice.call(arguments, 0, arguments.length);
             if (arguments[arguments.length-1] === null) args.pop();
 
-            
+            //check if the current page is in the progress of navigating to itself
+            //it will redirect to itself if the url was changed and _canNavigate is false
             if (!this._isCircularNavigationInProgress) {
                 //trigger an event pre 'router:location' to allow extensions to stop routing
                 Adapt.trigger("router:navigate", arguments);
@@ -56,6 +57,7 @@ define([
             
             if (this._isCircularNavigationInProgress) {
                 //navigation correction finished
+                //router has successfully renavigated to the current id as the url was changed whilst _canNavigate: false
                 delete this._isCircularNavigationInProgress;
                 return;
             }

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -1,9 +1,8 @@
-define(function(require) {
-
-    var Backbone = require('backbone');
-    var Adapt = require('coreJS/adapt');
-    var RouterModel = require('coreModels/routerModel');
-    var PageView = require('coreViews/pageView');
+define([
+    'coreJS/adapt',
+    'coreModels/routerModel',
+    'coreViews/pageView',
+], function(Adapt, RouterModel, PageView) {
 
     Adapt.router = new RouterModel(null, {reset: true});
 
@@ -17,12 +16,57 @@ define(function(require) {
                 document.title = Adapt.course.get('title');
             });
             this.listenTo(Adapt, 'navigation:backButton', this.navigateToPreviousRoute);
+            this.listenTo(Adapt, "router:navigateTo", this.handleRoute);
         },
 
         routes: {
-            "":"handleCourse",
-            "id/:id":"handleId",
-            ":pluginName(/*location)(/*action)": "handlePluginRouter"
+            "":"handleRoute",
+            "id/:id":"handleRoute",
+            ":pluginName(/*location)(/*action)": "handleRoute"
+        },
+
+        handleRoute: function() {
+            var args = [].slice.call(arguments, 0, arguments.length);
+            if (arguments[arguments.length-1] === null) args.pop();
+
+            
+            if (!this._isCircularNavigationInProgress) {
+                //trigger an event pre 'router:location' to allow extensions to stop routing
+                Adapt.trigger("router:navigate", arguments);
+            }
+
+            if (Adapt.router.get('_canNavigate')) {
+                
+                //disable navigation whilst rendering
+                Adapt.router.set('_canNavigate', false, {pluginName: "adapt"});
+
+                //only navigate if this switch is set
+                switch (args.length) {
+                case 1:
+                    //if only one parameter assume id
+                    return this.handleId.apply(this, arguments);
+                case 2:
+                    //if two parameters assume plugin
+                    return this.handlePluginRouter.apply(this, arguments);
+                }
+                //if < 1 || > 2 parameters, route to course
+                return this.handleCourse();
+            }
+
+            
+            if (this._isCircularNavigationInProgress) {
+                //navigation correction finished
+                delete this._isCircularNavigationInProgress;
+                return;
+            }
+            
+            //cancel navigation to stay at current location
+            this._isCircularNavigationInProgress = true;
+            Adapt.trigger("router:navigationCancelled", arguments);
+
+            //reset url to current one
+            this.navigateToCurrentRoute(true);
+
         },
 
         handlePluginRouter: function(pluginName, location, action) {
@@ -44,6 +88,10 @@ define(function(require) {
             Adapt.course.set('_isReady', false);
             this.setContentObjectToVisited(Adapt.course);
             this.updateLocation('course');
+            Adapt.once('menuView:ready', function() {
+                //allow navigation
+                Adapt.router.set('_canNavigate', true, {pluginName: "adapt"});
+            });
             Adapt.trigger('router:menu', Adapt.course);
         },
 
@@ -61,15 +109,25 @@ define(function(require) {
                     if (currentModel.get('_type') == 'page') {
                         var location = 'page-' + id;
                         this.updateLocation(location, 'page', id);
+                        Adapt.once('pageView:ready', function() {
+                            //allow navigation
+                            Adapt.router.set('_canNavigate', true, {pluginName: "adapt"});
+                        });
                         Adapt.trigger('router:page', currentModel);
                         this.$wrapper.append(new PageView({model:currentModel}).$el);
                     } else {
                         var location = 'menu-' + id;
                         this.updateLocation(location, 'menu', id);
+                        Adapt.once('menuView:ready', function() {
+                            //allow navigation
+                            Adapt.router.set('_canNavigate', true, {pluginName: "adapt"});
+                        });
                         Adapt.trigger('router:menu', currentModel);
                     }
                 break;
                 default:
+                    //allow navigation
+                    Adapt.router.set('_canNavigate', true, {pluginName: "adapt"});
                     Adapt.navigateToElement('.' + id);
             }
         },
@@ -82,10 +140,10 @@ define(function(require) {
             $('.loading').show();
         },
 
-        navigateToPreviousRoute: function() {
+        navigateToPreviousRoute: function(force) {
             // Sometimes a plugin might want to stop the default navigation
             // Check whether default navigation has changed
-            if (Adapt.router.get('_canNavigate')) {
+            if (Adapt.router.get('_canNavigate') || force) {
                 if (!Adapt.location._currentId) {
                     return Backbone.history.history.back();
                 }
@@ -99,6 +157,18 @@ define(function(require) {
                     return;
                 }
                 this.navigateToParent();
+            }
+        },
+
+        navigateToCurrentRoute: function(force) {
+            
+            if (Adapt.router.get('_canNavigate') || force) {
+                if (!Adapt.location._currentId) {
+                    return;
+                }
+                var currentId = Adapt.location._currentId;
+                var route = (currentId === Adapt.course.get("_id")) ? "#/" : "#/id/" + currentId;
+                this.navigate(route, { trigger: true, replace: true });
             }
         },
 


### PR DESCRIPTION
* changes Adapt object from _.extend({}, Backbone.Events) to Backbone.Model to accommodate run-time variables in a consistent way
* extended Backbone.Model to include optional attribute locking, the locking mechanism is one lock per plugin name, to set or unset
* added _canScroll to Adapt model to block Adapt.scrollTo function from performing the scroll (useful for block sliders when they should manage their own scrolling)
* made Adapt.get("_canScroll") a locked attribute
* made Adapt.router.get("_canNavigate") a locked attribute (to overcome brians issue (https://github.com/adaptlearning/adapt_framework/issues/587)
* extended router to block all navigation events when using Adapt.router.set("_canNavigate", false, { pluginName: "plugin" });
* made router block navigation events when content is loading (to solve media element issue in ie8 on a navigate+back in quick succession)
* kept .set(attributeName, value, options) to old backboneModel.js implementation using {pluginName: ''}

This is the long awaited re-implementation of backboneModel.js. Rather than being a mediator, this is a locking mechanism. It is not enabled for every model, only for models where is it explicitly enabled. It is enabled on the Adapt and Adapt.router models at present, for _canScroll and _canNavigate respectively.


New backbone model functions can be found in https://github.com/adaptlearning/adapt_framework/blob/ABU-674/src/core/js/models/lockingModel.js

Description of new Backbone.Model functions:

```
set(attrName, attrVal, options)  : an extension to the original function

  Model.set("_canNavigate", false, { pluginName: "plugin" });
  Model.set("_canNavigate", true, { pluginName: "plugin" });


setLocking(attrName, defaultLockValue) : add locking to a model attribute

    Model.setLocking("_isVisible", false);


unsetLocking(attrName) : remove locking from a model attribute

    Model.unsetLocking("_isVisible");


isLocking(attrName) : returns t/f if the attribute is a locking attribute

    Model.isLocking("_isVisible");


isLocked(attributeName, options) : returns t/f/undefined is the attribute it locked, if it is locked for the supplied pluginName or undefined if it is not a locking attribute

    Model.isLocked("_isVisible");
    Model.isLocked("_isVisible", {pluginName: "plugin"});


getLockCount(attributeName, options) : returns an integer/undefined for the number of locks held in total for the attribute, or for the supplied pluginName or undefined if the attribute is not a locking attribute

    Model.getLockValue("_isVisible");
    Model.getLockValue("_isVisible", {pluginName: "plugin"});


setLockState(attributeName, value, options) : sets the locking value for the given pluginName to value (t/f)

    Model.setLockValue("_isVisible", true, {pluginName: "plugin"});


```