### PR TITLE
add a .ready property, a setReadyStatus method & ...

### DIFF
--- a/src/core/js/offlineStorage.js
+++ b/src/core/js/offlineStorage.js
@@ -1,11 +1,13 @@
 define([
-	'coreJS/adapt'
+	'core/js/adapt'
 ], function(Adapt) {
 
 	//Basic API for setting and getting name+value pairs
 	//Allows registration of a single handler.
 
 	Adapt.offlineStorage = {
+
+		ready: false,
 
 		initialize: function(handler) {
 			this._handler = handler;
@@ -19,6 +21,14 @@ define([
 		get: function(name) {
 			if (!(this._handler && this._handler.get)) return;
 			return this._handler.get.apply(this._handler, arguments);
+		},
+
+		/**
+		 * Some forms of offlineStorage could take time to initialise, this allows us to let plugins know when it's ready to be used 
+		 */
+		setReadyStatus: function() {
+			this.ready = true;
+			Adapt.trigger("offlineStorage:ready");
 		}
 
 	};


### PR DESCRIPTION
...an 'offlineStorage:ready' event to allow offlineStorage handlers to be able to notify plugins when the offlineStorage API is ready for use

part of a series of 3 PRs to address adaptlearning/adapt-contrib-languagePicker#5