### PR TITLE
bugfix/accessibility

### DIFF
--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -10,7 +10,7 @@ define(function(require) {
         $accessibilityToggle: $("#accessibility-toggle"),
 
         _tabIndexElements: 'a, button, input, select, textarea, [tabindex]',
-        _hasTabPosition: false,
+        _isButtonRedirectionOn: true,
         _hasUsageInstructionRead: false,
         _isLoaded: false,
         _hasCourseLoaded: false,
@@ -210,7 +210,7 @@ define(function(require) {
             this.setNavigationBar();
 
             //MAKE FOCUS RIGHT
-            this._hasTabPosition = false
+            this._isButtonRedirectionOn = true;
             this.focusInitial();
 
         },
@@ -259,7 +259,7 @@ define(function(require) {
             } else {
 
                 //OTHERWISE ENABLE TAB REDIRECTION TO TOGGLE BUTTON
-                this._hasTabPosition = false;
+                this._isButtonRedirectionOn = true;
             }
         },
 
@@ -384,7 +384,7 @@ define(function(require) {
         focusInitial: function() {
             if (!this.isActive()) return;
 
-            this._hasTabPosition = true;
+            this._isButtonRedirectionOn = false;
 
             _.delay(_.bind(function() {
                 //ENABLED DOCUMENT READING
@@ -467,7 +467,7 @@ define(function(require) {
             if ($.a11y.userInteracted) return;
 
             //IF INITIAL TAB NOT CAPTURED AND ACCESSIBILITY NOT ON, RETURN
-            if (Accessibility.isActive() && Accessibility._hasTabPosition) return;
+            if (Accessibility.isActive() && !Accessibility._isButtonRedirectionOn) return;
 
             //IF TAB PRESSED, AND TAB REDIRECTION ON, ALWAYS TAB TO ACCESSIBILITY BUTTON ONLY
             Accessibility.$accessibilityToggle.focus();
@@ -476,7 +476,7 @@ define(function(require) {
 
         onFocusInstructions: function(event) {
             //HIDE INSTRUCTIONS FROM TAB WRAP AROUND AFTER LEAVING INSTRUCTIONS
-            if (!Accessibility._hasTabPosition) return;
+            if (Accessibility._isButtonRedirectionOn) return;
             if (!Accessibility._isLoaded) return;
             $(event.target).addClass("a11y-ignore-focus");
         }

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -22,7 +22,7 @@ define(function(require) {
 
             //TRIGGER SETUP ON DATA LOADED AND TOGGLE BUTTON
             Adapt.once('app:dataLoaded', function() {
-				//check if accessibility mode should be restored
+                //check if accessibility mode should be restored
                 this._hasCourseLoaded = true;
                 Adapt.config.get("_accessibility")._isActive = Adapt.offlineStorage.get("a11y") || false;
                 this.setupAccessibility();
@@ -54,6 +54,7 @@ define(function(require) {
             if (!this.isEnabled()) return;
 
             if (this._hasCourseLoaded) {
+                //save accessibility state
                 Adapt.offlineStorage.set("a11y", Adapt.config.get("_accessibility")._isActive);
             }
 

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -306,9 +306,9 @@ define(function(require) {
         },
 
         setupLogging: function() {
-            if (Adapt.course.has("_globals") && (!Adapt.course.get("_globals")._accessibility || !Adapt.course.get("_globals")._accessibility._logReading)) return;
+            if (!Adapt.config.get("_accessibility") || !Adapt.config.get("_accessibility")._logReading) return;
 
-            $($.a11y).on("reading", this.onRead);
+            $(document).on("reading", this.onRead);
         },
 
 

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -73,6 +73,8 @@ define(function(require) {
 
             this.configureA11yLibrary();
 			
+            this.touchDeviceCheck();
+			
             // Check if accessibility is active
             if (this.isActive()) {
 
@@ -244,14 +246,17 @@ define(function(require) {
             //SCREEN READER DON@T USE TABBING
             //FORCE ACCESSIBILITY ON TO RENDER NECESSARY STUFFS FOR TOUCH DEVICE SCREENREADERS
             if (!this.isEnabled()) return;
+
+            if (Modernizr.touch) {
+                 //Remove button
+                this.$accessibilityToggle.remove();
+            }
+
             if (!Modernizr.touch || this.isActive()) return;
 
             //If a touch device and not enabled, remove accessibility button and turn on accessibility
 
             this._isLoaded = true;
-
-             //Remove button
-            this.$accessibilityToggle.remove();
 
             //Force accessibility on
             Adapt.config.get('_accessibility')._isEnabled = true;

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -340,9 +340,7 @@ define(function(require) {
                 usageInstructions = instructionsList.notouch || "";
             }
 
-           this.$accessibilityInstructions
-                .one("blur", this.onFocusInstructions)
-                .html( usageInstructions );
+           this.$accessibilityInstructions.html( usageInstructions );
         },
 
         setupLogging: function() {
@@ -413,7 +411,11 @@ define(function(require) {
 
                     if (this._hasUserTabbed) return;
 	
-                    $("#accessibility-instructions").focusNoScroll();
+                    this.$accessibilityInstructions.one("blur", this.onFocusInstructions)
+	
+                    _.delay(function(){
+                        Accessibility.$accessibilityInstructions.focusNoScroll();
+                    }, 250);
 
                 } else {
 
@@ -499,7 +501,9 @@ define(function(require) {
             //HIDE INSTRUCTIONS FROM TAB WRAP AROUND AFTER LEAVING INSTRUCTIONS
             if (Accessibility._isButtonRedirectionOn) return;
             if (!Accessibility._isLoaded) return;
-            $(event.target).addClass("a11y-ignore-focus");
+            Accessibility.$accessibilityInstructions
+                .addClass("a11y-ignore-focus")
+                .off("blur", Accessibility.onFocusInstructions);
         }
 
     }, Backbone.Events);

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -201,8 +201,11 @@ define(function(require) {
             this._isLoaded = false;
             this._hasUserTabbed = false;
             //STOP DOCUMENT READING, MOVE FOCUS TO APPROPRIATE LOCATION
-            $("#a11y-focuser").focusNoScroll();
-            $.a11y_on(false, '#wrapper');
+            $("#a11y-focuser").a11y_focus(true);
+            _.defer(function() {
+                $.a11y_on(false, '.page');
+                $.a11y_on(false, '.menu');
+            });
         },
 
         onNavigationEnd: function(view) {
@@ -218,9 +221,8 @@ define(function(require) {
 
             this._isLoaded = true;
 
-            if (!this.isActive()) {
-                this.touchDeviceCheck();
-            }
+            $.a11y_on(false, '.page');
+            $.a11y_on(false, '.menu');
 
             this.configureA11yLibrary();
             $.a11y_update();
@@ -403,11 +405,13 @@ define(function(require) {
 
             var debouncedInitial = _.debounce(_.bind(function() {
                 //ENABLED DOCUMENT READING
-                $.a11y_on(true, '#wrapper');
 
                 if (!this._hasUsageInstructionRead) {
 
                     this._hasUsageInstructionRead = true;
+
+                    $.a11y_on(true, '.page');
+                    $.a11y_on(true, '.menu');
 
                     if (this._hasUserTabbed) return;
 	
@@ -419,7 +423,7 @@ define(function(require) {
 
                 } else {
 
-                    if (Adapt.location._currentId) {
+                    if (Adapt.location._currentId && $.a11y.options.OS!="mac") {
                         //required to stop JAWS from auto reading content in IE
                         var currentModel = Adapt.findById(Adapt.location._currentId);
                         var alertText = " ";
@@ -446,16 +450,21 @@ define(function(require) {
                         var windowScrollTop = $(window).scrollTop();
                         var documentScrollTop = $(document).scrollTop();
 
+                        $.a11y_on(true, '.page');
+                        $.a11y_on(true, '.menu');
+
                         //prevent auto scrolling to top when scroll has been initiated
                         if (windowScrollTop > 0 || documentScrollTop > 0 || this._hasUserTabbed) return;
 
+                        _.delay(function(){
                         $.a11y_focus();
+                        }, 500);
 
-                    }, this), 250);
+                    }, this), 500);
 
                 }
 
-            }, this), 1000);
+            }, this), 100);
             debouncedInitial();
 
         },

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -13,6 +13,7 @@ define(function(require) {
         _hasTabPosition: false,
         _hasUsageInstructionRead: false,
         _isLoaded: false,
+        _hasCourseLoaded: false,
         _legacyFocusElements: undefined,
 
         initialize: function() {
@@ -20,7 +21,14 @@ define(function(require) {
             if (this._isLoaded) return;
 
             //TRIGGER SETUP ON DATA LOADED AND TOGGLE BUTTON
-            Adapt.once('app:dataLoaded', this.setupAccessibility, Accessibility);
+            Adapt.once('app:dataLoaded', function() {
+				//check if accessibility mode should be restored
+                this._hasCourseLoaded = true;
+                Adapt.config.get("_accessibility")._isActive = Adapt.offlineStorage.get("a11y") || false;
+                this.setupAccessibility();
+                
+            }, Accessibility);
+
             Adapt.on('accessibility:toggle', this.setupAccessibility, Accessibility);
 
             //SETUP RENDERING HELPERS
@@ -43,6 +51,11 @@ define(function(require) {
 
         setupAccessibility: function() {
             //CALLED ON BUTTON CLICK AND ON DATA LOAD
+            if (!this.isEnabled()) return;
+
+            if (this._hasCourseLoaded) {
+                Adapt.offlineStorage.set("a11y", Adapt.config.get("_accessibility")._isActive);
+            }
 
             if (!this.isEnabled()) return;
 

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -62,7 +62,7 @@ define(function(require) {
             //CALLED ON BUTTON CLICK AND ON DATA LOAD
             if (!this.isEnabled()) return;
 
-            if (this._hasCourseLoaded) {
+            if (this._hasCourseLoaded && !Modernizr.touch) {
                 //save accessibility state
                 Adapt.offlineStorage.set("a11y", Adapt.config.get("_accessibility")._isActive);
             }

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -207,11 +207,20 @@ define(function(require) {
 
             this.configureA11yLibrary();
             $.a11y_update();
+            this.setNavigationBar();
 
             //MAKE FOCUS RIGHT
             this._hasTabPosition = false
             this.focusInitial();
 
+        },
+
+        setNavigationBar: function() {
+            if (this.isActive()) {
+                $(".navigation .aria-label").attr("tabindex", 0).removeAttr("aria-hidden");
+            } else {
+                $(".navigation .aria-label").attr("tabindex", -1).attr("aria-hidden", "true");
+            }
         },
 
         touchDeviceCheck: function() {

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -394,7 +394,7 @@
             var options = $.a11y.options;
             if (options.isDebug) console.log("focusOrNext", $element[0]);
 
-            $(domSelectors.focuser).focusNoScroll();
+            if (options.OS != "mac") $(domSelectors.focuser).focusNoScroll();
             $element.focusNoScroll();
 
             return this;
@@ -742,6 +742,7 @@
 
             isOn = isOn === undefined ? true : isOn;
             if (isOn) {
+                $(domSelectors.focuser).focusNoScroll();
                 this.find(domSelectors.hideableElements).filter(domFilters.globalTabIndexElementFilter).attr("aria-hidden", "true").attr("tabindex", "-1").addClass("aria-hidden");
             } else {
                 this.find(domSelectors.hideableElements).filter(domFilters.globalTabIndexElementFilter).attr("aria-hidden", "false").removeAttr("tabindex").removeClass("aria-hidden");

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -43,12 +43,12 @@
         }
         stringTrim.regex = /^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g;
 
-        function defer(func, that) {
+        function defer(func, that, t) {
             var thisHandle = that || this;
             var args = arguments;
-            setTimeout(function() {
+            return setTimeout(function() {
                 func.apply(thisHandle, args);
-            },0);
+            }, t||0);
         }
 
         function preventDefault(event) {
@@ -369,7 +369,7 @@
 
             defer(function() {
                 var options = $.a11y.options;
-                if (options.isDebug) console.log("focusNoScroll", this);
+                if (options.isDebug) console.log("focusNoScroll", this[0]);
 
                 var y = $(window).scrollTop();
                 this[0].focus();
@@ -390,7 +390,7 @@
             }
 
             var options = $.a11y.options;
-            if (options.isDebug) console.log("focusNoScroll", $element);
+            if (options.isDebug) console.log("focusOrNext", $element[0]);
 
             $(domSelectors.focuser).focusNoScroll();
             $element.focusNoScroll();
@@ -470,7 +470,7 @@
             var $element = $(event.target);
             
             state.$activeElement = $(event.currentTarget);
-            if (options.isDebug) console.log("focusCapture", $element);
+            if (options.isDebug) console.log("focusCapture", $element[0]);
         }
 
         function onFocus(event) {
@@ -479,7 +479,9 @@
 
             var $element = $(event.target);
 
-            if (options.isDebug) console.log("focus", $element);
+			a11y_triggerReadEvent($element);
+
+            if (options.isDebug) console.log("focus", $element[0]);
             
             state.$activeElement = $(event.currentTarget);
 
@@ -534,7 +536,7 @@
                 readText = label.attr("aria-label") || label.text();
             } else readText = $element.attr("aria-label") || $element.text();
 
-            $($.a11y).trigger("reading", stringTrim(readText));
+            $(document).trigger("reading", stringTrim(readText));
         }
 
         function a11y_reattachFocusGuard() {

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -893,13 +893,19 @@
             var options = $.a11y.options;
             if (!options.isAlertsEnabled) return this;
 
-            var $alert = $('<div role="alert" aria-label="'+text+'">');
+            var $alert = $('<div role="alert">'+text+'</div>');
 
             $($.a11y).trigger("reading", text);
-            $("#a11y-selected").append($alert).attr("role","alert");
-            
+            switch(options.OS) {
+            case "mac":
+                $("#a11y-selected").append($alert);
+                break;
+            default:
             $alert.css("visibility","hidden");
+                $("#a11y-selected").append($alert);
             $alert.css("visibility","visible");
+            }
+            
             setTimeout(function() {
                 $alert.remove();
             }, 20000);

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -358,7 +358,7 @@
             var isElementTopOutOfView = (elementTop < scrollTopWithTopOffset || elementTop > scrollBottomWithTopOffset);
 
             if (!isElementTopOutOfView) {
-                if ($element.is("select, input['text'], textarea") && iOS) { //ios 9.0.4 bugfix for keyboard and picker input
+                if ($element.is("select, input[type='text'], textarea") && iOS) { //ios 9.0.4 bugfix for keyboard and picker input
                     defer(function(){
                         if (options.isDebug) console.log("limitedScrollTo select fix", this.scrollToPosition);
                         $.scrollTo(this.scrollToPosition, { duration: 0 });
@@ -367,7 +367,7 @@
                 return;
             };
 
-            if ($element.is("select, input['text'], textarea") && iOS) {  //ios 9.0.4 bugfix for keyboard and picker input
+            if ($element.is("select, input[type='text'], textarea") && iOS) {  //ios 9.0.4 bugfix for keyboard and picker input
                 defer(function(){
                     if (options.isDebug) console.log("limitedScrollTo select fix", this.scrollToPosition);
                     $.scrollTo(this.scrollToPosition, { duration: 0 });
@@ -489,7 +489,7 @@
             var $element = $(event.target);
             
             if (!$element.is(domSelectors.globalTabIndexElements)) return;
-            if (iOS && $element.is("select, input['text'], textarea")) return;  //ios 9.0.4 bugfix for keyboard and picker input
+            if (iOS && $element.is("select, input[type='text'], textarea")) return;  //ios 9.0.4 bugfix for keyboard and picker input
             
             state.$activeElement = $(event.currentTarget);
             if (options.isDebug) console.log("focusCapture", $element[0]);
@@ -503,7 +503,7 @@
 
             if (!$element.is(domSelectors.globalTabIndexElements)) return;
             a11y_triggerReadEvent($element);
-            if (iOS && $element.is("select, input['text'], textarea")) return;  //ios 9.0.4 bugfix for keyboard and picker input
+            if (iOS && $element.is("select, input[type='text'], textarea")) return;  //ios 9.0.4 bugfix for keyboard and picker input
 
             if (options.isDebug) console.log("focus", $element[0]);
             
@@ -700,7 +700,7 @@
                 var $ele = $(event.target);
                 if (!$ele.is(domSelectors.globalTabIndexElements)) {
                     var $active = $.a11y.state.$activeElement;
-                    if (iOS && $active.is("select, input['text'], textarea")) return;
+                    if (iOS && $active.is("select, input[type='text'], textarea")) return;
                     defer(function() {
                         $active.focus();
                     }, $active, 500)
@@ -1147,12 +1147,16 @@
                 });
             }
 
-            if (state.$activeElement) {
-                state.$activeElement.focusOrNext();
-                state.$activeElement.limitedScrollTo();
-            } else {
-                $.a11y_focus();
-            }
+            defer(function() {
+
+                if (state.$activeElement) {
+                    state.$activeElement.focusOrNext();
+                    state.$activeElement.limitedScrollTo();
+                } else {
+                    $.a11y_focus();
+                }
+
+            }, this, 500);
 
             return this;
         };

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -547,7 +547,9 @@
                 $focusguard = $(domInjectElements.focusguard);
             }
 
-            $focusguard.remove().appendTo($('body')).attr("tabindex", 0);
+            var $currentFloor = $.a11y.state.floorStack[$.a11y.state.floorStack.length-1];
+
+            $focusguard.remove().appendTo($currentFloor).attr("tabindex", 0);
 
             $focusguard.off("click").off("focus");
 
@@ -643,6 +645,7 @@
         };
         $.a11y.state = {
             $activeElement: null,
+            floorStack: [$("body")],
             focusStack: [],
             tabIndexes: {},
             elementUIDIndex: 0,
@@ -944,6 +947,8 @@
 
             var options = $.a11y.options;
 
+            $.a11y.state.floorStack.push(this);
+
             this.a11y_only(container, true);
 
             if (this.length > 0) $(this[0]).limitedScrollTo();
@@ -964,6 +969,8 @@
         $.a11y_popdown = function() {
             var options = $.a11y.options;
             var state = $.a11y.state;
+
+            $.a11y.state.floorStack.pop();
 
             $(domSelectors.globalTabIndexElements).filter(domFilters.globalTabIndexElementFilter).each(function(index, item) {
                 var $item = $(item);

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -31,7 +31,7 @@
     // JQUERY INJECTED ELEMENTS
         var domInjectElements = {
             "focuser": '<a id="a11y-focuser" href="#" class="prevent-default a11y-ignore" tabindex="-1"></a>',
-            "focusguard": '<a id="a11y-focusguard" class="a11y-ignore a11y-ignore-focus" tabindex="0" role="button"></a>',
+            "focusguard": '<a id="a11y-focusguard" class="a11y-ignore a11y-ignore-focus" tabindex="0" role="button">&nbsp;</a>',
             "selected": '<a id="a11y-selected" href="#" class="prevent-default a11y-ignore" tabindex="-1"></a>',
             "arialabel": "<span class='aria-label prevent-default' tabindex='0' role='region'></span>"
         };

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -2,6 +2,8 @@
 
 (function($, window) {
     
+    var iOS = /iPad|iPhone|iPod/.test(navigator.platform);
+    
     // JQUERY FILTERS FOR ELEMENTS
         var domFilters = {
             "globalTabIndexElementFilter": ':not(.a11y-ignore)',
@@ -666,6 +668,8 @@
         $.a11y.ready = function() {
             var options = $.a11y.options;
 
+            if (iOS) options.OS = "mac";
+
             a11y_injectControlElements();
 
             if (options.isUserInputControlEnabled) {
@@ -690,6 +694,8 @@
         //REAPPLY ON SIGNIFICANT VIEW CHANGES
         $.a11y_update = function() {
             var options = $.a11y.options;
+
+            if (iOS) options.OS = "mac";
 
             if (options.isRemoveNotAccessiblesEnabled) {
                 a11y_removeNotAccessibles();

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -680,7 +680,6 @@
                 a11y_reattachFocusGuard();
             }
 
-            if (options.isDebug) console.log("a11y_ready");
             if (options.isDebug) {
                 console.log("a11y_ready");
                 a11y_debug();

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -937,7 +937,7 @@
         $.fn.a11y_text = function() {
             var options = $.a11y.options;
 
-            if (!options.isTabbableTextEnabled) return text;
+            if (!options.isTabbableTextEnabled) return this;
 
              for (var i = 0; i < this.length; i++) {
                 this[i].innerHTML = makeHTMLOrTextAccessible(this[i].innerHTML);

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -32,9 +32,9 @@
 
     // JQUERY INJECTED ELEMENTS
         var domInjectElements = {
-            "focuser": '<a id="a11y-focuser" href="#" class="prevent-default a11y-ignore" tabindex="-1"></a>',
+            "focuser": '<a id="a11y-focuser" href="#" class="prevent-default a11y-ignore" tabindex="-1" role="region">&nbsp;</a>',
             "focusguard": '<a id="a11y-focusguard" class="a11y-ignore a11y-ignore-focus" tabindex="0" role="button">&nbsp;</a>',
-            "selected": '<a id="a11y-selected" href="#" class="prevent-default a11y-ignore" tabindex="-1"></a>',
+            "selected": '<a id="a11y-selected" href="#" class="prevent-default a11y-ignore" tabindex="-1">&nbsp;</a>',
             "arialabel": "<span class='aria-label prevent-default' tabindex='0' role='region'></span>"
         };
 

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -479,7 +479,7 @@
 
             var $element = $(event.target);
 
-			a11y_triggerReadEvent($element);
+            a11y_triggerReadEvent($element);
 
             if (options.isDebug) console.log("focus", $element[0]);
             

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -618,6 +618,16 @@
             });
         }
 
+        function a11y_debug() {
+
+            if ($.a11y.state.isDebugApplied) return;
+
+            $.a11y.state.isDebugApplied = true;
+
+            $("body").on("focus blur click change", "*", function(event) {
+                console.log("a11y_debug", event.type, event.currentTarget);
+            });
+        }
         //TURN ON ACCESSIBILITY FEATURES
         $.a11y = function(isOn, options) {
             if ($.a11y.options.isDebug) console.log("$.a11y called", isOn, options )
@@ -671,6 +681,10 @@
             }
 
             if (options.isDebug) console.log("a11y_ready");
+            if (options.isDebug) {
+                console.log("a11y_ready");
+                a11y_debug();
+            }
 
         };
 

--- a/src/core/less/base.less
+++ b/src/core/less/base.less
@@ -247,6 +247,9 @@
 /*INVISIBLE ARIA-LABELS*/
 .aria-label {
     position:absolute !important;
+    &.relative {
+        position:relative !important;
+    }
     left:0px !important;
     width:auto !important;
     height:auto !important;
@@ -258,6 +261,7 @@
     padding:0 !important;
     margin:0 !important;
     line-height: normal !important;
+    z-index:1;
 }
 
     /*FORCE ARIA-LABELS TO HIDE ON HIDDEN*/
@@ -279,6 +283,7 @@
     padding:0 !important;
     margin:0 !important;
     line-height: normal !important;
+    z-index:1;
 
     /*IPAD: Stop accessibility cursor focusing until end of page;*/
     .touch & { 
@@ -306,6 +311,7 @@
     padding:0 !important;
     margin:0 !important;
     line-height: normal !important;
+    z-index:1;
 }
 
 /*FOCUS DISTRACTION*/
@@ -323,6 +329,7 @@
     padding:0 !important;
     margin:0 !important;
     line-height: normal !important;
+    z-index:1;
 }
 
 


### PR DESCRIPTION
https://adaptlearning.atlassian.net/browse/ABU-1039:
* If the course is closed and then relaunched there is no way to switch on accessibility mode or tab to the yes/no buttons on the bookmarking pop-up. This also affects courses if there is an initial pop-up (eg a explanatory/help pop up).  
* fixed, framework now remember accessibility state

https://adaptlearning.atlassian.net/browse/ABU-1095:
* when the pop-up opens voiceover either reads 'index htlm link' or focus is on the first hyperlink and not the 'pop-up opened' aria. Close button is not in the tabbing sequence. When the close button is selected directly and the pop-up closes focus returns to the top of the page.  
* fixed, issue with notify having moved to the top of the document before the content and the focusguard at the bottom of the document wasn't capturing the last tab properly.
the focusguard now gets injected into the appropriate 'endpoint' in the document. either in the body or in the relevant popup.

https://adaptlearning.atlassian.net/browse/ABU-1091:
* If the user tabs through the resources/PLP drawer focus moves to the elementsbehind then to the top of the page.  
* part two, fixing the focusguard to inject into the bottom of popups, or in this case, the drawer

https://adaptlearning.atlassian.net/browse/ABU-1093:
* When feedback pop-up is opened the close button is not in the tabbing sequence.  
* fixed with injecting focusguard into the bottom of the relevant popup or in the document body
