### PR TITLE
Don't override template if already set - fix to issue #770

### DIFF
--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -97,7 +97,7 @@ define([
         // Store the component view
         if (Adapt.componentStore[name])
             throw Error('This component already exists in your project');
-        if(!object.template) object.template = name;
+        if(!object.template || object.template != name) object.template = name;
         Adapt.componentStore[name] = object;
 
     }


### PR DESCRIPTION
Fixes this change:
https://github.com/adaptlearning/adapt_framework/commit/a7af2e3f8713979f3b8933ed6c443f254ec6eb27#diff-dc2a9e6689317375d0da7294e71344c8
to avoid issue reported here:
https://github.com/adaptlearning/adapt_framework/issues/770