### PR TITLE
multilang grunt tracking-id's

### DIFF
--- a/grunt/config/tracking-insert.js
+++ b/grunt/config/tracking-insert.js
@@ -1,6 +1,6 @@
 module.exports = {
   options: {
-      courseFile: '<%= sourcedir %>course/en/course.json',
-      blocksFile: '<%= sourcedir %>course/en/blocks.json'
+      courseFile: '<%= sourcedir %>course/*/course.json',
+      blocksFile: '<%= sourcedir %>course/*/blocks.json'
   }
 }

--- a/grunt/config/tracking-remove.js
+++ b/grunt/config/tracking-remove.js
@@ -1,6 +1,6 @@
 module.exports = {
   options: {
-      courseFile: '<%= sourcedir %>course/en/course.json',
-      blocksFile: '<%= sourcedir %>course/en/blocks.json'
+      courseFile: '<%= sourcedir %>course/*/course.json',
+      blocksFile: '<%= sourcedir %>course/*/blocks.json'
   }
 }

--- a/grunt/config/tracking-reset.js
+++ b/grunt/config/tracking-reset.js
@@ -1,6 +1,6 @@
 module.exports = {
     options: {
-        courseFile: '<%= sourcedir %>course/en/course.json',
-        blocksFile: '<%= sourcedir %>course/en/blocks.json'
+        courseFile: '<%= sourcedir %>course/*/course.json',
+        blocksFile: '<%= sourcedir %>course/*/blocks.json'
     }
 }

--- a/grunt/tasks/tracking-insert.js
+++ b/grunt/tasks/tracking-insert.js
@@ -9,7 +9,19 @@ module.exports = function(grunt) {
             _trackingIdsSeen: []
         });
         
-        function insertTrackingIds(blocks, course){
+        var blocksFiles = grunt.file.expand(options.blocksFile)
+        var courseFiles = grunt.file.expand(options.blocksFile)
+        
+        for (var i = 0; i < blocksFiles.length; i++) {
+            insertTrackingIds(blocksFiles[i], courseFiles[i]);
+            options._latestTrackingId = -1;
+            options._trackingIdsSeen = [];
+        }
+        
+        function insertTrackingIds(blocksPath, coursePath){
+            var blocks = grunt.file.readJSON(blocksPath);
+            var course = grunt.file.readJSON(coursePath);
+            
             options._latestTrackingId = course._latestTrackingId || -1;
             
             for(var i = 0; i < blocks.length; i++) {
@@ -29,14 +41,13 @@ module.exports = function(grunt) {
                 if(options._latestTrackingId < block._trackingId) {
                     options._latestTrackingId = block._trackingId;
                 }
-                    
+
             }
             course._latestTrackingId = options._latestTrackingId;
             grunt.log.writeln("Task complete. The latest tracking ID is " + course._latestTrackingId);
-            grunt.file.write(options.courseFile, JSON.stringify(course, null, "    "));
-            grunt.file.write(options.blocksFile, JSON.stringify(blocks, null, "    "));
+            grunt.file.write(coursePath, JSON.stringify(course, null, "    "));
+            grunt.file.write(blocksPath, JSON.stringify(blocks, null, "    "));
         }
         
-        insertTrackingIds(grunt.file.readJSON(options.blocksFile), grunt.file.readJSON(options.courseFile));
     });
 }

--- a/grunt/tasks/tracking-insert.js
+++ b/grunt/tasks/tracking-insert.js
@@ -9,9 +9,9 @@ module.exports = function(grunt) {
             _trackingIdsSeen: []
         });
         
-        var blocksFiles = grunt.file.expand(options.blocksFile)
-        var courseFiles = grunt.file.expand(options.blocksFile)
-        
+        var blocksFiles = grunt.file.expand(options.blocksFile);
+        var courseFiles = grunt.file.expand(options.courseFile);
+
         for (var i = 0; i < blocksFiles.length; i++) {
             insertTrackingIds(blocksFiles[i], courseFiles[i]);
             options._latestTrackingId = -1;
@@ -50,4 +50,4 @@ module.exports = function(grunt) {
         }
         
     });
-}
+};

--- a/grunt/tasks/tracking-remove.js
+++ b/grunt/tasks/tracking-remove.js
@@ -18,12 +18,12 @@ module.exports = function(grunt) {
             grunt.file.write(blocksPath, JSON.stringify(blocks, null, "    "));
         }
         
