### PR TITLE
Accessibility issue with question component reset button

### DIFF
--- a/src/core/js/views/questionView.js
+++ b/src/core/js/views/questionView.js
@@ -467,6 +467,7 @@ define(function(require) {
                 _isSubmitted: false
             });
             this.$(".component-widget").removeClass("submitted");
+            this.$('.component-body-inner').a11y_focus();
         },
 
         // Used by the question view to reset the stored user answer


### PR DESCRIPTION
On reset,  the focus returns to the start question text.