### PR TITLE
add startText to trickle button

### DIFF
--- a/src/course/en/blocks.json
+++ b/src/course/en/blocks.json
@@ -139,6 +139,7 @@
                 "_autoHide": true,
                 "_className": "",
                 "text": "Continue",
+                "startText": "Begin",
                 "finalText": "Finish",
                 "_component": "trickle-button"
             },
@@ -171,6 +172,7 @@
                 "_autoHide": true,
                 "_className": "",
                 "text": "Continue",
+                "startText": "Begin",
                 "finalText": "Finish",
                 "_component": "trickle-button"
             },
@@ -203,6 +205,7 @@
                 "_autoHide": true,
                 "_className": "",
                 "text": "Continue",
+                "startText": "Begin",
                 "finalText": "Finish",
                 "_component": "trickle-button"
             },
@@ -235,6 +238,7 @@
                 "_autoHide": true,
                 "_className": "",
                 "text": "Continue",
+                "startText": "Begin",
                 "finalText": "Finish",
                 "_component": "trickle-button"
             },
@@ -267,6 +271,7 @@
                 "_autoHide": true,
                 "_className": "",
                 "text": "Continue",
+                "startText": "Begin",
                 "finalText": "Finish",
                 "_component": "trickle-button"
             },
@@ -299,6 +304,7 @@
                 "_autoHide": true,
                 "_className": "",
                 "text": "Continue",
+                "startText": "Begin",
                 "finalText": "Finish",
                 "_component": "trickle-button"
             },
@@ -331,6 +337,7 @@
                 "_autoHide": true,
                 "_className": "",
                 "text": "Continue",
+                "startText": "Begin",
                 "finalText": "Finish",
                 "_component": "trickle-button"
             },
@@ -363,6 +370,7 @@
                 "_autoHide": true,
                 "_className": "",
                 "text": "Continue",
+                "startText": "Begin",
                 "finalText": "Finish",
                 "_component": "trickle-button"
             },


### PR DESCRIPTION
add startText label to trickle buttons so that the export task can get the value and add to the language files

fixes #1282 