### PR TITLE
Fix to issue #792 - Added missing underscore

### DIFF
--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -19,7 +19,7 @@ define(function(require){
     Adapt.scrollTo = function(selector, settings) {
         // Get the current location - this is set in the router
         var location = (Adapt.location._contentType) ?
-            Adapt.location._contentType : Adapt.location.currentLocation;
+            Adapt.location._contentType : Adapt.location._currentLocation;
         // Trigger initial scrollTo event
         Adapt.trigger(location+':scrollTo', selector);
         //Setup duration variable passed upon arguments


### PR DESCRIPTION
It should be Adapt.location._currentLocation as it is used e.g. in router.js