### PR TITLE
issue-1051: added accessibility helpers

### DIFF
--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -116,6 +116,26 @@ define(function(require) {
                 return $.a11y_normalize(text);
             });
 
+            Handlebars.registerHelper('a11y_aria_label', function(text) {
+                return '<div class="aria-label a11y-ignore-focus prevent-default" tabindex="0" role="region">'+text+'</div>';
+            });
+
+            Handlebars.registerHelper('a11y_aria_label_relative', function(text) {
+                return '<div class="aria-label relative a11y-ignore-focus prevent-default" tabindex="0" role="region">'+text+'</div>';
+            });
+
+            Handlebars.registerHelper('a11y_wrap_focus', function(text) {
+                return '<a id="a11y-focusguard" class="a11y-ignore a11y-ignore-focus" tabindex="0" role="button">&nbsp;</a>';
+            });
+
+            Handlebars.registerHelper('a11y_attrs_heading', function(level) {
+                return 'role="heading" aria-level="'+level+'" tabindex="0"';
+            });
+
+            Handlebars.registerHelper('a11y_attrs_tabbable', function() {
+                return 'role="region" tabindex="0"';
+            });
+
         },
 
         setupToggleButton: function() {

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -117,11 +117,11 @@ define(function(require) {
             });
 
             Handlebars.registerHelper('a11y_aria_label', function(text) {
-                return '<div class="aria-label a11y-ignore-focus prevent-default" tabindex="0" role="region">'+text+'</div>';
+                return '<div class="aria-label prevent-default" tabindex="0" role="region">'+text+'</div>';
             });
 
             Handlebars.registerHelper('a11y_aria_label_relative', function(text) {
-                return '<div class="aria-label relative a11y-ignore-focus prevent-default" tabindex="0" role="region">'+text+'</div>';
+                return '<div class="aria-label relative prevent-default" tabindex="0" role="region">'+text+'</div>';
             });
 
             Handlebars.registerHelper('a11y_wrap_focus', function(text) {


### PR DESCRIPTION
https://github.com/adaptlearning/adapt_framework/issues/1051

* added ```a11y_attrs_heading(level)``` - for defining header attributes correctly
```handlebars
<div class="menu-title-inner h1 accessible-text-block" role="heading" aria-level="1" tabindex="0">
{{{displayTitle}}}
</div>
```
```handlebars
<div class="menu-title-inner h1 accessible-text-block" {{{a11y_attrs_heading 1}}}>
{{{displayTitle}}}
</div>
```

* added ```a11y_attrs_tabbable``` - for defining tabbable attributes correctly
```handlebars
<div class="menu-title-inner h1 accessible-text-block" role="region" tabindex="0">
{{{displayTitle}}}
</div>
```
```handlebars
<div class="menu-title-inner h1 accessible-text-block" {{{a11y_attrs_tabbable}}}>
{{{displayTitle}}}
</div>
```


* added ```a11y_aria_label``` - for defining aria labels correctly, for entry to a region, always appears at the top of a section
* added ```a11y_aria_label_relative``` - for defining relatively positioned aria labels correctly, like at the bottom of pages or menus
```handlebars
<div class="menu-container" role="region" aria-label="{{_globals._menu._boxmenu.ariaRegion}}">
	
	<div class='menu-container-inner box-menu-inner clearfix'>
		
	</div>
	<div class="aria-label relative prevent-default" tabindex="0" role="region">{{_globals._menu._boxmenu.menuEnd}}</div>
</div>
```
```handlebars
<div class="menu-container">
    {{{a11y_aria_label _globals._menu._boxmenu.ariaRegion}}}
	
	<div class='menu-container-inner box-menu-inner clearfix'>
		
	</div>
    {{{a11y_aria_label_relative _globals._menu._boxmenu.menuEnd}}}
</div>
```


* added ```a11y_wrap_focus``` - for defining where focus should wrap around to the beginning of the section, like drawer bottom, page/menu bottom etc
```handlebars
<div class="page-inner article-container" role="main" aria-label="{{_accessibility._ariaLabels.page}}">
</div>
{{{a11y_wrap_focus}}}
```
