### PR TITLE
issue-1009: notify:cancelled event added

### DIFF
--- a/src/core/js/views/notifyView.js
+++ b/src/core/js/views/notifyView.js
@@ -91,6 +91,7 @@ define(function(require) {
             event.preventDefault();
             //tab index preservation, notify must close before subsequent callback is triggered
             this.closeNotify();
+            Adapt.trigger("notify:cancelled");
         },
 
         resetNotifySize: function() {


### PR DESCRIPTION
#1009 

To allow plugins to capture all exits from a notify