### PR TITLE
startController fix for multilang courses

### DIFF
--- a/src/core/js/app.js
+++ b/src/core/js/app.js
@@ -1,22 +1,23 @@
 require([
-    'coreJS/adapt',
-    'coreJS/router',
-    'coreJS/drawer',
-    'coreJS/device',
-    'coreJS/popupManager',
-    'coreJS/notify',
-    'coreJS/accessibility',
-    'coreViews/navigationView',
-    'coreJS/adaptCollection',
-    'coreModels/configModel',
-    'coreModels/courseModel',
-    'coreModels/contentObjectModel',
-    'coreModels/articleModel',
-    'coreModels/blockModel',
-    'coreModels/componentModel',
-    'coreModels/questionModel',
-    'coreJS/offlineStorage',
-    'coreModels/lockingModel',
+    'core/js/adapt',
+    'core/js/router',
+    'core/js/startController',
+    'core/js/drawer',
+    'core/js/device',
+    'core/js/popupManager',
+    'core/js/notify',
+    'core/js/accessibility',
+    'core/js/views/navigationView',
+    'core/js/adaptCollection',
+    'core/js/models/configModel',
+    'core/js/models/courseModel',
+    'core/js/models/contentObjectModel',
+    'core/js/models/articleModel',
+    'core/js/models/blockModel',
+    'core/js/models/componentModel',
+    'core/js/models/questionModel',
+    'core/js/offlineStorage',
+    'core/js/models/lockingModel',
     'velocity',
     'imageReady',
     'inview',
@@ -28,7 +29,7 @@ require([
     'extensions/extensions',
     'menu/menu',
     'theme/theme'
-], function (Adapt, Router, Drawer, Device, PopupManager, Notify, Accessibility, NavigationView, AdaptCollection, ConfigModel, CourseModel, ContentObjectModel, ArticleModel, BlockModel, ComponentModel, QuestionModel) {
+], function (Adapt, Router, StartController, Drawer, Device, PopupManager, Notify, Accessibility, NavigationView, AdaptCollection, ConfigModel, CourseModel, ContentObjectModel, ArticleModel, BlockModel, ComponentModel, QuestionModel) {
 
     // Append loading template and show
     window.Handlebars = _.extend(require("handlebars"), window.Handlebars)
@@ -54,7 +55,13 @@ require([
                 Adapt.trigger('app:languageChanged', newLanguage);
 
                 _.defer(function() {
-                    Backbone.history.navigate('#/', { trigger: true, replace: true });
+                    var startController = new StartController();
+                    var hash = '#/';
+
+                    if (startController.isEnabled())
+                        hash = startController.getStartHash();
+                    
+                    Backbone.history.navigate(hash, { trigger: true, replace: true });
                 });
             }
 

--- a/src/core/js/app.js
+++ b/src/core/js/app.js
@@ -32,7 +32,7 @@ require([
 ], function (Adapt, Router, StartController, Drawer, Device, PopupManager, Notify, Accessibility, NavigationView, AdaptCollection, ConfigModel, CourseModel, ContentObjectModel, ArticleModel, BlockModel, ComponentModel, QuestionModel) {
 
     // Append loading template and show
-    window.Handlebars = _.extend(require("handlebars"), window.Handlebars)
+    window.Handlebars = _.extend(require("handlebars"), window.Handlebars);
 
     var template = Handlebars.templates['loading'];
     $('#wrapper').append(template());
@@ -162,9 +162,9 @@ require([
                 //use view+model object
                 var ViewModelObject = Adapt.componentStore[json._component];
 
-				if(!ViewModelObject) {
+                if(!ViewModelObject) {
                     throw new Error(json._component + ' component not found. Is it installed and included?');
-		        }
+                }
 
                 //if model defined for component use component model
                 if (ViewModelObject.model) {

--- a/src/core/js/startController.js
+++ b/src/core/js/startController.js
@@ -12,13 +12,15 @@ define([
 
         initialize: function() {
             this.model = new Backbone.Model(Adapt.course.get("_start"));
-
-            this.setStartLocation();
         },
 
         setStartLocation: function() {
             if (!this.isEnabled()) return;
 
+            window.location.hash = this.getStartHash();
+        },
+
+        getStartHash: function() {
             var startId = this.getStartId();
 
             var hasStartId = (startId)
@@ -43,7 +45,7 @@ define([
                 startHash = hasLocationHash ? window.location.hash : startHash;
             }
 
-            window.location.hash = startHash;
+            return startHash;
         },
 
         isEnabled: function() {
@@ -86,7 +88,8 @@ define([
     });
 
     Adapt.once("adapt:start", function() {
-        new StartController();
+        var startController = new StartController();
+        startController.setStartLocation();
     });
 
     return StartController;


### PR DESCRIPTION
changed format in require paths
refactored startController for better code reuse

when a new language is loaded, either navigate to startHash created by startController or default location