### PR TITLE
issue-1187: matching partial feedback fix

### DIFF
--- a/src/core/js/views/questionView.js
+++ b/src/core/js/views/questionView.js
@@ -485,7 +485,11 @@ define([
 
             //if the function DOES exist on the view and MATCHES the compatibility function above, use the model only
             if (this.constructor.prototype[checkForFunction] === viewOnlyCompatibleQuestionView[checkForFunction])  {
-                if (checkForFunction === "setupFeedback") return true; //questionView
+                switch (checkForFunction) {
+                case "setupFeedback":
+                case "markQuestion": 
+                    return true; //questionView   
+                }
                 return false; //questionModel
             }
 

--- a/src/core/js/views/questionView.js
+++ b/src/core/js/views/questionView.js
@@ -484,7 +484,10 @@ define([
             if (!this.constructor.prototype[checkForFunction]) return false; //questionModel
 
             //if the function DOES exist on the view and MATCHES the compatibility function above, use the model only
-            if (this.constructor.prototype[checkForFunction] === viewOnlyCompatibleQuestionView[checkForFunction]) return false; //questionModel
+            if (this.constructor.prototype[checkForFunction] === viewOnlyCompatibleQuestionView[checkForFunction])  {
+                if (checkForFunction === "setupFeedback") return true; //questionView
+                return false; //questionModel
+            }
 
             //if the function DOES exist on the view and does NOT match the compatibility function above, use the view function
             return true; //questionView


### PR DESCRIPTION
Question View:

1. setupFeedback https://github.com/adaptlearning/adapt_framework/blob/cd2b27ba2c5df4e6f4c60ba15cacd4b769d9cfa2/src/core/js/views/questionView.js#L429-L447

2. markQuestion https://github.com/adaptlearning/adapt_framework/blob/cd2b27ba2c5df4e6f4c60ba15cacd4b769d9cfa2/src/core/js/views/questionView.js#L397-L410

Both functions should be called through the view always in compatibility mode as some of their sub functions can live on the view only

#1187 