### PR TITLE
Resolves #1021, passes a subset of attributes to Grunt replace task

### DIFF
--- a/grunt/config/replace.js
+++ b/grunt/config/replace.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var fs = require('fs');
+var _ = require('underscore');
 
 module.exports = function (grunt, options) {
 
@@ -37,6 +38,10 @@ module.exports = function (grunt, options) {
       }
     }
 
+    // Ensure that only whitelisted attributes can be replaced.
+    courseJson = _.pick(courseJson, 'title', 'displayTitle', 'body', 'description');
+    configJson = _.pick(configJson, '_xapi', '_spoor');
+    
     // Combine the course and config JSON so both can be passed to replace.  
     var json = {
       'course': courseJson,


### PR DESCRIPTION
The grunt-replace module would fail if undefined or null values were passed.  Passing a smaller list of course and config properties reduces the chances of that, and will speed up performance.