### PR TITLE
enhancement/925: allow component specific & standard question models

### DIFF
--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -110,6 +110,7 @@ define([
         
         Adapt.componentStore[name] = object;
 
+        return object;
     }
 
     // Used to map ids to collections

--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -99,7 +99,15 @@ define([
         // Store the component view
         if (Adapt.componentStore[name])
             throw Error('This component already exists in your project');
-        if(!object.template) object.template = name;
+
+        if (object.view) {
+            //use view+model object
+            if(!object.view.template) object.view.template = name;
+        } else {
+            //use view object
+            if(!object.template) object.template = name;
+        }
+        
         Adapt.componentStore[name] = object;
 
     }

--- a/src/core/js/app.js
+++ b/src/core/js/app.js
@@ -14,6 +14,7 @@ require([
     'coreModels/articleModel',
     'coreModels/blockModel',
     'coreModels/componentModel',
+    'coreModels/questionModel',
     'coreJS/offlineStorage',
     'coreModels/lockingModel',
     'velocity',
@@ -27,7 +28,7 @@ require([
     'extensions/extensions',
     'menu/menu',
     'theme/theme'
-], function (Adapt, Router, Drawer, Device, PopupManager, Notify, Accessibility, NavigationView, AdaptCollection, ConfigModel, CourseModel, ContentObjectModel, ArticleModel, BlockModel, ComponentModel) {
+], function (Adapt, Router, Drawer, Device, PopupManager, Notify, Accessibility, NavigationView, AdaptCollection, ConfigModel, CourseModel, ContentObjectModel, ArticleModel, BlockModel, ComponentModel, QuestionModel) {
 
     // Append loading template and show
     window.Handlebars = _.extend(require("handlebars"), window.Handlebars)
@@ -138,7 +139,25 @@ require([
         });
 
         Adapt.components = new AdaptCollection(null, {
-            model: ComponentModel,
+            model: function(json) {
+
+                //use view+model object
+                var ViewModelObject = Adapt.componentStore[json._component];
+
+                //if model defined for component use component model
+                if (ViewModelObject.model) {
+                    return new ViewModelObject.model(json);
+                }
+
+                var View = ViewModelObject.view || ViewModelObject;
+                //if question type use question model
+                if (View._isQuestionType) {
+                    return new QuestionModel(json);
+                }
+
+                //otherwise use component model
+                return new ComponentModel(json);
+            },
             url: courseFolder + "components.json"
         });
     }

--- a/src/core/js/models/componentModel.js
+++ b/src/core/js/models/componentModel.js
@@ -1,37 +1,9 @@
-define(function(require) {
-
-    var Adapt = require('coreJS/adapt');
-	var AdaptModel = require('coreModels/adaptModel');
+define([
+    'coreJS/adapt',
+    'coreModels/adaptModel'
+], function(Adapt, AdaptModel) {
 
     var ComponentModel = AdaptModel.extend({
-    	init: function() {
-    		// Setup _isQuestionType on question components
-    		var componentType = this.get('_component');
-            if (Adapt.componentStore[componentType]) {
-        		if (Adapt.componentStore[componentType]._isQuestionType) {
-        			this.set('_isQuestionType', true);
-        		}
-            }
-    	},
-
-        reset: function(type, force) {
-            if (!this.get("_canReset") && !force) return;
-
-            type = type || true;
-
-            AdaptModel.prototype.reset.call(this, type, force);
-
-            if (this.get("_isQuestionType")) {
-                var attempts = this.get('_attempts');
-                this.set({
-                    _attemptsLeft: attempts,
-                    _isCorrect: undefined,
-                    _isSubmitted: false,
-                    _buttonState: 'submit'
-                });
-            }
-        },
-
         _parent:'blocks',
     	_siblings:'components'
     });

--- a/src/core/js/models/questionModel.js
+++ b/src/core/js/models/questionModel.js
@@ -1,0 +1,34 @@
+define([
+    'coreJS/adapt',
+    'coreModels/componentModel'
+], function(Adapt, ComponentModel) {
+
+    var QuestionModel = ComponentModel.extend({
+
+    	defaults: function() {
+            return _.extend({
+                '_isQuestionType': true
+            }, ComponentModel.prototype.defaults);
+        },
+
+        reset: function(type, force) {
+            if (!this.get("_canReset") && !force) return;
+
+            type = type || true;
+
+            AdaptModel.prototype.reset.call(this, type, force);
+
+            var attempts = this.get('_attempts');
+            this.set({
+                _attemptsLeft: attempts,
+                _isCorrect: undefined,
+                _isSubmitted: false,
+                _buttonState: 'submit'
+            });
+        }
+
+    });
+
+    return QuestionModel;
+
+});

--- a/src/core/js/models/questionModel.js
+++ b/src/core/js/models/questionModel.js
@@ -5,7 +5,7 @@ define([
 
     var QuestionModel = ComponentModel.extend({
 
-    	defaults: function() {
+        defaults: function() {
             return _.extend({
                 '_isQuestionType': true
             }, ComponentModel.prototype.defaults);
@@ -16,7 +16,7 @@ define([
 
             type = type || true;
 
-            AdaptModel.prototype.reset.call(this, type, force);
+            ComponentModel.prototype.reset.call(this, type, force);
 
             var attempts = this.get('_attempts');
             this.set({

--- a/src/core/js/views/adaptView.js
+++ b/src/core/js/views/adaptView.js
@@ -1,8 +1,6 @@
-define(function(require) {
-
-    var Backbone = require('backbone');
-    var Handlebars = require('handlebars');
-    var Adapt = require('coreJS/adapt');
+define([
+    'coreJS/adapt'
+], function(Adapt) {
 
     var AdaptView = Backbone.View.extend({
 
@@ -49,7 +47,14 @@ define(function(require) {
                 if (model.get('_isAvailable')) {
                     nthChild ++;
 
-                    var ChildView = this.constructor.childView || Adapt.componentStore[model.get("_component")];
+                    var ChildView;
+                    var ViewModelObject = this.constructor.childView || Adapt.componentStore[model.get("_component")];
+
+                    //use view+model object
+                    if (ViewModelObject.view) ChildView = ViewModelObject.view;
+                    //use view only object
+                    else ChildView = ViewModelObject;
+
                     if (ChildView) {
                         var $parentContainer = this.$(this.constructor.childContainer);
                         model.set("_nthChild", nthChild);


### PR DESCRIPTION
#925 

* added questionModel
* moved questionModel code out of componentModel into questionModel
* added code to optionally allow components to register their own model through the ``Adapt.register`` interface.
```
Adapt.register("name", { view: View, model: Model }); //new style
Adapt.register("name", View); //old style - still works fine
```
* changed component model creation to use a component specified model (if available), the questionModel or the componentModel where required (which, as a plus, means any view-only question components will automatically use the questionModel and need no reworking for this PR to fit)
* reworked require statements to AMD style

should be entirely unobtrusive

task following this:
* move questionView model code into questionModel
* provide backwards compatibility layer in questionView to redirect older components to the moved questionModel code
* split all core components into a model and view where relevant

pros:
* all models represent the data and behaviour of their component model (rather than just the data as it is at the moment)
* views no longer contain model initialization or model only code
* score calculation functions are present on unrendered component models and allow extensions to act upon the models without having to first render them into a view
* smaller views = less complex code
* correct partitioning = higher clarity 
* closer to the MVC style = easier for programmers to grasp
* framework will continue to support View only style alongside View+Model style (until we decide to get rid of it)
* if we transition from backbone to another framework having a good mvc aligned implementation will help porting

cons:
* View+Model components will not work in earlier versions of the framework which don't support it, means potential issues with AT framework vs plugin versions
