### PR TITLE
Added toggle state label

### DIFF
--- a/src/core/js/views/accessibilityView.js
+++ b/src/core/js/views/accessibilityView.js
@@ -28,7 +28,9 @@ define(function(require) {
 
                 var toggleText = isActive ? offLabel : onLabel;
 
-                this.$el.html(toggleText).attr('aria-label', Adapt.course.get("title") + ". " + Adapt.course.get('_globals')._accessibility._ariaLabels.accessibilityToggleButton);
+                this.$el.html(toggleText).attr('aria-label', Adapt.course.get("title") + ". "
+                    + Adapt.course.get('_globals')._accessibility._ariaLabels.accessibilityToggleButton + ". "
+                    + $.a11y_normalize(toggleText));
             }
         },
 


### PR DESCRIPTION
The Turn Accessibility On button doesn't have a state to the screen reader as it uses button text and an aria label.

As there was no state indicator in aria-label I've added the `toggleText` value to the end of it.

Issue https://github.com/adaptlearning/adapt_framework/issues/1172