### PR TITLE
Added a replace task to the end of grunt server-build

### DIFF
--- a/grunt/config/replace.js
+++ b/grunt/config/replace.js
@@ -1,0 +1,33 @@
+module.exports = function (grunt, options) {
+
+  var courseDir = options.sourcedir + 'course/';
+  if (options.outputdir.indexOf('courses')) {
+    courseDir = options.outputdir + 'course/';
+  }
+
+  var configJson = grunt.file.readJSON(courseDir + 'config.json');
+  var defaultLanguage = configJson._defaultLanguage || 'en'
+  var pathToCourseJson = courseDir + defaultLanguage + '/course.json';
+  var courseJSON = grunt.file.readJSON(pathToCourseJson);
+  
+  return {
+    dist: {
+      options: {
+        patterns: [
+          {
+            json: courseJSON
+          }
+        ]
+      },
+      files: [
+        {
+          expand: true,
+          flatten: true,
+          src: [options.outputdir + '*.xml'],
+          dest: options.outputdir
+        }
+      ]
+    }
+  }
+
+}

--- a/grunt/tasks/build.js
+++ b/grunt/tasks/build.js
@@ -13,6 +13,7 @@ module.exports = function(grunt) {
         'schema-defaults',
         'tracking-insert',
         'javascript:compile',
-        'clean:dist'
+        'clean:dist',
+        'replace'
     ]);
 }

--- a/grunt/tasks/dev.js
+++ b/grunt/tasks/dev.js
@@ -12,6 +12,7 @@ module.exports = function(grunt) {
         'schema-defaults',
         'tracking-insert',
         'javascript:dev',
-        'watch'
+        'watch',
+        'replace'
     ]);
 }

--- a/grunt/tasks/server-build.js
+++ b/grunt/tasks/server-build.js
@@ -10,7 +10,8 @@ module.exports = function(grunt) {
             'copy',
             'less:' + requireMode,
             'handlebars',
-            'javascript:' + requireMode
+            'javascript:' + requireMode,
+            'replace'
         ]);
     });
 }

--- a/package.json
+++ b/package.json
@@ -138,13 +138,14 @@
     "grunt-jscs": "^2.6.0",
     "grunt-jsonlint": "~1.0.4",
     "grunt-open": "~0.2.3",
+    "grunt-replace": "^0.11.0",
     "jit-grunt": "^0.9.1",
     "jshint-stylish": "^2.1.0",
     "less": "^2.5.3",
     "load-grunt-config": "^0.17.2",
-    "underscore": "~1.6.0",
-    "underscore-deep-extend": "0.0.5",
     "requirejs": "^2.1.22",
-    "time-grunt": "^1.2.1"
+    "time-grunt": "^1.2.1",
+    "underscore": "~1.6.0",
+    "underscore-deep-extend": "0.0.5"
   }
 }


### PR DESCRIPTION
Added a grunt config task called replace.

This makes use of [grunt-replace](https://www.npmjs.com/package/grunt-replace) npm library.

The task will replace any strings in xml files (prefixed with `@@`) with matching properties found in the course.json file.