### PR TITLE
hotfix/ABU-1133: general accessibility fixes

### DIFF
--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -238,7 +238,7 @@ define(function(require) {
 
         setNavigationBar: function() {
             if (this.isActive()) {
-                $(".navigation .aria-label").attr("tabindex", 0).removeAttr("aria-hidden");
+                $(".navigation .aria-label").attr("tabindex", 0).removeAttr("aria-hidden").removeClass("a11y-ignore");
             } else {
                 $(".navigation .aria-label").attr("tabindex", -1).attr("aria-hidden", "true");
             }


### PR DESCRIPTION
* redirect onFocusCapture of focused elements from proxy elements (label) or overlay elements (divs/span) to their correct tabbable element (input, button, a, etc)
* fix focusOrNext behaviour so that it finds the next focusable element in the entire document, not just the immediate next siblings
* allow elements to signal that they aren't effected by scrolling .focus (i.e. absolutely positioned to a fixed html tag)
* ignore errors if the element gaining focused is out-of-view (ie8, invalid error/warning)
* move some of the behaviour from a11y_iosFalseClickFix to onFocusCapture to lessen the need for the fix, make the fix specific and to make onFocusCapture more robust
* make sure popdown forces return to previous element
* make sure navigation aria label is visible when required
