### PR TITLE
issue #1219 

### DIFF
--- a/grunt/tasks/translate/createLookupTable.js
+++ b/grunt/tasks/translate/createLookupTable.js
@@ -49,7 +49,10 @@ module.exports = function (grunt) {
             break;
           
           case "array":
-            if (description.items.type === "object") {
+            if (!description.hasOwnProperty('items')) {
+              // handles "inputType": "List" edge-case
+              break;
+            } else if (description.items.type === "object") {
               _traverseSchemas(description.items.properties, store, _path+attributeName+"/", shouldPickValue);
             } else {
               var next = {};

--- a/grunt/tasks/translate/createLookupTable.js
+++ b/grunt/tasks/translate/createLookupTable.js
@@ -52,7 +52,9 @@ module.exports = function (grunt) {
             if (!description.hasOwnProperty('items')) {
               // handles "inputType": "List" edge-case
               break;
-            } else if (description.items.type === "object") {
+            }
+
+            if (description.items.type === "object") {
               _traverseSchemas(description.items.properties, store, _path+attributeName+"/", shouldPickValue);
             } else {
               var next = {};


### PR DESCRIPTION
Currently array's without items attribute are not supported. Example for this is `"inputType": "List"` used for lockedBy attribute.

Handle this case by skippinkg to next item.
If list of array needs to be supported, use array + items definition instead. E.g. textinput `_items._answers`