### PR TITLE
hotfix/accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## [Unreleased][unreleased]
 - Nothing!
 
+## [2.0.8] - 2015-12-04
+### Headline changes
+- accessibility hotfix, remove iOS select fix
+- accessibility hotfix, improved onFocusCapture to find next focusable component if cannot find any other.
+
 ## [2.0.7] - 2015-12-03
 ### Headline changes
 - accessibility hotfix, missing variable declararation ios
@@ -230,7 +235,8 @@ The initial version of the Adapt framework.
 - Everything!
 
 
-[unreleased]: https://github.com/adaptlearning/adapt_framework/compare/v2.0.7...HEAD
+[unreleased]: https://github.com/adaptlearning/adapt_framework/compare/v2.0.8...HEAD
+[2.0.7]: https://github.com/adaptlearning/adapt_framework/compare/v2.0.7...v2.0.8
 [2.0.7]: https://github.com/adaptlearning/adapt_framework/compare/v2.0.6...v2.0.7
 [2.0.6]: https://github.com/adaptlearning/adapt_framework/compare/v2.0.5...v2.0.6
 [2.0.5]: https://github.com/adaptlearning/adapt_framework/compare/v2.0.4...v2.0.5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt_framework",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Adapt Learning output framework",
   "repository": {
     "type": "git",

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -401,7 +401,7 @@
             return this; //chainability
         };
 
-        $.fn.focusOrNext = function() {
+        $.fn.focusOrNext = function(returnOnly) {
             if (this.length === 0) return this;
 
             var $element = $(this[0]);
@@ -440,9 +440,11 @@
 
             var options = $.a11y.options;
             if (options.isDebug) console.log("focusOrNext", $element[0]);
-
-            if (options.OS != "mac") $(domSelectors.focuser).focusNoScroll();
-            $element.focusNoScroll();
+            
+            if (returnOnly !== true) {
+                if (options.OS != "mac") $(domSelectors.focuser).focusNoScroll();
+                $element.focusNoScroll();
+            }
 
             //return element focused
             return $element;
@@ -529,14 +531,20 @@
                     var $proxyElements = $parents.filter("[for]");
 
                     //if no proxy elements, ignore
-                    if ($proxyElements.length === 0) return;
-
-                    //isolate proxy element by id
-                    var $proxyElement = $("#"+$proxyElements.attr("for"));
-                    if (!$proxyElement.is(domSelectors.globalTabIndexElements)) return;
-                    
-                    //use tabbable proxy
-                    $element = $proxyElement;
+                    if ($proxyElements.length === 0) {
+                        //find next focusable element if no proxy element found
+                        $element = $element.focusOrNext(true);
+                    } else {
+                        //isolate proxy element by id
+                        var $proxyElement = $("#"+$proxyElements.attr("for"));
+                        if (!$proxyElement.is(domSelectors.globalTabIndexElements)) {
+                            //find next focusable element if no tabbable element found
+                            $element = $element.focusOrNext(true);
+                        } else {
+                            //use tabbable proxy
+                            $element = $proxyElement;
+                        }
+                    }
                 } else {
                     
                     //use tabbable parent

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -968,7 +968,7 @@
 
     //MAKE SELECTED
 
-        $.fn.a11y_selected = function(isOn) {
+        $.fn.a11y_selected = function(isOn, noFocus) {
             if (this.length === 0) return this;
 
             var options = $.a11y.options;
@@ -980,15 +980,15 @@
                 switch ($.a11y.options.OS) {
                 case "mac":
                     //ANNOUNCES SELECTION ON A MAC BY ADDING A SPAN AND SHIFTING FOCUS
-                    $("#a11y-selected").focusNoScroll();
+                    if (noFocus !== true) $("#a11y-selected").focusNoScroll();
                     _.delay(function() {
                         selected.prepend($("<span class='a11y-selected aria-label'>selected </span>"))
-                        $(selected).focusNoScroll();
+                        if (noFocus !== true) $(selected).focusNoScroll();
                     },250);
                     break;
                 default:
                     //ANOUNCES THE SELECTION ON TABLETS AND PCS
-                    $.a11y_alert("selected " + selected.text());
+                    if (noFocus !== true) $.a11y_alert("selected " + selected.text());
                     selected.attr( "aria-label", "selected " + selected.text()).addClass("a11y-selected");
                     break;
                 }

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -552,8 +552,6 @@
                 }
             }
 
-            if (iOS && $element.is("select, input[type='text'], textarea")) return;  //ios 9.0.4 bugfix for keyboard and picker input
-            
             state.$activeElement = $(event.currentTarget);
             if (options.isDebug) console.log("focusCapture", $element[0]);
         }
@@ -566,7 +564,6 @@
 
             if (!$element.is(domSelectors.globalTabIndexElements)) return;
             a11y_triggerReadEvent($element);
-            if (iOS && $element.is("select, input[type='text'], textarea")) return;  //ios 9.0.4 bugfix for keyboard and picker input
 
             if (options.isDebug) console.log("focus", $element[0]);
             
@@ -705,57 +702,6 @@
             });
         }
 
