### PR TITLE
bugfix/ABU-1132: Remove CORS <=IE9

### DIFF
--- a/src/core/js/scriptLoader.js
+++ b/src/core/js/scriptLoader.js
@@ -22,9 +22,16 @@
 
     //3. Load adapt
     function loadAdapt() {
-        $.ajaxPrefilter(function( options ) {
-            options.crossDomain = true;
-        });
+        switch (IE) {
+        case 8: case 9:
+            //ie8 and ie9 don't do crossdomain with jquery normally
+            break;
+        default:
+            //cross domain support for all other browers
+            $.ajaxPrefilter(function( options ) {
+                options.crossDomain = true;
+            });
+        }
         Modernizr.load("adapt/js/adapt.min.js");
     }
 


### PR DESCRIPTION
jquery doesn't support cors in ie8/ie9 like this and stops all json loading.
removed support for ie8+ie9