### PR TITLE
Resolves #961, adds check on _canNavigate to navigateToParent()

### DIFF
--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -213,10 +213,12 @@ define([
             }
         },
 
-        navigateToParent: function() {
-            var parentId = Adapt.contentObjects.findWhere({_id:Adapt.location._currentId}).get("_parentId");
-            var route = (parentId === Adapt.course.get("_id")) ? "#/" : "#/id/" + parentId;
-            this.navigate(route, { trigger: true });
+        navigateToParent: function(force) {
+            if (Adapt.router.get('_canNavigate') || force) {
+                var parentId = Adapt.contentObjects.findWhere({_id:Adapt.location._currentId}).get("_parentId");
+                var route = (parentId === Adapt.course.get("_id")) ? "#/" : "#/id/" + parentId;
+                this.navigate(route, { trigger: true });  
+            }
         },
 
         setContentObjectToVisited: function(model) {


### PR DESCRIPTION
This makes it consistent with the other navigation functions.