### PR TITLE
bugfix/imageReady: fixed background image checks

### DIFF
--- a/src/core/js/libraries/imageReady.js
+++ b/src/core/js/libraries/imageReady.js
@@ -5,7 +5,7 @@
 	if ($.fn.imageready) return;
 	
 	var stripCSSURL = /url\(([^)]*)\)/g;
-	var stripCSSHyphens = /[\"\']/g;
+	var stripCSSQuotes = /[\"\']/g;
 
 	$.fn.imageready = function(callback, options) {
 		//setup options
@@ -29,7 +29,7 @@
 				var matches = stripCSSURL.exec(backgroundImageValue);
 				if (matches === null) return;
 				var url = matches[1];
-				url = url.replace(stripCSSHyphens, "");
+				url = url.replace(stripCSSQuotes, "");
 				$backgroundImage.attr("src", url);
 				$images.add($backgroundImage);
 				$images = $images.add($backgroundImage);

--- a/src/core/js/libraries/imageReady.js
+++ b/src/core/js/libraries/imageReady.js
@@ -5,6 +5,7 @@
 	if ($.fn.imageready) return;
 	
 	var stripCSSURL = /url\(([^)]*)\)/g;
+	var stripCSSHyphens = /[\"\']/g;
 
 	$.fn.imageready = function(callback, options) {
 		//setup options
@@ -28,8 +29,11 @@
 				var matches = stripCSSURL.exec(backgroundImageValue);
 				if (matches === null) return;
 				var url = matches[1];
+				url = url.replace(stripCSSHyphens, "");
 				$backgroundImage.attr("src", url);
 				$images.add($backgroundImage);
+				$images = $images.add($backgroundImage);
+				$images.loaded = 0;
 			});
 		});
 


### PR DESCRIPTION
- correctly added background image checks to the $images array
- fix firefox css absolute urls by removing the " or ' from the outside of the url declaration url("absolute")