### PR TITLE
Add _shouldStoreResponses to the config file

### DIFF
--- a/src/course/config.json
+++ b/src/course/config.json
@@ -17,7 +17,8 @@
         "_tracking": {
             "_requireCourseCompleted": true,
             "_requireAssessmentPassed": true,
-            "_shouldSubmitScore": false
+            "_shouldSubmitScore": false,
+            "_shouldStoreResponses": false
         },
         "_reporting": {
             "_comment": "Your options here are 'completed', 'passed', 'failed', and 'incomplete'",


### PR DESCRIPTION
After the fixes for this feature has been merged to all question components and spoor extension I believe it is the time to add "_shouldStoreResponses": false  to the adapt framework.