### PR TITLE
Amends to navigateTo

### DIFF
--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -18,7 +18,7 @@ define([
             this.listenTo(Adapt, 'navigation:backButton', this.navigateToPreviousRoute);
             this.listenTo(Adapt, 'navigation:homeButton', this.navigateToHomeRoute);
             this.listenTo(Adapt, 'navigation:parentButton', this.navigateToParent);
-            this.listenTo(Adapt, "router:navigateTo", this.handleRoute);
+            this.listenTo(Adapt, "router:navigateTo", this.navigateToArguments);
         },
 
         routes: {
@@ -142,6 +142,36 @@ define([
 
         showLoading: function() {
             $('.loading').show();
+        },
+        
+        navigateToArguments: function(args) {
+            args = [].slice.call(args, 0, args.length);
+            if (args[args.length-1] === null) args.pop();
+            switch (args.length) {
+            case 0:
+                this.navigate("#/", {trigger:false, replace:false});
+                break;
+            case 1:
+                var foundId = false;
+                try {
+                    Adapt.findById(args[0]);
+                    foundId = true;
+                } catch(e) {
+
+                }
+                if (foundId) {
+                    this.navigate("#/id/"+args[0], {trigger:false, replace:false});
+                } else {
+                    this.navigate("#/"+args[0], {trigger:false, replace:false});
+                }
+            case 2:
+                this.navigate("#/"+args[0]+"/"+args[1], {trigger:false, replace:false});
+                break;
+            case 3:
+                this.navigate("#/"+args[0]+"/"+args[1]+"/"+args[2], {trigger:false, replace:false});
+                break;
+            }
+            this.handleRoute.apply(this, args);
         },
 
         navigateToPreviousRoute: function(force) {


### PR DESCRIPTION
to allow plugins to capture and defer routing without being aware of the parameters provided.

used in conjunction with:

``this.listenTo(Adapt, "router:navigate", arguments);``
``Adapt.router.set("_canNavigation", false, {pluginName: "name"});``
``//do something else here``
``Adapt.router.set("_canNavigation", true, {pluginName: "name"});``
``Adapt.trigger(Adapt, "router:navigateTo", arguments);``
