### PR TITLE
Remove encoding detection on export

### DIFF
--- a/grunt/tasks/translate/exportFile.js
+++ b/grunt/tasks/translate/exportFile.js
@@ -55,7 +55,7 @@ module.exports = function (grunt) {
             _cb(error);
           } else {
             var src = path.join("languagefiles", grunt.config("translate.masterLang"), name+".csv");
-            grunt.file.write(src, output);
+            grunt.file.write(src, "\ufeff" + output);
             _cb();
           }
         });

--- a/grunt/tasks/translate/loadCourseData.js
+++ b/grunt/tasks/translate/loadCourseData.js
@@ -1,6 +1,4 @@
 var path = require("path");
-var jschardet = require("jschardet");
-var iconv = require("iconv-lite");
 
 module.exports = function (grunt) {
   
@@ -28,21 +26,8 @@ module.exports = function (grunt) {
     for (var file in fileMap) {
         if (fileMap.hasOwnProperty(file)) {
             var src = path.join.apply(null, fileMap[file]);
-            var fileBuffer = grunt.file.read(src, {encoding: null});
 
-            // decode course files
-            var detected = jschardet.detect(fileBuffer);
-            var fileAsString;
-
-            if (iconv.encodingExists(detected.encoding)) {
-                fileAsString = iconv.decode(fileBuffer, detected.encoding);
-                grunt.log.debug(file+' - encoding detected: '+detected.encoding);
-            } else {
-                fileAsString = iconv.decode(fileBuffer, 'utf8');
-                grunt.log.debug(file+' - encoding not detected, used utf-8 instead');
-            }
-
-            global.translate.courseData[file] = JSON.parse(fileAsString);
+            global.translate.courseData[file] = grunt.file.readJSON(src);
         }
     }
 


### PR DESCRIPTION
My suggestion is to remove the encoding detection on export since it is causing issues rather than solving them. We should make the assumption that the user starts with UTF-8-encoded JSON.

Export
* Write to UTF-8-encoded CSV or JSON.
* If CSV, add a byte order mark so that Excel (2007+) recognises it as UTF-8.

Excel
* On Windows, Excel defaults to saving in Windows-1252 encoding, which includes standard accented and extended punctutation [characters](https://en.wikipedia.org/wiki/Windows-1252#Code_page_layout), e.g. `á`, `’`, `–`, so nothing should be garbled from Adapt's default JSON.
* The user will have to follow [workarounds](http://stackoverflow.com/questions/4221176/excel-to-csv-with-utf8-encoding) if they want to save out a CSV from Excel in true UTF-8 encoding since this is a limitation of Excel itself.

Import
* Retain character detection and decoding before writing to JSON.