### PR TITLE
hotfix/router: missing break and navigateToElement fix

### DIFF
--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -89,7 +89,9 @@ define([
             })
         });
 
-        Backbone.history.navigate('#/id/' + currentPage.get('_id'), {trigger: true});
+        var shouldReplaceRoute = settings.replace || false;
+
+        Backbone.history.navigate('#/id/' + currentPage.get('_id'), {trigger: true, replace: shouldReplaceRoute});
     }
 
     Adapt.register = function(name, object) {

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -132,7 +132,7 @@ define([
                 default:
                     //allow navigation
                     Adapt.router.set('_canNavigate', true, {pluginName: "adapt"});
-                    Adapt.navigateToElement('.' + id);
+                    Adapt.navigateToElement('.' + id, {replace:true});
             }
         },
 

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -164,6 +164,7 @@ define([
                 } else {
                     this.navigate("#/"+args[0], {trigger:false, replace:false});
                 }
+                break;
             case 2:
                 this.navigate("#/"+args[0]+"/"+args[1], {trigger:false, replace:false});
                 break;


### PR DESCRIPTION
1. Add missing ``break;``
2. When using an article/block/component id to navigate, should replace route with content object id. This is to preserve the history of the back button.