### PR TITLE
Corrects #1152 with start controller functionality

### DIFF
--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -92,7 +92,7 @@ define([
                 // Do not allow access to the menu when the start controller is enabled.
                 var startController = Adapt.course.get('_start');
                 
-                if (startController._isEnabled == true && startController._force == true) {
+                if (startController._isEnabled == true && startController._isMenuDisabled == true) {
                     return;
                 }
             }

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -88,6 +88,15 @@ define([
         },
 
         handleCourse: function() {
+            if (Adapt.course.has('_start')) {
+                // Do not allow access to the menu when the start controller is enabled.
+                var startController = Adapt.course.get('_start');
+                
+                if (startController._isEnabled == true && startController._force == true) {
+                    return;
+                }
+            }
+
             this.showLoading();
             this.removeViews();
             Adapt.course.set('_isReady', false);


### PR DESCRIPTION
If the start controler is enabled, and '_force' is set to true, it should not be possible to route to the menu.