### PR TITLE
ABU-1075 - store uid on dom object

### DIFF
--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -908,10 +908,10 @@
                 var $item = $(item);
                 
                 var elementUID;
-                if ($item.a11y_uid == undefined) {
-                    $item.a11y_uid = "UID" + ++state.elementUIDIndex;
+                if (item.a11y_uid == undefined) {
+                    item.a11y_uid = "UID" + ++state.elementUIDIndex;
                 }
-                elementUID = $item.a11y_uid;
+                elementUID = item.a11y_uid;
 
                 if (storeLastTabIndex) {
                     if (state.tabIndexes[elementUID] === undefined) state.tabIndexes[elementUID] = [];
@@ -968,11 +968,11 @@
                 var previousTabIndex = 0;
 
                 var elementUID;
-                if ($item.a11y_uid == undefined) {
+                if (item.a11y_uid == undefined) {
                     //assign element a unique id
-                    $item.a11y_uid = "UID" + ++state.elementUIDIndex;
+                    item.a11y_uid = "UID" + ++state.elementUIDIndex;
                 }
-                elementUID = $item.a11y_uid;
+                elementUID = item.a11y_uid;
 
 
                 if (state.tabIndexes[elementUID] !== undefined && state.tabIndexes[elementUID].length !== 0) {


### PR DESCRIPTION
a jquery object is receiving a uid instead of the dom object, so saving and restoring dom object tabindexes is flawed.
need to change to assigning a uid to the dom object so that it's tabindex can be restored correctly.

change made.