### PR TITLE
Remove additional px from topOffset variable

### DIFF
--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -169,7 +169,7 @@ define(function(require) {
 
         configureA11yLibrary: function() {
 
-            var topOffset = $('.navigation').height()+10;
+            var topOffset = $('.navigation').height();
             var bottomoffset = 0;
             $.a11y.options.focusOffsetTop = topOffset;
             $.a11y.options.focusOffsetBottom = bottomoffset;


### PR DESCRIPTION
Fix issue #1241 - a11y calculates component to be out of view from additional px added.