### PR TITLE
Corrects issue with phantom drawer displaying on a language change

### DIFF
--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -154,6 +154,8 @@ define([
 
     // Used to map ids to collections
     Adapt.setupMapping = function() {
+        // Clear any existing mappings.
+        Adapt.mappedIds = {};
 
         // Setup course Id
         Adapt.mappedIds[Adapt.course.get('_id')] = "course";

--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -49,7 +49,7 @@ define([
 
     Adapt.location = {};
     Adapt.componentStore = {};
-    var mappedIds = {};
+    Adapt.mappedIds = {};
 
     Adapt.initialize = _.once(function() {
 
@@ -156,7 +156,7 @@ define([
     Adapt.setupMapping = function() {
 
         // Setup course Id
-        mappedIds[Adapt.course.get('_id')] = "course";
+        Adapt.mappedIds[Adapt.course.get('_id')] = "course";
 
         // Setup each collection
         var collections = ["contentObjects", "articles", "blocks", "components"];
@@ -166,20 +166,16 @@ define([
             var models = Adapt[collection].models;
             for (var j = 0, lenj = models.length; j < lenj; j++) {
                 var model = models[j];
-                mappedIds[model.get('_id')] = collection;
+                Adapt.mappedIds[model.get('_id')] = collection;
 
             }
         }
 
     }
 
-    Adapt.resetMapping = function () {
-        mappedIds = {};
-    }
-
     Adapt.mapById = function(id) {
         // Returns collection name that contains this models Id
-        return mappedIds[id];
+        return Adapt.mappedIds[id];
     }
 
     Adapt.findById = function(id) {

--- a/src/core/js/app.js
+++ b/src/core/js/app.js
@@ -47,7 +47,6 @@ require([
             mapAdaptIdsToObjects();
 
             if (isLanguageChange) {
-                Adapt.trigger('app:languageChanged', language);
 
                 _.defer(function() {
                     var startController = new StartController();
@@ -90,6 +89,8 @@ require([
             }
             
             Adapt.setupMapping();
+
+            isLanguageChange && Adapt.trigger('app:languageChanged', language);
             
             try {
                 Adapt.trigger('app:dataReady');
@@ -111,6 +112,9 @@ require([
     }
 
     function mapAdaptIdsToObjects () {
+        // Clear any existing mappings, as they are no longer valid.
+        Adapt.mappedIds = {};
+
         Adapt.contentObjects._byAdaptID = Adapt.contentObjects.groupBy("_id");
         Adapt.articles._byAdaptID = Adapt.articles.groupBy("_id");
         Adapt.blocks._byAdaptID = Adapt.blocks.groupBy("_id");

--- a/src/core/js/app.js
+++ b/src/core/js/app.js
@@ -91,7 +91,7 @@ require([
                     Backbone.history.navigate(hash, { trigger: true, replace: true });
                 });
             }
-            
+
             try {
                 Adapt.trigger('app:dataReady');
             } catch(e) {
@@ -112,9 +112,6 @@ require([
     }
 
     function mapAdaptIdsToObjects () {
-        // Clear any existing mappings, as they are no longer valid.
-        Adapt.mappedIds = {};
-
         Adapt.contentObjects._byAdaptID = Adapt.contentObjects.groupBy("_id");
         Adapt.articles._byAdaptID = Adapt.articles.groupBy("_id");
         Adapt.blocks._byAdaptID = Adapt.blocks.groupBy("_id");

--- a/src/core/js/app.js
+++ b/src/core/js/app.js
@@ -46,20 +46,6 @@ require([
 
             mapAdaptIdsToObjects();
 
-            if (isLanguageChange) {
-
-                _.defer(function() {
-                    var startController = new StartController();
-                    var hash = '#/';
-
-                    if (startController.isEnabled()) {
-                        hash = startController.getStartHash(true);
-                    }
-                    
-                    Backbone.history.navigate(hash, { trigger: true, replace: true });
-                });
-            }
-
             if (typeof Adapt.course.get('_buttons').submit !== 'undefined') {
                 // Backwards compatibility with v1.x
                 var oldButtons = Adapt.course.get('_buttons');
@@ -89,8 +75,22 @@ require([
             }
             
             Adapt.setupMapping();
+            
+            if (isLanguageChange) {
 
-            isLanguageChange && Adapt.trigger('app:languageChanged', language);
+                Adapt.trigger('app:languageChanged', language);
+
+                _.defer(function() {
+                    var startController = new StartController();
+                    var hash = '#/';
+
+                    if (startController.isEnabled()) {
+                        hash = startController.getStartHash(true);
+                    }
+                    
+                    Backbone.history.navigate(hash, { trigger: true, replace: true });
+                });
+            }
             
             try {
                 Adapt.trigger('app:dataReady');

--- a/src/core/js/drawer.js
+++ b/src/core/js/drawer.js
@@ -23,7 +23,7 @@ define(function(require) {
 
 		Adapt.on('app:languageChanged', function() {
 			drawerView.remove();
-			drawerView = new DrawerView({collection: DrawerCollection, forceCheckVisibility: true});
+			drawerView = new DrawerView({collection: DrawerCollection});
 		});
 	};
 

--- a/src/core/js/drawer.js
+++ b/src/core/js/drawer.js
@@ -23,7 +23,7 @@ define(function(require) {
 
 		Adapt.on('app:languageChanged', function() {
 			drawerView.remove();
-			drawerView = new DrawerView({collection: DrawerCollection}); 
+			drawerView = new DrawerView({collection: DrawerCollection, forceCheckVisibility: true});
 		});
 	};
 

--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -92,9 +92,11 @@ define(function(require) {
         },
 
         checkIfDrawerIsAvailable: function() {
-            if(this.collection.length == 0) {
+            if (this.collection.length == 0) {
                 $('.navigation-drawer-toggle-button').addClass('display-none');
                 Adapt.trigger('drawer:noItems');
+            } else {
+                $('.navigation-drawer-toggle-button').removeClass('display-none');
             }
         },
 

--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -8,8 +8,10 @@ define(function(require) {
         className: 'drawer display-none',
         disableAnimation: false,
         escapeKeyAttached: false,
+        forceCheckVisibility: false,
 
-        initialize: function() {
+        initialize: function(options) {
+            this.forceCheckVisibility = options.forceCheckVisibility || false;
             this.disableAnimation = Adapt.config.has('_disableAnimation') ? Adapt.config.get('_disableAnimation') : false;
             this._isVisible = false;
             this.drawerDir = 'right';
@@ -78,6 +80,10 @@ define(function(require) {
         // Set tabindex for select elements
         postRender: function() {
             this.$('a, button, input, select, textarea').attr('tabindex', -1);
+
+            if (this.forceCheckVisibility) {
+                this.checkIfDrawerIsAvailable();
+            }
         },
 
         openCustomView: function(view, hasBackButton) {

--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -27,7 +27,6 @@ define(function(require) {
         setupEventListeners: function() {
             this.listenTo(Adapt, 'navigation:toggleDrawer', this.toggleDrawer);
             this.listenTo(Adapt, 'drawer:triggerCustomView', this.openCustomView);
-            this.listenTo(Adapt, 'app:dataReady', this.checkIfDrawerIsAvailable);
             this.listenTo(Adapt, 'drawer:closeDrawer', this.onCloseDrawer);
             this.listenTo(Adapt, 'remove', this.onCloseDrawer);
             this.listenTo(Adapt, 'accessibility:toggle', this.onAccessibilityToggle);

--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -9,7 +9,7 @@ define(function(require) {
         disableAnimation: false,
         escapeKeyAttached: false,
 
-        initialize: function(options) {
+        initialize: function() {
             this.disableAnimation = Adapt.config.has('_disableAnimation') ? Adapt.config.get('_disableAnimation') : false;
             this._isVisible = false;
             this.drawerDir = 'right';

--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -8,7 +8,6 @@ define(function(require) {
         className: 'drawer display-none',
         disableAnimation: false,
         escapeKeyAttached: false,
-        forceCheckVisibility: false,
 
         initialize: function(options) {
             this.forceCheckVisibility = options.forceCheckVisibility || false;
@@ -29,7 +28,7 @@ define(function(require) {
         setupEventListeners: function() {
             this.listenTo(Adapt, 'navigation:toggleDrawer', this.toggleDrawer);
             this.listenTo(Adapt, 'drawer:triggerCustomView', this.openCustomView);
-            this.listenToOnce(Adapt, 'adapt:initialize', this.checkIfDrawerIsAvailable);
+            this.listenTo(Adapt, 'app:dataReady', this.checkIfDrawerIsAvailable);
             this.listenTo(Adapt, 'drawer:closeDrawer', this.onCloseDrawer);
             this.listenTo(Adapt, 'remove', this.onCloseDrawer);
             this.listenTo(Adapt, 'accessibility:toggle', this.onAccessibilityToggle);
@@ -80,10 +79,6 @@ define(function(require) {
         // Set tabindex for select elements
         postRender: function() {
             this.$('a, button, input, select, textarea').attr('tabindex', -1);
-
-            if (this.forceCheckVisibility) {
-                this.checkIfDrawerIsAvailable();
-            }
         },
 
         openCustomView: function(view, hasBackButton) {

--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -10,7 +10,6 @@ define(function(require) {
         escapeKeyAttached: false,
 
         initialize: function(options) {
-            this.forceCheckVisibility = options.forceCheckVisibility || false;
             this.disableAnimation = Adapt.config.has('_disableAnimation') ? Adapt.config.get('_disableAnimation') : false;
             this._isVisible = false;
             this.drawerDir = 'right';
@@ -79,6 +78,8 @@ define(function(require) {
         // Set tabindex for select elements
         postRender: function() {
             this.$('a, button, input, select, textarea').attr('tabindex', -1);
+
+            this.checkIfDrawerIsAvailable();
         },
 
         openCustomView: function(view, hasBackButton) {

--- a/src/core/templates/navigation.hbs
+++ b/src/core/templates/navigation.hbs
@@ -1,5 +1,5 @@
 {{! All links in the nav bar should have an attritbue of data-event, navigationView uses this to fire a global event}}
 <div class="navigation-inner clearfix" role="navigation" aria-label="{{_globals._accessibility._ariaLabels.navigation}}">
     <button class="base navigation-back-button icon icon-controls-small-left" data-event="backButton" role="button" aria-label="{{_globals._accessibility._ariaLabels.previous}}"></button>
-    <button class="base navigation-drawer-toggle-button icon icon-list" data-event="toggleDrawer" role="button" aria-label="{{_globals._accessibility._ariaLabels.navigationDrawer}}"></button>
+    <button class="base navigation-drawer-toggle-button icon icon-list display-none" data-event="toggleDrawer" role="button" aria-label="{{_globals._accessibility._ariaLabels.navigationDrawer}}"></button>
 </div>


### PR DESCRIPTION
This appears to be because the drawer listens to the "adapt:initialize"
before checking that it has no items and should be hidden.

Since "adapt:initialize" should not be triggered more than once, I've added
a 'forceCheckVisibility' flag which forcees this check when the language
changes.
