### PR TITLE
Added support for string substitution in XML files

### DIFF
--- a/grunt/config/replace.js
+++ b/grunt/config/replace.js
@@ -1,0 +1,56 @@
+module.exports = function (grunt, options) {
+
+  var courseDir = options.sourcedir + 'course/';
+
+  if (options.outputdir.indexOf('build/') > -1) {
+    courseDir = options.outputdir + 'course/';
+  }
+
+  var configJson = grunt.file.readJSON(courseDir + 'config.json');
+  var defaultLanguage = configJson._defaultLanguage || 'en';
+  var courseJson = grunt.file.readJSON(courseDir + defaultLanguage + '/course.json');
+
+  // Backwards compatibility for courses missing 'description'
+  if (!courseJson.hasOwnProperty('description')) {
+    courseJson.description = '';
+  }
+
+  // A shim for edge cases where xAPI has not been configured.
+  if (!configJson.hasOwnProperty('_xapi')) {
+    configJson._xapi = {
+      'activityID': '',
+      '_isEnabled': false
+    };
+  } else {
+    // xAPI has been enabled, check if the activityID has been set.
+    if (configJson._xapi.hasOwnProperty('activityID') && configJson._xapi.activityID == '') {
+      grunt.log.writeln('WARNING: xAPI activityID has not been set');
+    }
+  }
+
+  // Combine the course and config JSON so both can be passet to replace.  
+  var json = {
+    'course': courseJson,
+    'config': configJson
+  };
+
+  return {
+    dist: {
+      options: {
+        patterns: [
+          {
+            json: json
+          }
+        ]
+      },
+      files: [
+        {
+          expand: true,
+          flatten: true,
+          src: [options.outputdir + '*.xml'],
+          dest: options.outputdir
+        }
+      ]
+    }
+  }
+}

--- a/grunt/config/replace.js
+++ b/grunt/config/replace.js
@@ -28,7 +28,7 @@ module.exports = function (grunt, options) {
     }
   }
 
-  // Combine the course and config JSON so both can be passet to replace.  
+  // Combine the course and config JSON so both can be passed to replace.  
   var json = {
     'course': courseJson,
     'config': configJson

--- a/grunt/tasks/build.js
+++ b/grunt/tasks/build.js
@@ -13,6 +13,7 @@ module.exports = function(grunt) {
         'schema-defaults',
         'tracking-insert',
         'javascript:compile',
-        'clean:dist'
+        'clean:dist',
+        'replace'
     ]);
 }

--- a/grunt/tasks/dev.js
+++ b/grunt/tasks/dev.js
@@ -12,6 +12,7 @@ module.exports = function(grunt) {
         'schema-defaults',
         'tracking-insert',
         'javascript:dev',
+        'replace',
         'watch'
     ]);
 }

--- a/grunt/tasks/server-build.js
+++ b/grunt/tasks/server-build.js
@@ -10,7 +10,8 @@ module.exports = function(grunt) {
             'copy',
             'less:' + requireMode,
             'handlebars',
-            'javascript:' + requireMode
+            'javascript:' + requireMode,
+            'replace'
         ]);
     });
 }

--- a/package.json
+++ b/package.json
@@ -138,13 +138,14 @@
     "grunt-jscs": "^2.6.0",
     "grunt-jsonlint": "~1.0.4",
     "grunt-open": "~0.2.3",
+    "grunt-replace": "^0.11.0",
     "jit-grunt": "^0.9.1",
     "jshint-stylish": "^2.1.0",
     "less": "^2.5.3",
     "load-grunt-config": "^0.17.2",
-    "underscore": "~1.6.0",
-    "underscore-deep-extend": "0.0.5",
     "requirejs": "^2.1.22",
-    "time-grunt": "^1.2.1"
+    "time-grunt": "^1.2.1",
+    "underscore": "~1.6.0",
+    "underscore-deep-extend": "0.0.5"
   }
 }

--- a/src/course/en/course.json
+++ b/src/course/en/course.json
@@ -3,6 +3,7 @@
     "_type": "course",
     "title": "Adapt Version 2.0 demonstration",
     "displayTitle": "Adapt Version 2.0 demonstration",
+    "description": "A sample course demonstrating the capabilities of the Adapt Version 2.0",
     "body": "Welcome to the demonstration build for Version 2.0 of the Adapt framework.<br><br>We’ve added some major new items of functionality to Adapt for this release, most notably accessibility to WAI level AA, Right to Left language support and greatly improved assessments. If you’d like to find out more about this, along with the the other improvements we’ve made then please read the release notes (Link to follow for demo).               ",
     "_buttons": {
         "_submit": {


### PR DESCRIPTION
This is required to support upcoming work on the xAPI plugin but will also work with a slightly modified Spoor plugin.  The placeholder format is: @@property.

Right now properties from config.json and course.json are supported.

Squashed commit messages:
- Added replace task to build.js and dev.js
- Added support for passing both course and config to replace call
- Added 'description' to course.json.  This attribute is useful for the SCORM and xAPI extensions.
- Added shim for missing xAPI property. This is to cover edge cases where the xAPI extension may be defined but its configuration may be incomplete.
- Added a warning mesage for when xAPI activityID has not been set.  The course will not confirm to the spec if this has been left empty.