### PR TITLE
remove one of the calls to checkLocking to avoid a warning appearing in the console

### DIFF
--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -41,9 +41,11 @@ define(function (require) {
                 this.setupChildListeners();
             }
 
-            this.checkLocking();
             this.init();
+            
             _.defer(_.bind(function() {
+                this.checkLocking();
+                
                 if (this._children) {
                     this.checkCompletionStatus();
                     this.checkInteractionCompletionStatus();

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -44,11 +44,12 @@ define(function (require) {
             this.init();
             
             _.defer(_.bind(function() {
-                this.checkLocking();
-                
                 if (this._children) {
                     this.checkCompletionStatus();
+                    
                     this.checkInteractionCompletionStatus();
+                    
+                    this.checkLocking();
                 }
             }, this));
         },
@@ -59,7 +60,7 @@ define(function (require) {
 
             this.listenTo(Adapt[this._children], {
                 "change:_isReady": this.checkReadyStatus,
-                "change:_isComplete": this.checkCompletionStatus,
+                "change:_isComplete": this.onIsComplete,
                 "change:_isInteractionComplete": this.checkInteractionCompletionStatus
             });
 
@@ -119,11 +120,10 @@ define(function (require) {
                     isComplete = (availableChildren.where({_isComplete: true, _isOptional: false}).length >= requireCompletionOf );
                 }
     
-                this.set({_isComplete:isComplete});
-                Adapt.checkedCompletion();
+                this.set({_isComplete: isComplete});
                 
+                Adapt.checkedCompletion();
             }, this));
-            this.checkLocking();
         },
 
         checkInteractionCompletionStatus: function () {
@@ -396,6 +396,12 @@ define(function (require) {
             }
 
             return false;
+        },
+        
+        onIsComplete: function() {
+            this.checkCompletionStatus();
+            
+            this.checkLocking();
         }
 
     });


### PR DESCRIPTION
also refactor code so that we don't have to hide the call to `checkLocking` inside `checkCompletionStatus`

fixes #1025