### PR TITLE
bugfix/inview

### DIFF
--- a/src/core/js/libraries/inview.js
+++ b/src/core/js/libraries/inview.js
@@ -2,6 +2,7 @@
 
 (function() {
 	var expando = $.expando;
+	var expandoIndex = 0;
 
 	//element + event handler storage
 	var onScreenObjs = {};
@@ -15,6 +16,7 @@
 	//jQuery element + event handler attachment / removal
 	$.event.special.onscreen = {
 		add: function(data) {
+			checkExpando(this);
 			onScreenObjs[data.guid + "-" + this[expando]] = { 
 				data: data, 
 				$element: $(this) 
@@ -31,6 +33,7 @@
   	};
 	$.event.special.inview = {
 		add: function(data) {
+			checkExpando(this);
 			inViewObjs[data.guid + "-" + this[expando]] = {
 				data: data, 
 				$element: $(this) 
@@ -46,6 +49,9 @@
 		}
   	};
 
+	function checkExpando(element) {
+		if (!element[expando]) element[expando] = ++expandoIndex;
+  	}
 
   	function getElementOnScreenMeasurements($element) {
   		if ($element.length === 0) return;


### PR DESCRIPTION
Sometimes expando properties don't work well and so to uniquely identify each element it is necessary to give it a unique expando parameter.

Without this fix, bindings on multiple elements with the same callback function won't work. They'll callback once and only on the last element attached.