### PR TITLE
Rework to device.js

### DIFF
--- a/src/core/js/device.js
+++ b/src/core/js/device.js
@@ -41,7 +41,7 @@ define(function(require) {
     function getScreenWidth() {
         return isAppleDevice()
             ? getAppleScreenWidth()
-            : window.innerWidth || $window.width()
+            : window.innerWidth || $window.width();
     }
 
     var onWindowResize = _.debounce(function onScreenSizeChanged() {

--- a/src/core/js/device.js
+++ b/src/core/js/device.js
@@ -6,7 +6,7 @@ define(function(require) {
 
     Adapt.device = {
         touch: Modernizr.touch,
-        screenWidth: isAppleDevice() ? screen.width : window.innerWidth || $window.width()
+        screenWidth: getScreenWidth()
     };
 
     Adapt.once('app:dataReady', function() {
@@ -38,11 +38,15 @@ define(function(require) {
         return screenSize;
     }
 
+    function getScreenWidth() {
+        return isAppleDevice()
+            ? getAppleScreenWidth()
+            : window.innerWidth || $window.width()
+    }
+
     var onWindowResize = _.debounce(function onScreenSizeChanged() {
         // Calculate the screen width.
-        Adapt.device.screenWidth = isAppleDevice()
-            ? screen.width
-            : window.innerWidth || $window.width();
+        Adapt.device.screenWidth = getScreenWidth();
 
         var newScreenSize = checkScreenSize();
 
@@ -67,6 +71,10 @@ define(function(require) {
 
     function isAppleDevice() {
         return /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+    }
+
+    function getAppleScreenWidth() {
+        return (Math.abs(window.orientation) === 90) ? screen.height : screen.width;
     }
 
     function getPlatform() {


### PR DESCRIPTION
- Abstracted code into a getScreenWidth() function
- Corrected issue with width reported for iOS devices in landscape by adding getAppleScreenWidth() function