### PR TITLE
 fix to ensure that the _start route is respected when changing language

### DIFF
--- a/src/core/js/app.js
+++ b/src/core/js/app.js
@@ -64,8 +64,9 @@ require([
                     var startController = new StartController();
                     var hash = '#/';
 
-                    if (startController.isEnabled())
-                        hash = startController.getStartHash();
+                    if (startController.isEnabled()) {
+                        hash = startController.getStartHash(true);
+                    }
                     
                     Backbone.history.navigate(hash, { trigger: true, replace: true });
                 });

--- a/src/core/js/app.js
+++ b/src/core/js/app.js
@@ -118,7 +118,7 @@ require([
             Adapt.off('adaptCollection:dataLoaded courseModel:dataLoaded');
 
         }
-    }
+    };
     
     function outputError(e) {
         //Allow plugin loading errors to output without stopping Adapt from loading
@@ -190,7 +190,7 @@ require([
             },
             url: courseFolder + "components.json"
         });
-    }
+    };
 
     function onLanguageChange(model, language) {
         Adapt.offlineStorage.set('lang', language);
@@ -215,6 +215,5 @@ require([
 
     // Events that are triggered by the main Adapt content collections and models
     Adapt.once('configModel:loadCourseData', onLoadCourseData);
-
 
 });

--- a/src/core/js/startController.js
+++ b/src/core/js/startController.js
@@ -1,5 +1,5 @@
 define([
-    'coreJS/adapt'
+    'core/js/adapt'
 ], function(Adapt) {
     
     var StartController = function() {
@@ -94,5 +94,4 @@ define([
 
     return StartController;
 
-
-})
+});

--- a/src/core/js/startController.js
+++ b/src/core/js/startController.js
@@ -20,7 +20,7 @@ define([
             window.location.hash = this.getStartHash();
         },
 
-        getStartHash: function() {
+        getStartHash: function(alwaysForce) {
             var startId = this.getStartId();
 
             var hasStartId = (startId)
@@ -28,7 +28,7 @@ define([
                 : false;
 
             var isRouteSpecified = (_.indexOf(window.location.href,"#") > -1);
-            var shouldForceStartId = this.model.get("_force");
+            var shouldForceStartId = alwaysForce || this.model.get("_force");
             var shouldNavigateToStartId = hasStartId && (!isRouteSpecified || shouldForceStartId);
 
             var startHash = "#/";


### PR DESCRIPTION
Currently, unless `_force` is set, when you change language, you always end up back at `/#`. Because the course is being reset, you should follow the route specified in the `_start` configuration - even when `_force` is not set