### PR TITLE
enhancement/929: remove core require mappings "coreJS" "coreViews"

### DIFF
--- a/config.js
+++ b/config.js
@@ -10,11 +10,6 @@ require.config({
         inview: 'core/js/libraries/inview',
         a11y: 'core/js/libraries/jquery.a11y',
         scrollTo: 'core/js/libraries/scrollTo',
-        coreJS: 'core/js',
-        coreViews: 'core/js/views',
-        coreModels: 'core/js/models',
-        coreCollections: 'core/js/collections',
-        coreHelpers: 'core/js/helpers',
         templates: 'templates/templates'
     },
     shim: {
@@ -65,5 +60,14 @@ require.config({
     ],
     exclude: [
         'jquery'
-    ]
+    ],
+    map: {
+        '*': {
+            coreJS: 'core/js',
+            coreViews: 'core/js/views',
+            coreModels: 'core/js/models',
+            coreCollections: 'core/js/collections',
+            coreHelpers: 'core/js/helpers'
+        }
+    }
 });

--- a/src/core/js/scriptLoader.js
+++ b/src/core/js/scriptLoader.js
@@ -7,8 +7,24 @@
         }
         return false;
     })();
+    
+    //2. Setup require for old style module declarations
+    function setupRequireJS() {
+        requirejs.config({
+            map: {
+                '*': {
+                    coreJS: 'core/js',
+                    coreViews: 'core/js/views',
+                    coreModels: 'core/js/models',
+                    coreCollections: 'core/js/collections',
+                    coreHelpers: 'core/js/helpers'
+                }
+            }
+        });
+        loadJQuery();
+    }
 
-    //2. Load jquery
+    //3. Load jquery
     function loadJQuery() {
         Modernizr.load([
             {
@@ -20,7 +36,7 @@
         ]);
     }
 
-    //3. Load adapt
+    //4. Load adapt
     function loadAdapt() {
         switch (IE) {
         case 8: case 9:
@@ -47,7 +63,7 @@
         },
         {
             load: "libraries/require.js",
-            complete: loadJQuery
+            complete: setupRequireJS
         }
     ]);
 


### PR DESCRIPTION
* removed explicit conversion of module declarations to "coreJS" style from "core/js" (+models, views etc)
* remapped current require("coreJS/adapt) style to "core/js/adapt" in grunt
* remapped current require("coreJS/adapt) style to "core/js/adapt" in browser

#929

actions to follow:
* convert all old require declarations from "coreJS" style to new "core/js/" style
* new new grunt requirejs task needs to be compatible with this style

should be unobtrusive as the old style can be remapped to the new style until we've converted everything.