### PR TITLE
Hotfix for a11y limitedScrollTo Position

### DIFF
--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -351,7 +351,7 @@
             var isElementTopOutOfView = (elementTop < scrollTopWithTopOffset || elementTop > scrollBottomWithTopOffset);
             if (!isElementTopOutOfView) return;
 
-            var scrollToPosition = elementTop - topOffset;
+            var scrollToPosition = elementTop - topOffset - (windowAvailableHeight / 2);
             if (scrollToPosition < 0) scrollToPosition = 0;
 
             defer(function() {


### PR DESCRIPTION
Fix aimed at keeping content centralised on screen to give context to surroundings