### PR TITLE
Resolves #1096, device width for iOS devices

### DIFF
--- a/src/core/js/device.js
+++ b/src/core/js/device.js
@@ -2,41 +2,44 @@ define(function(require) {
 
     var Adapt = require('coreJS/adapt');
     var Bowser = require('coreJS/libraries/bowser');
-
-    Adapt.device = {};
-
     var $window = $(window);
 
-    // Check whether device is touch enabled
-    Adapt.device.touch = Modernizr.touch;
+    Adapt.device = {
+        touch: Modernizr.touch,
+        screenWidth: isAppleDevice() ? screen.width : window.innerWidth || $window.width()
+    };
 
     Adapt.once('app:dataReady', function() {
-        // The theme.json will have been loaded at this point
         Adapt.device.screenSize = checkScreenSize();
 
-        $('html').addClass("size-"+Adapt.device.screenSize);
+        $('html').addClass("size-" + Adapt.device.screenSize);
+
+        // As Adapt.config is available it's ok to bind the 'resize'.
+        $window.on('resize', onWindowResize);
     });
 
-    Adapt.device.screenWidth = isAppleDevice()
-        ? screen.width
-        : window.innerWidth || $window.width();
-
+    /**
+     * Compares the calculated screen width to the breakpoints defined in config.json.
+     * 
+     * @returns {string} 'large', 'medium' or 'small'
+     */
     function checkScreenSize() {
-
+        var screenSizeConfig = Adapt.config.get('screenSize');
         var screenSize;
 
-        if (Adapt.device.screenWidth > Adapt.config.get('screenSize').medium) {
+        if (Adapt.device.screenWidth > screenSizeConfig.medium) {
             screenSize = 'large';
-        } else if (Adapt.device.screenWidth > Adapt.config.get('screenSize').small) {
+        } else if (Adapt.device.screenWidth > screenSizeConfig.small) {
             screenSize = 'medium';
         } else {
             screenSize = 'small';
         }
+
         return screenSize;
     }
 
     var onWindowResize = _.debounce(function onScreenSizeChanged() {
-
+        // Calculate the screen width.
         Adapt.device.screenWidth = isAppleDevice()
             ? screen.width
             : window.innerWidth || $window.width();
@@ -46,7 +49,7 @@ define(function(require) {
         if (newScreenSize !== Adapt.device.screenSize) {
             Adapt.device.screenSize = newScreenSize;
 
-            $('html').removeClass("size-small size-medium size-large").addClass("size-"+Adapt.device.screenSize);
+            $('html').removeClass("size-small size-medium size-large").addClass("size-" + Adapt.device.screenSize);
 
             Adapt.trigger('device:changed', Adapt.device.screenSize);
         }
@@ -54,8 +57,6 @@ define(function(require) {
 	    Adapt.trigger('device:resize', Adapt.device.screenWidth);
 
     }, 100);
-
-    $window.on('resize', onWindowResize);
 
     var browser = Bowser.name;
     var version = Bowser.version;

--- a/src/core/js/device.js
+++ b/src/core/js/device.js
@@ -17,7 +17,9 @@ define(function(require) {
         $('html').addClass("size-"+Adapt.device.screenSize);
     });
 
-    Adapt.device.screenWidth = $window.width();
+    Adapt.device.screenWidth = isAppleDevice()
+        ? screen.width
+        : window.innerWidth || $window.width();
 
     function checkScreenSize() {
 
@@ -34,7 +36,11 @@ define(function(require) {
     }
 
     var onWindowResize = _.debounce(function onScreenSizeChanged() {
-        Adapt.device.screenWidth = window.innerWidth || $window.width();
+
+        Adapt.device.screenWidth = isAppleDevice()
+            ? screen.width
+            : window.innerWidth || $window.width();
+
         var newScreenSize = checkScreenSize();
 
         if (newScreenSize !== Adapt.device.screenSize) {
@@ -45,7 +51,7 @@ define(function(require) {
             Adapt.trigger('device:changed', Adapt.device.screenSize);
         }
 
-	Adapt.trigger('device:resize', Adapt.device.screenWidth);
+	    Adapt.trigger('device:resize', Adapt.device.screenWidth);
 
     }, 100);
 
@@ -57,6 +63,10 @@ define(function(require) {
 
     // Bowser only checks against navigator.userAgent so if the OS is undefined, do a check on the navigator.platform
     if (OS == undefined) OS = getPlatform();
+
+    function isAppleDevice() {
+        return /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+    }
 
     function getPlatform() {
 
@@ -71,7 +81,6 @@ define(function(require) {
         }
 
         return "PlatformUnknown";
-
     }
 
     function pixelDensity() {


### PR DESCRIPTION
When content is rendered inside frames, the wrong size classes were being applied for iOS devices.  Switching to use screen.width as part of the calculation resolves this.

Android devices already behave as expected.