### PR TITLE
amend to slider in c-80

### DIFF
--- a/src/course/en/components.json
+++ b/src/course/en/components.json
@@ -569,11 +569,7 @@
 		"instruction": "Drag the slider to make your choice and select Submit.",
 		"labelStart": "",
 		"labelEnd": "",
-		"_correctAnswer": "",
-		"_correctRange": {
-			"_bottom": 7,
-			"_top": 7
-		},
+		"_correctAnswer": "7",
 		"_feedback": {
 			"correct": "Correct answer feedback.<br><br>Yes, that’s right. According to Miller’s paper 7 +/- 2 chunks of information was the limited capacity of working memory. Various theories from the field of cognitive psychology such as Miller’s <a href='http://en.wikipedia.org/wiki/The_Magical_Number_Seven,_Plus_or_Minus_Two' target='_blank'>magical number</a>, <a href='http://en.wikipedia.org/wiki/Chunking_%28psychology%29#Chunking_as_the_learning_of_long-term_memory_structures' target='_blank'>chunking</a>, <a href='http://en.wikipedia.org/wiki/Forgetting_curve' target='_blank'>the forgetting curve</a> and <a href='http://en.wikipedia.org/wiki/Spaced_repetition' target='_blank'>spaced repetition</a> have all influenced learning theory over the last 50 years or so.<br><br><em>Component facts: The correct answer for a slider component can be an exact number or a range. In this instance the answer was set as 7 however we could have set the range as 5-9 as the correct option due to the correct answer being seven plus or minus two. Component is either single or spanned.</em>",
 			"_incorrect": {


### PR DESCRIPTION
Since the correct answer is a single number and not a range, it is confusing to specify it using the `_correctRange` property (even though it does work). Therefore am changing this to the more appropriate `_correctAnswer` property.