### PR TITLE
Don't override template if already set

### DIFF
--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -80,7 +80,7 @@ define(function(require){
         // Store the component view
         if (Adapt.componentStore[name])
             throw Error('This component already exists in your project');
-        object.template = name;
+        if(!object.template) object.template = name;
         Adapt.componentStore[name] = object;
 
     }


### PR DESCRIPTION
Allows devs to more easily extend existing components, by making available existing templates. Currently you're forced to create a new template with the name registered by your component.

This allows you to do such things as:
```
var TextDerivitive = Text.extend({
    template: "text",
    ...
});
```