### PR TITLE
store defaultLang in offlineStorage

### DIFF
--- a/src/core/js/app.js
+++ b/src/core/js/app.js
@@ -56,6 +56,11 @@ require([
                 _.defer(function() {
                     Backbone.history.navigate('#/', { trigger: true, replace: true });
                 });
+            } else {
+                // make sure _defaultLanguage is stored in offlineStorage
+                if (Adapt.offlineStorage.get('lang') === undefined) {
+                    Adapt.offlineStorage.set('lang', Adapt.config.get('_defaultLanguage'));
+                }
             }
 
             if (typeof Adapt.course.get('_buttons').submit !== 'undefined') {


### PR DESCRIPTION
when the learner selects the language that is set as the defaultLanguage from the initial languagePicker, this language is not stored in offline storage

this commit fixes this

note:
Adapt.config.get('_defaultLanguage') is restored with the value from offlinestorage. Therefore the check for lang in offlineStorage is actually not needed, makes it clearer though what is intended.