### PR TITLE
Added layout sort override

### DIFF
--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -192,7 +192,7 @@ define(function (require) {
             }
 
             if (this.get('_type') == 'block' && childrenCollection.length == 2
-                && childrenCollection.models[0].get('_layout') !== 'left') {
+                && childrenCollection.models[0].get('_layout') !== 'left' && this.get('_sortComponents') !== false) {
                 // Components may have a 'left' or 'right' _layout,
                 // so ensure they appear in the correct order
                 // Re-order component models to correct it

--- a/src/core/js/models/blockModel.js
+++ b/src/core/js/models/blockModel.js
@@ -5,7 +5,13 @@ define(function(require) {
     var BlockModel = AdaptModel.extend({
         _parent:'articles',
     	_siblings:'blocks',
-        _children: 'components'
+        _children: 'components',
+        
+        defaults: function() {
+            return _.extend({
+                _sortComponents: true
+            }, AdaptModel.prototype.defaults);
+        }
     });
 
     return BlockModel;


### PR DESCRIPTION
Added a snippet of code which allows you to override the left/right sort order of components by applying '_sortComponents': false to the container block.

Ideally used for when you have an MCQ component left aligned and Graphic component right aligned on desktop but want the Graphic component to appear above the MCQ in mobile view. 

All component JSON is unchanged, only amendment is to define the right aligned Graphic component above the left aligned MCQ component in the components.json.