### PR TITLE
ABU-1075 - store uid on dom object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## [Unreleased][unreleased]
 - Nothing!
 
+## [2.0.3] - 2015-10-02
+### Added
+- fixed popup tab index save/restore [ABU-1075](https://adaptlearning.atlassian.net/browse/ABU-1075)
+
 ## [2.0.2] - 2015-09-28
 ### Added
 - add new button styles to base.less (#732, [ABU-1069](https://adaptlearning.atlassian.net/browse/ABU-1069))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 - Nothing!
 
 ## [2.0.3] - 2015-10-02
-### Added
+### Fixed
 - fixed popup tab index save/restore [ABU-1075](https://adaptlearning.atlassian.net/browse/ABU-1075)
 
 ## [2.0.2] - 2015-09-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,7 +196,8 @@ The initial version of the Adapt framework.
 - Everything!
 
 
-[unreleased]: https://github.com/adaptlearning/adapt_framework/compare/v2.0.2...HEAD
+[unreleased]: https://github.com/adaptlearning/adapt_framework/compare/v2.0.3...HEAD
+[2.0.3]: https://github.com/adaptlearning/adapt_framework/compare/v2.0.2...v2.0.3
 [2.0.2]: https://github.com/adaptlearning/adapt_framework/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/adaptlearning/adapt_framework/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/adaptlearning/adapt_framework/compare/v1.1.3...v2.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt_framework",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Adapt Learning output framework",
   "repository": {
     "type": "git",

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -908,10 +908,10 @@
                 var $item = $(item);
                 
                 var elementUID;
-                if ($item.a11y_uid == undefined) {
-                    $item.a11y_uid = "UID" + ++state.elementUIDIndex;
+                if (item.a11y_uid == undefined) {
+                    item.a11y_uid = "UID" + ++state.elementUIDIndex;
                 }
-                elementUID = $item.a11y_uid;
+                elementUID = item.a11y_uid;
 
                 if (storeLastTabIndex) {
                     if (state.tabIndexes[elementUID] === undefined) state.tabIndexes[elementUID] = [];
@@ -968,11 +968,11 @@
                 var previousTabIndex = 0;
 
                 var elementUID;
-                if ($item.a11y_uid == undefined) {
+                if (item.a11y_uid == undefined) {
                     //assign element a unique id
-                    $item.a11y_uid = "UID" + ++state.elementUIDIndex;
+                    item.a11y_uid = "UID" + ++state.elementUIDIndex;
                 }
-                elementUID = $item.a11y_uid;
+                elementUID = item.a11y_uid;
 
 
                 if (state.tabIndexes[elementUID] !== undefined && state.tabIndexes[elementUID].length !== 0) {


### PR DESCRIPTION
a jquery object is receiving a uid instead of the dom object, so saving and restoring dom object tabindexes is flawed.
need to change to assigning a uid to the dom object so that it's tabindex can be restored correctly.

change made.