-        function a11y_iosSelectFix() { //ios 9.0.4 bugfix for voiceover + keyboard and picker input
-            var scrollPosition = 0;
-
-            function onOpen(event) {
-                scrollPosition = $(window).scrollTop();
-                var $ele = $(event.currentTarget);
-                $ele.one("focusout", blockFocus);
-                hideUp($ele);
-            }
-
-            function hideUp($element) {
-                var $toHide = $(domSelectors.focusableElements);
-                $toHide = $toHide.not($element);
-                $toHide.each(function(index,item) {
-                    var $item = $(item);
-                    item._hideUpPrev = $(item).attr("aria-hidden");
-                    $(item).attr("aria-hidden", true);
-                });
-            }
-            function hideDown($element) {
-                var $toShow = $(domSelectors.focusableElements);
-                $toShow = $toShow.not($element);
-                $toShow.each(function(index,item) {
-                    var $item = $(item);
-                    if (item._hideUpPrev == undefined) {
-                        $(item).removeAttr("aria-hidden");  
-                    } else {
-                        $(item).attr("aria-hidden",item._hideUpPrev);
-                    }
-                    item._hideUpPrev = undefined;
-                });
-            }
-
-            function blockFocus(event) {
-                event.preventDefault();
-                event.stopImmediatePropagation();
-                event.stopPropagation();
-                var $ele = $(event.currentTarget);
-                defer(function() {
-                    this.off("focusout", blockFocus);
-                    this.focus();
-                    defer(function() {
-                        $.scrollTo(scrollPosition, {duration:0});
-                        hideDown(this);
-                    }, this, 1000);
-                }, $ele, 500);
-            }
-
-            $("body").on("click", "select, input[type='text'], textarea", onOpen);
-        }
-
         function a11y_iosFalseClickFix() {  //ios 9.0.4 bugfix for invalid clicks on input overlays
             //with voiceover on, ios will allow clicks on :before and :after content text. this causes the first tabbable element to recieve focus
             //redirect focus back to last item in this instance
@@ -769,8 +715,6 @@
 
                 var $active = $.a11y.state.$activeElement;
                 if (!$active.is(domSelectors.globalTabIndexElements)) return;
-
-                if (iOS && $active.is("select, input[type='text'], textarea")) return;
 
                 if (options.isDebug) console.log("a11y_iosFalseClickFix", $active[0]);
 
@@ -789,7 +733,6 @@
             if ($.a11y.state.isIOSFixesApplied) return;
 
             $.a11y.state.isIOSFixesApplied = true;
-            a11y_iosSelectFix();
             a11y_iosFalseClickFix();
 
         }

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -552,7 +552,7 @@
                 }
             }
 
-            state.$activeElement = $(event.currentTarget);
+            state.$activeElement = $element;
             if (options.isDebug) console.log("focusCapture", $element[0]);
         }
 


### PR DESCRIPTION
- removed ios select fix as it causes more issues that it fixes
- improved onFocusCapture to capture the next tabbable element if the current focus target is not tabbable, has no tabbable parents and is not a proxy for another element 