### PR TITLE
Resolves #1073, adds support for hiding 'Feedback' button

### DIFF
--- a/src/core/js/models/questionModel.js
+++ b/src/core/js/models/questionModel.js
@@ -16,6 +16,7 @@ define([
                 '_isQuestionType': true,
                 '_shouldDisplayAttempts': false,
                 '_canShowModelAnswer': true,
+                '_canShowFeedback': true,
                 '_canShowMarking': true,
                 '_questionWeight': Adapt.config.get("_questionWeight"),
             }, ComponentModel.prototype.defaults);

--- a/src/core/js/views/buttonsView.js
+++ b/src/core/js/views/buttonsView.js
@@ -30,6 +30,7 @@ define(function() {
         postRender: function() {
             this.updateAttemptsCount();
             this.checkResetSubmittedState();
+            this.checkFeedbackState();
             this.onButtonStateChanged(null, this.model.get('_buttonState'));
             this.onFeedbackMessageChanged(null, this.model.get('feedbackMessage'));
         },
@@ -107,6 +108,16 @@ define(function() {
             }
 
             this.updateAttemptsCount();
+        },
+
+        checkFeedbackState: function(){
+            if (!this.model.get('_canShowFeedback')) {
+                // If feedback should be hidden, the 'Submit' button should stretch
+                // to fill the space and the 'Feedback' button should be hidden.
+                // (These classes must be implemented in the theme.)
+                this.$('.buttons-action').addClass('buttons-action-fullwidth');
+                this.$('.buttons-feedback').addClass('no-feedback');
+            }
         },
 
         updateAttemptsCount: function(model, changedAttribute) {


### PR DESCRIPTION
A new checkFeedbackState() function has been added to buttonsView.js.

This is dependent on the theme implementing the 'no-feedback' and 'buttons-action-fullwidth' classes.