### PR TITLE
Resolves #1017, checks _isLocked in router

### DIFF
--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -176,7 +176,6 @@ define([
     Adapt.mapById = function(id) {
         // Returns collection name that contains this models Id
         return mappedIds[id];
-
     }
 
     Adapt.findById = function(id) {
@@ -187,7 +186,14 @@ define([
             return Adapt.course;
         }
 
-        return Adapt[Adapt.mapById(id)]._byAdaptID[id][0];
+        var collectionType = Adapt.mapById(id);
+
+        if (!collectionType) {
+            console.warn('Adapt.findById() unable to find collection type for id: ' + id);
+            return;
+        }
+
+        return Adapt[collectionType]._byAdaptID[id][0];
 
     }
 

--- a/src/core/js/models/configModel.js
+++ b/src/core/js/models/configModel.js
@@ -7,12 +7,13 @@ define(function(require) {
 
         defaults: {
             screenSize : {
-                small:520,
-                medium:760,
-                large:1024
+                small: 520,
+                medium: 760,
+                large: 1024
             },
-            _canLoadData:true,
-            _disableAnimation:false
+            _forceRouteLocking: false,
+            _canLoadData: true,
+            _disableAnimation: false
         },
 
         initialize: function(attrs, options) {

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -106,10 +106,11 @@ define([
             var type = '';
             
             if (!currentModel) {
+                Adapt.router.set('_canNavigate', true, {pluginName: "adapt"});
                 return;
-            } else {
-                type = currentModel.get('_type');
             }
+
+            type = currentModel.get('_type');
 
             switch (type) {
                 case 'page':
@@ -117,7 +118,11 @@ define([
                     if (currentModel.get('_isLocked') && Adapt.config.get('_forceRouteLocking')) {
                         console.log('Unable to navigate to locked id: ' + id);
                         Adapt.router.set('_canNavigate', true, {pluginName: "adapt"});
-                        return Backbone.history.history.back();
+                        if (Adapt.location._previousId === undefined) {
+                            return this.navigate("#/", {trigger:true, replace:true});
+                        } else {
+                            return Backbone.history.history.back();
+                        }
                     } else {
                         this.showLoading();
                         this.removeViews();

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -94,7 +94,7 @@ define([
             this.setContentObjectToVisited(Adapt.course);
             this.updateLocation('course');
             Adapt.once('menuView:ready', function() {
-                //allow navigation
+                // Allow navigation
                 Adapt.router.set('_canNavigate', true, {pluginName: "adapt"});
             });
             Adapt.trigger('router:menu', Adapt.course);
@@ -103,37 +103,51 @@ define([
         handleId: function(id) {
 
             var currentModel = Adapt.findById(id);
+            var type = '';
+            
+            if (!currentModel) {
+                return;
+            } else {
+                type = currentModel.get('_type');
+            }
 
-            switch (currentModel.get('_type')) {
-                case 'page': case 'menu':
-                    this.showLoading();
-                    this.removeViews();
-
-                    this.setContentObjectToVisited(currentModel);
-
-                    if (currentModel.get('_type') == 'page') {
-                        var location = 'page-' + id;
-                        this.updateLocation(location, 'page', id);
-                        Adapt.once('pageView:ready', function() {
-                            //allow navigation
-                            Adapt.router.set('_canNavigate', true, {pluginName: "adapt"});
-                        });
-                        Adapt.trigger('router:page', currentModel);
-                        this.$wrapper.append(new PageView({model:currentModel}).$el);
+            switch (type) {
+                case 'page':
+                case 'menu':
+                    if (currentModel.get('_isLocked')) {
+                        console.log('Unable to navigate to locked id: ' + id);
+                        Adapt.router.set('_canNavigate', true, {pluginName: "adapt"});
+                        return Backbone.history.history.back();
                     } else {
-                        var location = 'menu-' + id;
-                        this.updateLocation(location, 'menu', id);
-                        Adapt.once('menuView:ready', function() {
-                            //allow navigation
-                            Adapt.router.set('_canNavigate', true, {pluginName: "adapt"});
-                        });
-                        Adapt.trigger('router:menu', currentModel);
-                    }
+                        this.showLoading();
+                        this.removeViews();
+
+                        this.setContentObjectToVisited(currentModel);
+
+                        if (type == 'page') {
+                            var location = 'page-' + id;
+                            this.updateLocation(location, 'page', id);
+                            Adapt.once('pageView:ready', function() {
+                                // Allow navigation
+                                Adapt.router.set('_canNavigate', true, {pluginName: "adapt"});
+                            });
+                            Adapt.trigger('router:page', currentModel);
+                            this.$wrapper.append(new PageView({model: currentModel}).$el);
+                        } else {
+                            var location = 'menu-' + id;
+                            this.updateLocation(location, 'menu', id);
+                            Adapt.once('menuView:ready', function() {
+                                // Allow navigation
+                                Adapt.router.set('_canNavigate', true, {pluginName: "adapt"});
+                            });
+                            Adapt.trigger('router:menu', currentModel);
+                        }
+                    } 
                 break;
                 default:
                     //allow navigation
                     Adapt.router.set('_canNavigate', true, {pluginName: "adapt"});
-                    Adapt.navigateToElement('.' + id, {replace:true});
+                    Adapt.navigateToElement('.' + id, {replace: true});
             }
         },
 

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -172,14 +172,7 @@ define([
                 this.navigate("#/", {trigger:false, replace:false});
                 break;
             case 1:
-                var foundId = false;
-                try {
-                    Adapt.findById(args[0]);
-                    foundId = true;
-                } catch(e) {
-
-                }
-                if (foundId) {
+                if (Adapt.findById(args[0])) {
                     this.navigate("#/id/"+args[0], {trigger:false, replace:false});
                 } else {
                     this.navigate("#/"+args[0], {trigger:false, replace:false});

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -114,7 +114,7 @@ define([
             switch (type) {
                 case 'page':
                 case 'menu':
-                    if (currentModel.get('_isLocked')) {
+                    if (currentModel.get('_isLocked') && Adapt.config.get('_forceRouteLocking')) {
                         console.log('Unable to navigate to locked id: ' + id);
                         Adapt.router.set('_canNavigate', true, {pluginName: "adapt"});
                         return Backbone.history.history.back();

--- a/src/core/js/startController.js
+++ b/src/core/js/startController.js
@@ -62,10 +62,9 @@ define([
                     var className =  item._className;
                     var skipIfComplete = item._skipIfComplete;
                     
-                    var model;
-                    try {
-                        model = Adapt.findById(item._id);
-                    } catch(e) {
+                    var model = Adapt.findById(item._id);
+                    
+                    if (!model) {
                         console.log("startController: cannot find id", item._id);
                         continue;
                     }

--- a/src/core/js/views/questionView.js
+++ b/src/core/js/views/questionView.js
@@ -481,7 +481,7 @@ define(function(require) {
             try {
                 //try to get the current page location
                 var currentModel = Adapt.findById(Adapt.location._currentId);
-                if (currentModel.get("_isReady")) {
+                if (currentModel && currentModel.get("_isReady")) {
                     //if the page is ready, focus on the first tabbable item
                     //otherwise will try to set focus as page loads and components are rendered
                     this.$el.a11y_focus();

--- a/src/core/js/views/questionView.js
+++ b/src/core/js/views/questionView.js
@@ -478,16 +478,13 @@ define(function(require) {
             });
             this.$(".component-widget").removeClass("submitted");
             
-            try {
-                //try to get the current page location
-                var currentModel = Adapt.findById(Adapt.location._currentId);
-                if (currentModel && currentModel.get("_isReady")) {
-                    //if the page is ready, focus on the first tabbable item
-                    //otherwise will try to set focus as page loads and components are rendered
-                    this.$el.a11y_focus();
-                }
-            } catch(e) {}
-            
+            // Attempt to get the current page location
+            var currentModel = Adapt.findById(Adapt.location._currentId);
+            if (currentModel && currentModel.get("_isReady")) {
+                //if the page is ready, focus on the first tabbable item
+                //otherwise will try to set focus as page loads and components are rendered
+                this.$el.a11y_focus();
+            }
         },
 
         // Used by the question view to reset the stored user answer


### PR DESCRIPTION
This prevents routing to a locked page/menu via the URL, or menu link which has not yet been updated to support _isLocked.

Also, Adapt.findById() has been updated to return a warning when the _id value passed in does not exist in the mapping.