### PR TITLE
issue/917

### DIFF
--- a/grunt/config/connect.js
+++ b/grunt/config/connect.js
@@ -1,16 +1,21 @@
-module.exports = {
+module.exports = function (grunt, options) {
+
+  var port = grunt.option('port') || 9001;
+
+  return {
     server: {
       options: {
-        port: 9001,
+        port: port,
         base: '<%= outputdir %>',
         keepalive:true
       }
     },
     spoorOffline: {
-        options: {
-            port: 9001,
-            base: '<%= outputdir %>',
-            keepalive:true
-        }
+      options: {
+        port: port,
+        base: '<%= outputdir %>',
+        keepalive:true
+      }
     }
+  }
 }

--- a/grunt/config/open.js
+++ b/grunt/config/open.js
@@ -1,8 +1,14 @@
-module.exports = {
+module.exports = function (grunt, options) {
+
+  var host = grunt.option('host') || "localhost";
+
+  return {
     server: {
-        path: 'http://localhost:<%= connect.server.options.port %>/'
+      path: 'http://'+host+':<%= connect.server.options.port %>/'
     },
     spoor: {
-        path: 'http://localhost:<%= connect.server.options.port %>/scorm_test_harness.html'
+      path: 'http://'+host+':<%= connect.server.options.port %>/scorm_test_harness.html'
     }
+  }
+
 }

--- a/grunt/helpers.js
+++ b/grunt/helpers.js
@@ -106,7 +106,7 @@ module.exports = function(grunt) {
                     if (!fs.statSync(folderPath).isDirectory()) continue;
 
                     var bowerJson = require(path.join(folderPath, 'bower.json'));
-                    
+
                     for (var key in bowerJson.dependencies) {
                         if (!_.contains(buildIncludes, key)) dependencies.push(key)
                     }
@@ -115,7 +115,7 @@ module.exports = function(grunt) {
                 }
             }
         }
-        
+
         return [].concat(exports.defaults.includes, buildIncludes, dependencies);
     };
 


### PR DESCRIPTION
adds optional parameters to the grunt server tasks
--port="9002"
Allows multiple instances running at the same time
Defaults to 9001

--host="0.0.0.0"
Access a course in the local network by the host ip adress. Handy to access the course in a virtual machine (testing ie)
Defaults to "localhost"