### PR TITLE
issue-1159: add screenSize from theme to less

### DIFF
--- a/grunt/config/less.js
+++ b/grunt/config/less.js
@@ -12,6 +12,7 @@ module.exports = function (grunt, options) {
                     '<%= sourcedir %>extensions/**/*.less',
                     '<%= sourcedir %>theme/<%= theme %>/**/*.less'
                 ],
+                config: '<%= outputdir %>course/config.json',
                 sourcemaps:true,
                 compress:false,
                 dest: '<%= outputdir %>adapt/css/',
@@ -34,6 +35,7 @@ module.exports = function (grunt, options) {
                     '<%= sourcedir %>extensions/**/*.less',
                     '<%= sourcedir %>theme/<%= theme %>/**/*.less'
                 ],
+                config: '<%= outputdir %>course/config.json',
                 sourcemaps: false,
                 compress:true,
                 dest: '<%= outputdir %>adapt/css/',

--- a/grunt/tasks/build.js
+++ b/grunt/tasks/build.js
@@ -7,13 +7,13 @@ module.exports = function(grunt) {
         'check-json',
         'clean:output',
         'copy',
-        'less:compile',
         'handlebars',
         'create-json-config',
         'schema-defaults',
         'tracking-insert',
         'javascript:compile',
         'clean:dist',
+        'less:compile',
         'replace'
     ]);
 }

--- a/grunt/tasks/dev.js
+++ b/grunt/tasks/dev.js
@@ -6,12 +6,12 @@ module.exports = function(grunt) {
         '_log-vars',
         'check-json',
         'copy',
-        'less:dev',
         'handlebars',
         'create-json-config',
         'schema-defaults',
         'tracking-insert',
         'javascript:dev',
+        'less:dev',
         'replace',
         'watch'
     ]);

--- a/grunt/tasks/less.js
+++ b/grunt/tasks/less.js
@@ -44,7 +44,7 @@ module.exports = function(grunt) {
 						screenSize = configjson.screenSize || screenSize;
 					} catch (e) {}
 
-					console.log("sreen size:", screenSize);
+					console.log("screen size:", screenSize);
 
 					imports += "\n@adapt-device-small:"+screenSize.small+";";
 					imports += "\n@adapt-device-medium:"+screenSize.medium+";";

--- a/grunt/tasks/less.js
+++ b/grunt/tasks/less.js
@@ -35,9 +35,9 @@ module.exports = function(grunt) {
 
 				if (options.config) {
 					var screenSize = {
-						"small": 520,
-				        "medium": 760,
-				        "large": 900
+                        "small": 520,
+                        "medium": 760,
+                        "large": 900
 					};
 					try {
 						var configjson = JSON.parse(grunt.file.read(options.config).toString());

--- a/grunt/tasks/less.js
+++ b/grunt/tasks/less.js
@@ -44,7 +44,7 @@ module.exports = function(grunt) {
 						screenSize = configjson.screenSize || screenSize;
 					} catch (e) {}
 
-					console.log(screenSize);
+					console.log("sreen size:", screenSize);
 
 					imports += "\n@adapt-device-small:"+screenSize.small+";";
 					imports += "\n@adapt-device-medium:"+screenSize.medium+";";

--- a/grunt/tasks/less.js
+++ b/grunt/tasks/less.js
@@ -35,9 +35,9 @@ module.exports = function(grunt) {
 
 				if (options.config) {
 					var screenSize = {
-			                        "small": 520,
-			                        "medium": 760,
-			                        "large": 900
+						"small": 520,
+						"medium": 760,
+						"large": 900
 					};
 					try {
 						var configjson = JSON.parse(grunt.file.read(options.config).toString());

--- a/grunt/tasks/less.js
+++ b/grunt/tasks/less.js
@@ -35,9 +35,9 @@ module.exports = function(grunt) {
 
 				if (options.config) {
 					var screenSize = {
-                        "small": 520,
-                        "medium": 760,
-                        "large": 900
+			                        "small": 520,
+			                        "medium": 760,
+			                        "large": 900
 					};
 					try {
 						var configjson = JSON.parse(grunt.file.read(options.config).toString());

--- a/grunt/tasks/less.js
+++ b/grunt/tasks/less.js
@@ -32,6 +32,25 @@ module.exports = function(grunt) {
 						imports+= "@import '" + trimmed + "';\n";
 					});	
 				}
+
+				if (options.config) {
+					var screenSize = {
+						"small": 520,
+				        "medium": 760,
+				        "large": 900
+					};
+					try {
+						var configjson = JSON.parse(grunt.file.read(options.config).toString());
+						screenSize = configjson.screenSize || screenSize;
+					} catch (e) {}
+
+					console.log(screenSize);
+
+					imports += "\n@adapt-device-small:"+screenSize.small+";";
+					imports += "\n@adapt-device-medium:"+screenSize.medium+";";
+					imports += "\n@adapt-device-large:"+screenSize.large+";";
+					
+				}
 			}
 
 			var sourcemaps;


### PR DESCRIPTION
https://github.com/adaptlearning/adapt_framework/issues/1159

added ```@adapt-device-small, @adapt-device-medium @adapt-device-large``` to less straight from theme.json

removes the need to specify screen widths in both json and less.