### PR TITLE
Changed height to outerHeight

### DIFF
--- a/src/core/js/views/notifyView.js
+++ b/src/core/js/views/notifyView.js
@@ -103,7 +103,7 @@ define(function(require) {
 
         resizeNotify: function() {
             var windowHeight = $(window).height();
-            var notifyHeight = this.$('.notify-popup').height();
+            var notifyHeight = this.$('.notify-popup').outerHeight();
 
             if (notifyHeight > windowHeight) {
                 this.$('.notify-popup').css({


### PR DESCRIPTION
Using `outerHeight` instead of `height` gets the height of an element *including* any padding added to it, making vertical alignment more accurate.