### PR TITLE
review-issue-1228: speed up javascript task

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,66 +1,17 @@
 require.config({
     paths: {
-        jquery: 'core/js/libraries/jquery',
-        underscore: 'core/js/libraries/underscore',
-        backbone: 'core/js/libraries/backbone',
-        modernizr: 'core/js/libraries/modernizr',
-        handlebars: 'core/js/libraries/handlebars',
-        velocity: 'core/js/libraries/velocity',
-        imageReady: 'core/js/libraries/imageReady',
-        inview: 'core/js/libraries/inview',
-        a11y: 'core/js/libraries/jquery.a11y',
-        scrollTo: 'core/js/libraries/scrollTo',
-        templates: 'templates/templates'
+        jquery: 'empty:',
+        underscore: 'empty:',
+        backbone: 'empty:',
+        modernizr: 'empty:',
+        handlebars: 'empty:',
+        velocity: 'empty:',
+        imageReady: 'empty:',
+        inview: 'empty:',
+        a11y: 'empty:',
+        scrollTo: 'empty:',
+        libraries: 'empty:'
     },
-    shim: {
-        jquery: {
-            exports: '$'
-        },
-        backbone: {
-            deps: [
-                'underscore',
-                'jquery'
-            ],
-            exports: 'Backbone'
-        },
-        underscore: {
-            exports: '_'
-        },
-        handlebars: {
-            exports: 'Handlebars'
-        },
-        velocity: {
-            deps: [
-                'jquery'
-            ]
-        },
-        imageReady: {
-            deps: [
-                'jquery'
-            ]
-        },
-        inview: {
-            deps: [
-                'jquery'
-            ]
-        },
-        scrollTo: {
-            deps: [
-                'jquery'
-            ]
-        },
-        a11y: {
-            deps: [
-                'jquery'
-            ]
-        }
-    },
-    packages: [
-
-    ],
-    exclude: [
-        'jquery'
-    ],
     map: {
         '*': {
             coreJS: 'core/js',

--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -173,16 +173,24 @@ module.exports = function (grunt, options) {
                 {
                     expand: true,
                     src: [
-                        '<%= sourcedir %>core/js/libraries/require.js',
-                        '<%= sourcedir %>core/js/libraries/modernizr.js',
-                        '<%= sourcedir %>core/js/libraries/json2.js',
-                        '<%= sourcedir %>core/js/libraries/consoles.js',
-                        '<%= sourcedir %>core/js/libraries/jquery.js',
-                        '<%= sourcedir %>core/js/libraries/jquery.v2.js'
+                        '<%= sourcedir %>core/js/libraries/*.js'
                     ],
                     dest: '<%= outputdir %>libraries/',
                     filter: 'isFile',
                     flatten: true
+                },
+                {
+                    expand: true,
+                    src: ['**/libraries/**/*'],
+                    cwd: '<%= sourcedir %>',
+                    dest: '<%= outputdir %>/libraries/',
+                    filter: function(filepath) {
+                        return grunt.config('helpers').includedFilter(filepath);
+                    },
+                    rename: function(destFolder, srcFileName) {
+                        var endOfRequired = srcFileName.indexOf("libraries/") + 9;
+                        return destFolder + srcFileName.substr(endOfRequired);
+                    }
                 },
                 {
                     expand: true,

--- a/grunt/config/javascript.js
+++ b/grunt/config/javascript.js
@@ -18,24 +18,6 @@ module.exports = function (grunt, options) {
                 pluginsFilter: function(filepath) {
                     return grunt.config('helpers').includedFilter(filepath);
                 },
-                //translate old style bundle references into something that does exist
-                map: {
-                    "*": {
-                        "components/components": "plugins",
-                        "extensions/extensions": "plugins",
-                        "menu/menu": "plugins",
-                        "theme/theme": "plugins",
-                        //this is a really hacky way to make the templates AT multi-user writable !rethink at a later date!
-                        "templates": "plugins",
-                        "templates/templates": "plugins"
-                    }
-                },
-                paths: {
-                    "components/components": "plugins",
-                    "extensions/extensions": "plugins",
-                    "menu/menu": "plugins",
-                    "theme/theme": "plugins"
-                },
                 generateSourceMaps: true,
                 preserveLicenseComments:false,
                 optimize: 'none'
@@ -54,28 +36,14 @@ module.exports = function (grunt, options) {
                     '<%= sourcedir %>menu/<%= menu %>/bower.json',
                     '<%= sourcedir %>theme/<%= theme %>/bower.json'
                 ],
+                preserveLicenseComments:false,
+                uglify2: {
+                    compress: false
+                },
                 pluginsPath: '<%= sourcedir %>/plugins.js',
                 pluginsModule: 'plugins',
                 pluginsFilter: function(filepath) {
                     return grunt.config('helpers').includedFilter(filepath);
-                },
-                //translate old style bundle references into something that does exist
-                map: {
-                    "*": {
-                        "components/components": "plugins",
-                        "extensions/extensions": "plugins",
-                        "menu/menu": "plugins",
-                        "theme/theme": "plugins",
-                        //this is a really hacky way to make the templates AT multi-user writable !rethink at a later date!
-                        "templates": "plugins",
-                        "templates/templates": "plugins"
-                    }
-                },
-                paths: {
-                    "components/components": "plugins",
-                    "extensions/extensions": "plugins",
-                    "menu/menu": "plugins",
-                    "theme/theme": "plugins"
                 },
                 optimize: 'uglify2'
             }

--- a/grunt/config/javascript.js
+++ b/grunt/config/javascript.js
@@ -46,6 +46,11 @@ module.exports = function (grunt, options) {
                     return grunt.config('helpers').includedFilter(filepath);
                 },
                 optimize: 'uglify2'
+            },
+            files: {
+              '<%= outputdir %>adapt/js/adapt.min.js': [
+                '<%= sourcedir %>/**/*.js'
+              ]
             }
         }
     }

--- a/grunt/tasks/build.js
+++ b/grunt/tasks/build.js
@@ -2,18 +2,40 @@
 * For production
 */
 module.exports = function(grunt) {
-    grunt.registerTask('build', 'Creates a production-ready build of the course', [
-        '_log-vars',
-        'check-json',
-        'clean:output',
-        'copy',
-        'handlebars',
-        'create-json-config',
-        'schema-defaults',
-        'tracking-insert',
-        'javascript:compile',
-        'clean:dist',
-        'less:compile',
-        'replace'
-    ]);
+    grunt.registerTask('build', 'Creates a production-ready build of the course', function() {
+        var tasks;
+
+        if (grunt.option("newer")) {
+            tasks = [
+                '_log-vars',
+                'check-json',
+                'copy',
+                'handlebars',
+                'create-json-config',
+                'schema-defaults',
+                'tracking-insert',
+                'newer:javascript:compile',
+                'clean:dist',
+                'less:compile',
+                'replace'
+            ];
+        } else {
+            tasks = [
+                '_log-vars',
+                'check-json',
+                'clean:output',
+                'copy',
+                'handlebars',
+                'create-json-config',
+                'schema-defaults',
+                'tracking-insert',
+                'javascript:compile',
+                'clean:dist',
+                'less:compile',
+                'replace'
+            ];  
+        };
+
+        grunt.task.run(tasks);
+    });
 }

--- a/grunt/tasks/javascript.js
+++ b/grunt/tasks/javascript.js
@@ -12,7 +12,7 @@ module.exports = function(grunt) {
 		var options = this.options({});
 
 		if (options.plugins) {
-			var pluginsClientSidePatch = 'requirejs.config({map: { "*": { "extensions/extensions":"'+options.pluginsModule+'","menu/menu":"'+options.pluginsModule+'","theme/theme":"'+options.pluginsModule+'","components/components":"'+options.pluginsModule+'" } } });';
+			var pluginsClientSidePatch = '';
 
 			var doesPluginPathExists = true;
 			try {

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "grunt-contrib-watch": "~1.0.0",
     "grunt-jscs": "~2.8.0",
     "grunt-jsonlint": "~1.0.7",
+    "grunt-newer": "^1.2.0",
     "grunt-open": "~0.2.3",
     "grunt-replace": "~1.0.1",
     "jit-grunt": "~0.10.0",
@@ -147,8 +148,5 @@
     "time-grunt": "~1.3.0",
     "underscore": "~1.8.3",
     "underscore-deep-extend": "~1.1.4"
-  },
-  "dependencies": {
-    "grunt-newer": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -147,5 +147,8 @@
     "time-grunt": "~1.3.0",
     "underscore": "~1.8.3",
     "underscore-deep-extend": "~1.1.4"
+  },
+  "dependencies": {
+    "grunt-newer": "^1.2.0"
   }
 }

--- a/src/core/js/app.js
+++ b/src/core/js/app.js
@@ -17,17 +17,7 @@ require([
     'coreModels/questionModel',
     'coreJS/offlineStorage',
     'coreModels/lockingModel',
-    'velocity',
-    'imageReady',
-    'inview',
-    'handlebars',
-    'templates',
-    'jquery',
-    'scrollTo',
-    'components/components',
-    'extensions/extensions',
-    'menu/menu',
-    'theme/theme'
+    'plugins'
 ], function (Adapt, Router, Drawer, Device, PopupManager, Notify, Accessibility, NavigationView, AdaptCollection, ConfigModel, CourseModel, ContentObjectModel, ArticleModel, BlockModel, ComponentModel, QuestionModel) {
 
     // Append loading template and show

--- a/src/core/js/scriptLoader.js
+++ b/src/core/js/scriptLoader.js
@@ -19,6 +19,16 @@
                     coreCollections: 'core/js/collections',
                     coreHelpers: 'core/js/helpers'
                 }
+            },
+            paths: {
+                underscore: 'libraries/underscore',
+                backbone: 'libraries/backbone',
+                handlebars: 'libraries/handlebars',
+                velocity: 'libraries/velocity',
+                imageReady: 'libraries/imageReady',
+                inview: 'libraries/inview',
+                a11y: 'libraries/jquery.a11y',
+                scrollTo: 'libraries/scrollTo'
             }
         });
         loadJQuery();
@@ -41,8 +51,22 @@
         if(window.jQuery === undefined) {
             setTimeout(checkJQueryStatus, 100);
         } else {
-            loadAdapt();
+            loadFoundationLibraries();
         }
+    }
+
+    function loadFoundationLibraries() {
+        require([
+            "underscore",
+            "backbone",
+            "handlebars",
+            "velocity",
+            "imageReady",
+            "inview",
+            "a11y",
+            "scrollTo",
+            "templates"
+        ], loadAdapt);
     }
 
     //5. Load adapt


### PR DESCRIPTION
https://github.com/adaptlearning/adapt_framework/issues/1228

* made all libraries in src/core/libraries load before adapt.min.js
  - they load on an http request each rather than being compiled (old school style) - seems like a reasonable trade-off now that network speeds are pretty good

* removed unnecessary code references

* removed build license comments in favour of dropping output compression (roughly the same byte size but reduces the compile time by 4 seconds)

* allowed all plugins to have a "libraries" folder

* added grunt build --newer
  - no clean
  - rebuild javascript only when source has changed

javascript:dev takes 2.2seconds - down from 3
javascript:compile takes 5 seconds - down from 14