### PR TITLE
set navigateToHomeRoute to navigate to '#/' (instead of '#') to stop …

### DIFF
--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -210,7 +210,7 @@ define([
         
         navigateToHomeRoute: function(force) {
             if (Adapt.router.get('_canNavigate') || force ) {
-                this.navigate('#', {trigger: true});                
+                this.navigate('#/', {trigger: true});
             }
         },
 


### PR DESCRIPTION
…the page from scrolling to the top immediately prior to navigation (see #1079)

If you want to test this you'll need to change the back button to a home button by changing theme/templates/navigation.hbs so that the data-event of the `button` with class `navigation-back-button` is `homeButton` (instead of `backButton`).