### PR TITLE
Add grunt languages option

### DIFF
--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -15,7 +15,7 @@ module.exports = function (grunt, options) {
             files: [
                 {
                     expand: true,
-                    src: ['**/*', '!**/*.json'],
+                    src: ['<%=languages%>/**/*', '!**/*.json'],
                     cwd: '<%= sourcedir %>course/',
                     dest: '<%= outputdir %>course/'
                 }
@@ -25,7 +25,7 @@ module.exports = function (grunt, options) {
             files: [
                 {
                     expand: true,
-                    src: ['**/*.json'],
+                    src: ['<%=languages%>/*.json'],
                     cwd: '<%= sourcedir %>course/',
                     dest: '<%= outputdir %>course/'
                 }

--- a/grunt/config/jsonlint.js
+++ b/grunt/config/jsonlint.js
@@ -1,3 +1,3 @@
 module.exports = {
-  src: [ '<%= sourcedir %>course/**/*.json' ]
+  src: [ '<%= sourcedir %>course/<%=languages%>/*.json' ]
 }

--- a/grunt/config/watch.js
+++ b/grunt/config/watch.js
@@ -13,7 +13,7 @@ module.exports = {
         tasks : ['jsonlint', 'check-json', 'copy:courseJson']
     },
     courseAssets: {
-        files: ['<%= sourcedir %>course/**/*', '!<%= sourcedir %>course/**/*.json'],
+        files: ['<%= sourcedir %>course/<%=languages%>/*', '!<%= sourcedir %>course/<%=languages%>/*.json'],
         tasks : ['copy:courseAssets']
     },
     js: {

--- a/grunt/helpers.js
+++ b/grunt/helpers.js
@@ -37,6 +37,7 @@ module.exports = function(grunt) {
         grunt.log.ok('Building to "' + grunt.config('outputdir') + '"');
         if (grunt.config('theme') !== '**') grunt.log.ok('Using theme "' + grunt.config('theme') + '"');
         if (grunt.config('menu') !== '**') grunt.log.ok('Using menu "' + grunt.config('menu') + '"');
+        if (grunt.config('languages') !== '**') grunt.log.ok('The following languages will be included in the build "' + grunt.config('languages') + '"');
     });
 
     // privates
@@ -77,6 +78,7 @@ module.exports = function(grunt) {
         outputdir: process.cwd() + path.sep + 'build' + path.sep,
         theme: '**',
         menu: '**',
+        languages: '**',
         includes: [
 
         ],
@@ -113,12 +115,21 @@ module.exports = function(grunt) {
     };
 
     exports.generateConfigData = function() {
+
+        var languageFolders = "";
+        if (grunt.option('languages') && grunt.option('languages').split(',').length > 1) {
+          languageFolders = "{" + grunt.option('languages') + "}";
+        } else {
+          languageFolders = grunt.option('languages');
+        }
+
         var data = {
             root: __dirname.split(path.sep).slice(0,-1).join(path.sep),
             sourcedir: appendSlash(grunt.option('sourcedir')) || exports.defaults.sourcedir,
             outputdir: appendSlash(grunt.option('outputdir')) || exports.defaults.outputdir,
             theme: grunt.option('theme') || exports.defaults.theme,
             menu: grunt.option('menu') || exports.defaults.menu,
+            languages: languageFolders || exports.defaults.languages
         };
 
         // Selectively load the course.json ('outputdir' passed by server-build)


### PR DESCRIPTION
To build specific language folders: grunt build —languages=“fr,de”. Accepts comma separated list of language folders.

Requires https://github.com/adaptlearning/adapt_framework/pull/1039 to deal with multi lang tracking ID's.
