### PR TITLE
bugfix: #1114

### DIFF
--- a/src/core/js/views/questionView.js
+++ b/src/core/js/views/questionView.js
@@ -342,7 +342,7 @@ define([
     * Remove this section in when all components use questionModel and there is no need to have model behaviour in the questionView
     */
 
-    var viewOnlyCompatibleQuestionView = QuestionView.extend({
+    var viewOnlyCompatibleQuestionView = {
 
         /* All of these functions have been moved to the questionModel.js file. 
          * On the rare occasion that they have not been overridden by the component and 
@@ -481,17 +481,18 @@ define([
             if (!this.constructor.prototype[checkForFunction]) return false; //questionModel
 
             //if the function DOES exist on the view and MATCHES the compatibility function above, use the model only
-            if (this.constructor.prototype[checkForFunction] === viewOnlyCompatibleQuestionView.prototype[checkForFunction]) return false; //questionModel
+            if (this.constructor.prototype[checkForFunction] === viewOnlyCompatibleQuestionView[checkForFunction]) return false; //questionModel
 
             //if the function DOES exist on the view and does NOT match the compatibility function above, use the view function
             return true; //questionView
         }
 
-    }, {
+    };
+    
+    //return question view class extended with the compatibility layer
+    return QuestionView.extend(viewOnlyCompatibleQuestionView, {
         _isQuestionType: true
     });
-
-    return viewOnlyCompatibleQuestionView;
 
     /*END OF BACKWARDS COMPATIBILITY SECTION*/
 


### PR DESCRIPTION
standard question view (new version) functions were not being called by the compatibility layer.

the checking statement, line 484, was checking if the required function on the current view prototype was the same as the compatibility layer function - which it always will have been because the compatibility extension view was always an extension of the question view.

i have stopped the compatibility extension including the question view prototype functions when the comparison takes place so that line 484 will not be comparing "setQuestionAsSubmitted" and "checkQuestionCompletion" to itself.