### PR TITLE
grunt translate refactor

### DIFF
--- a/grunt/config/translate.js
+++ b/grunt/config/translate.js
@@ -1,11 +1,10 @@
 module.exports = function (grunt) {
-    
-  return {
-    masterLang: "en",
-    targetLang: null,
-    format: "raw",
-    csvDelimeter: ",",
-    langFiles: ""
-  };
-  
+
+    return {
+        masterLang: "en",
+        targetLang: null,
+        format: "json",
+        csvDelimeter: ","
+    };
+
 };

--- a/grunt/config/translate.js
+++ b/grunt/config/translate.js
@@ -4,7 +4,8 @@ module.exports = function (grunt) {
         masterLang: "en",
         targetLang: null,
         format: "json",
-        csvDelimiter: ","
+        csvDelimiter: ",",
+        "shouldReplaceExisting": false
     };
 
 };

--- a/grunt/tasks/translate.js
+++ b/grunt/tasks/translate.js
@@ -14,8 +14,8 @@ module.exports = function(grunt) {
 
     grunt.registerTask("translate:import", "Import Language files and create a translated duplicte of a master Course.", [
       "_loadTranslateConfig",
-      "_loadMasterCourse",
       "_loadLanguageFiles",
+      "_loadMasterCourse",
       "_updateCourseData",
       "_saveCourseData"
     ]);

--- a/grunt/tasks/translate.js
+++ b/grunt/tasks/translate.js
@@ -4,7 +4,7 @@ module.exports = function(grunt) {
     Helper.loadSubTasks();
 
     grunt.registerTask('translate:export', 'Export Course Data into Language files ready to be translated', [
-      "_loadTranslateConfig",
+      "_getTranslateConfig",
       "_loadCourseData",
       "_parseSchemaFiles",
       "_createLookupTables",
@@ -13,7 +13,7 @@ module.exports = function(grunt) {
     ]);
 
     grunt.registerTask("translate:import", "Import Language files and create a translated duplicte of a master Course.", [
-      "_loadTranslateConfig",
+      "_getTranslateConfig",
       "_loadLanguageFiles",
       "_loadMasterCourse",
       "_updateCourseData",

--- a/grunt/tasks/translate/exportFile.js
+++ b/grunt/tasks/translate/exportFile.js
@@ -9,13 +9,13 @@ module.exports = function (grunt) {
     
     var next = this.async();
     
-    grunt.file.mkdir("languagefiles");
+    grunt.file.mkdir("languagefiles/"+grunt.config("translate.masterLang"));
     formatExport();
     
     
     
     function formatExport () {
-      var filename = "export_"+grunt.config("translate.masterLang");
+      var filename = "export";
       
       switch (grunt.config("translate.format")) {
         case "csv":
@@ -40,6 +40,7 @@ module.exports = function (grunt) {
       }, {});
       
       var options = {
+        quotedString: true,
         delimiter: grunt.config("translate.csvDelimiter")
       };
       
@@ -52,7 +53,7 @@ module.exports = function (grunt) {
           if (error) {
             _cb(error);
           } else {
-            var src = path.join("languagefiles",name+"_"+filename+".csv");
+            var src = path.join("languagefiles", grunt.config("translate.masterLang"), name+".csv");
             grunt.file.write(src, output);
             _cb();
           }
@@ -68,7 +69,7 @@ module.exports = function (grunt) {
     }
     
     function _exportRaw (filename) {
-      grunt.file.write(path.join("languagefiles",filename+".json"), JSON.stringify(global.translate.exportTextData," ", 4));
+      grunt.file.write(path.join("languagefiles", grunt.config("translate.masterLang"), filename+".json"), JSON.stringify(global.translate.exportTextData," ", 4));
       next();
     }
     

--- a/grunt/tasks/translate/loadCourseData.js
+++ b/grunt/tasks/translate/loadCourseData.js
@@ -7,6 +7,11 @@ module.exports = function (grunt) {
     var srcPath = grunt.config("sourcedir");
     var lang = grunt.config("translate.masterLang");
     
+    // check if master language course exists
+    if (!grunt.file.isDir(srcPath, "course", lang)) {
+        throw grunt.util.error("Folder "+lang+" does not exist in your Adapt course.");
+    }
+
     global.translate.courseData = {};
     global.translate.courseData.config = grunt.file.readJSON(path.join(srcPath,"course","config.json"));
     global.translate.courseData.course = grunt.file.readJSON(path.join(srcPath,"course",lang,"course.json"));

--- a/grunt/tasks/translate/loadLanguageFiles.js
+++ b/grunt/tasks/translate/loadLanguageFiles.js
@@ -7,26 +7,29 @@ module.exports = function (grunt) {
   grunt.registerTask("_loadLanguageFiles", function () {
     
     var next = this.async();
-    var langFiles = grunt.config("translate.langFiles");
+    var langFiles;
+    var inputFolder;
     global.translate.importData = [];
     
+    checkInputFolder();
     readLangFiles();
     processLangFiles();
     
+    function checkInputFolder () {
+      if (grunt.file.isDir("languagefiles", grunt.config("translate.targetLang"))) {
+        inputFolder = path.join("languagefiles", grunt.config("translate.targetLang"));
+      } else {
+        throw grunt.util.error(grunt.config("translate.targetLang") + " Folder does not exist. Please create this Folder in the languagefiles directory.");
+      }
+    }
     
     function readLangFiles () {
-      
-      // check if files exist
-      if (typeof langFiles === "string") {
-        langFiles = langFiles.split(",");
-      }
 
-      for (var i = 0; i < langFiles.length; i++) {
-        if (grunt.file.exists("languagefiles", langFiles[i])) {
-          langFiles[i] = path.join("languagefiles",langFiles[i]);
-        } else {
-          throw grunt.util.error(langFiles[i] + " not found");
-        }
+      // check if files exist
+      langFiles = grunt.file.expand(path.join(inputFolder,"*." + grunt.config('translate.format')));
+
+      if (langFiles.length === 0) {
+        throw grunt.util.error("No languagefiles found to process in folder " + grunt.config('translate.targetLang'));
       }
     }
   
@@ -84,16 +87,15 @@ module.exports = function (grunt) {
       var isValid = item.hasOwnProperty("file") && item.hasOwnProperty("id") && item.hasOwnProperty("path") && item.hasOwnProperty("value");
       
       if (!isValid) {
-        throw grunt.util.error("Sorry, the imported Files are not valid");
+        throw grunt.util.error("Sorry, the imported File is not valid");
       }
       next();
     }
     
     function processLangFiles () {
-      var format = path.parse(langFiles[0]).ext;
 
-      switch (format) {
-        case ".csv":
+      switch (grunt.config('translate.format')) {
+        case "csv":
           _parseCsvFiles();
           break;
         

--- a/grunt/tasks/translate/loadLanguageFiles.js
+++ b/grunt/tasks/translate/loadLanguageFiles.js
@@ -16,7 +16,10 @@ module.exports = function (grunt) {
     processLangFiles();
     
     function checkInputFolder () {
-      if (grunt.file.isDir("languagefiles", grunt.config("translate.targetLang"))) {
+
+      if (grunt.config("translate.targetLang") === null) {
+        throw grunt.util.error('Target language option is missing, please add --targetLang=<languageCode>');
+      } else if (grunt.file.isDir("languagefiles", grunt.config("translate.targetLang"))) {
         inputFolder = path.join("languagefiles", grunt.config("translate.targetLang"));
       } else {
         throw grunt.util.error(grunt.config("translate.targetLang") + " Folder does not exist. Please create this Folder in the languagefiles directory.");

--- a/grunt/tasks/translate/loadMasterCourse.js
+++ b/grunt/tasks/translate/loadMasterCourse.js
@@ -19,6 +19,10 @@ module.exports = function (grunt) {
       if (grunt.file.isDir(srcPath, "course", targetLang) && !grunt.config('translate.shouldReplaceExisting')) {
         throw grunt.util.error(targetLang+" folder already exist, to replace the content in this folder, please add a --replace flag to the grunt task.");
       }
+      
+      if (!grunt.file.isDir(srcPath, "course", masterLang)) {
+        throw grunt.util.error("Folder "+masterLang+" does not exist in your Adapt course.");
+      }
     }
     
     function copyCourse () {

--- a/grunt/tasks/translate/loadMasterCourse.js
+++ b/grunt/tasks/translate/loadMasterCourse.js
@@ -11,9 +11,15 @@ module.exports = function (grunt) {
     var masterLang = grunt.config("translate.masterLang");
     var srcPath = grunt.config("sourcedir");
     
+    checkCourseExists();
     copyCourse();
     getCourseDate();
     
+    function checkCourseExists () {
+      if (grunt.file.isDir(srcPath, "course", targetLang) && !grunt.config('translate.shouldReplaceExisting')) {
+        throw grunt.util.error(targetLang+" folder already exist, to replace the content in this folder, please add a --replace flag to the grunt task.");
+      }
+    }
     
     function copyCourse () {
       grunt.file.copy(path.join(srcPath,"course",masterLang,"course.json"), path.join(srcPath,"course",targetLang,"course.json"));

--- a/grunt/tasks/translate/loadTranslateConfig.js
+++ b/grunt/tasks/translate/loadTranslateConfig.js
@@ -1,8 +1,6 @@
 module.exports = function (grunt) {
 
-  grunt.registerTask("_loadTranslateConfig", function () {
-
-    var adaptConfig = grunt.file.readJSON("adapt.json");
+  grunt.registerTask("_getTranslateConfig", function () {
 
     // options masterLang, targetLang, format, files, csvDelimiter
     if (grunt.option("masterLang")) {
@@ -28,6 +26,10 @@ module.exports = function (grunt) {
 
     if (grunt.option("csvDelimiter")) {
       grunt.config.set('translate.csvDelimiter', grunt.option('csvDelimiter'));
+    }
+
+    if (grunt.option("replace")) {
+      grunt.config.set('translate.shouldReplaceExisting', true);
     }
 
   });

--- a/grunt/tasks/translate/loadTranslateConfig.js
+++ b/grunt/tasks/translate/loadTranslateConfig.js
@@ -1,54 +1,35 @@
 module.exports = function (grunt) {
-  
+
   grunt.registerTask("_loadTranslateConfig", function () {
-    
+
     var adaptConfig = grunt.file.readJSON("adapt.json");
-    
+
     // options masterLang, targetLang, format, files, csvDelimiter
     if (grunt.option("masterLang")) {
       grunt.config.set('translate.masterLang', grunt.option('masterLang'));
     }
-    
+
     if (grunt.option("targetLang")) {
       grunt.config.set('translate.targetLang', grunt.option('targetLang'));
     }
-    
+
     if (grunt.option("format")) {
-      grunt.config.set('translate.format', grunt.option('format'));
+      switch (grunt.option("format")) {
+        case "csv":
+          grunt.config.set('translate.format', 'csv');
+          break;
+        
+        case "json":
+        default:
+          grunt.config.set('translate.format', 'json');      
+          break;
+      }
     }
-    
+
     if (grunt.option("csvDelimiter")) {
       grunt.config.set('translate.csvDelimiter', grunt.option('csvDelimiter'));
     }
-    
-    if (grunt.option("files")) {
-      grunt.config.set('translate.langFiles', grunt.option('files'));
-    }
-    
-    // check config in adapt.json
-    
-    if (adaptConfig.hasOwnProperty("translate")) {
-      // masterLanguage
-      if (!grunt.option('masterLang') && adaptConfig.translate.hasOwnProperty("masterLanguage")) {
-        if (adaptConfig.translate.masterLanguage) {
-          grunt.config.set("translate.masterLang", adaptConfig.translate.masterLanguage);
-        }
-      }
-    
-      // csvDelimiter
-      if (!grunt.option('csvDelimiter') && adaptConfig.translate.hasOwnProperty("csvDelimiter")) {
-        if (adaptConfig.translate.csvDelimiter) {
-          grunt.config.set("translate.csvDelimiter", adaptConfig.translate.csvDelimiter);
-        }
-      }
-    
-      // language fiels
-      if (!grunt.option('files') && adaptConfig.translate.hasOwnProperty("files")) {
-        if ( adaptConfig.translate.files[grunt.config("translate.targetLang")] ) {
-          grunt.config.set("translate.langFiles", adaptConfig.translate.files[grunt.config("translate.targetLang")]);
-        }
-      }
-    }
+
   });
   
 };


### PR DESCRIPTION
`grunt translate:export [--masterLang=en] [--format=json|raw|csv]`

defaults to :
	--masterLang=en
	--format=json

`grunt translate:import [--masterLang=en] --targetLang=de [--format=json|raw|csv] --replace`
required:
	--targetLang

defaults to:
	--masterLang=en
	--format=json

**export:** grunt creates a lang folder namen like masterLang in languagefiles dir and exports the languagefiles in this dir
**import:** you must create you a folder named like your targetLang and add the translated file(s) into this dir
all csv/json files in the targetLang folder are read and parsed. so it should only contain one file for each a,b,c,course,co

When grunt translate:import is called, it checks now if there is already a folder in src/course named like targetLang. If there is one, it breaks unless the user adds a --replace flag to the grunt task.