-        var blocksFiles = grunt.file.expand(options.blocksFile)
-        var courseFiles = grunt.file.expand(options.blocksFile)
+        var blocksFiles = grunt.file.expand(options.blocksFile);
+        var courseFiles = grunt.file.expand(options.courseFile);
         
         for (var i = 0; i < blocksFiles.length; i++) {
             removeTrackingIds(blocksFiles[i], courseFiles[i]);
         }
         
     });
-}
+};

--- a/grunt/tasks/tracking-remove.js
+++ b/grunt/tasks/tracking-remove.js
@@ -5,17 +5,25 @@ module.exports = function(grunt) {
         if(!Helpers.isPluginInstalled('adapt-contrib-spoor')) return;
 
         var options = this.options();
-        function removeTrackingIds(blocks, course){
+        function removeTrackingIds(blocksPath, coursePath){
+            var blocks = grunt.file.readJSON(blocksPath);
+            var course = grunt.file.readJSON(coursePath);
             
             for(var i = 0; i < blocks.length; i++) {
                 delete blocks[i]._trackingId;
             }
             delete course._latestTrackingId;
             grunt.log.writeln("Tracking IDs removed.");
-            grunt.file.write(options.courseFile, JSON.stringify(course, null, "    "));
-            grunt.file.write(options.blocksFile, JSON.stringify(blocks, null, "    "));
+            grunt.file.write(coursePath, JSON.stringify(course, null, "    "));
+            grunt.file.write(blocksPath, JSON.stringify(blocks, null, "    "));
         }
         
-        removeTrackingIds(grunt.file.readJSON(options.blocksFile), grunt.file.readJSON(options.courseFile));
+        var blocksFiles = grunt.file.expand(options.blocksFile)
+        var courseFiles = grunt.file.expand(options.blocksFile)
+        
+        for (var i = 0; i < blocksFiles.length; i++) {
+            removeTrackingIds(blocksFiles[i], courseFiles[i]);
+        }
+        
     });
 }

--- a/grunt/tasks/tracking-reset.js
+++ b/grunt/tasks/tracking-reset.js
@@ -7,8 +7,18 @@ module.exports = function(grunt) {
         var options = this.options({
             _latestTrackingId: -1,
         });
+
+        var blocksFiles = grunt.file.expand(options.blocksFile)
+        var courseFiles = grunt.file.expand(options.blocksFile)
         
-        function resetTrackingIds(blocks, course){
+        for (var i = 0; i < blocksFiles.length; i++) {
+            resetTrackingIds(blocksFiles[i], courseFiles[i]);
+            options._latestTrackingId = -1;
+        }
+        
+        function resetTrackingIds(blocksPath, coursePath){
+            var blocks = grunt.file.readJSON(blocksPath);
+            var course = grunt.file.readJSON(coursePath);
             
             for(var i = 0; i < blocks.length; i++) {
                 var block = blocks[i];
@@ -18,10 +28,9 @@ module.exports = function(grunt) {
             }
             course._latestTrackingId = options._latestTrackingId;
             grunt.log.writeln("The latest tracking ID is " + course._latestTrackingId);
-            grunt.file.write(options.courseFile, JSON.stringify(course, null, "    "));
-            grunt.file.write(options.blocksFile, JSON.stringify(blocks, null, "    "));
+            grunt.file.write(coursePath, JSON.stringify(course, null, "    "));
+            grunt.file.write(blocksPath, JSON.stringify(blocks, null, "    "));
         }
-        
-        resetTrackingIds(grunt.file.readJSON(options.blocksFile), grunt.file.readJSON(options.courseFile));
+
     });
 }

--- a/grunt/tasks/tracking-reset.js
+++ b/grunt/tasks/tracking-reset.js
@@ -8,8 +8,8 @@ module.exports = function(grunt) {
             _latestTrackingId: -1,
         });
 
-        var blocksFiles = grunt.file.expand(options.blocksFile)
-        var courseFiles = grunt.file.expand(options.blocksFile)
+        var blocksFiles = grunt.file.expand(options.blocksFile);
+        var courseFiles = grunt.file.expand(options.courseFile);
         
         for (var i = 0; i < blocksFiles.length; i++) {
             resetTrackingIds(blocksFiles[i], courseFiles[i]);
@@ -33,4 +33,4 @@ module.exports = function(grunt) {
         }
 
     });
-}
+};


### PR DESCRIPTION
resolves #370 

updated to use globbing pattern for multiple language folders
gets applied to all matching blocks.json and course.json files, so there is no way to execute on one specific language. Please add a comment if you think this is missing.