### PR TITLE
Assessment, Trickle applied to block or article

### DIFF
--- a/src/course/en/components.json
+++ b/src/course/en/components.json
@@ -992,7 +992,7 @@
 			},
 			{
 				"text": "Block",
-				"_shouldBeSelected": false
+				"_shouldBeSelected": true
 			},
 			{
 				"text": "Component",


### PR DESCRIPTION
In the assessments page, the trickle can be applied to block or article, not article only.
https://github.com/adaptlearning/adapt-contrib-trickle