### PR TITLE
Resolves #1312, performance improvement for Grunt copyMain task

### DIFF
--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -181,7 +181,7 @@ module.exports = function (grunt, options) {
                 },
                 {
                     expand: true,
-                    src: ['**/libraries/**/*'],
+                    src: ['components/**/libraries/**/*', 'extensions/**/libraries/**/*', 'menu/<%= menu %>/libraries/**/*', 'theme/<%= theme %>/libraries/**/*'],
                     cwd: '<%= sourcedir %>',
                     dest: '<%= outputdir %>/libraries/',
                     filter: function(filepath) {
@@ -194,7 +194,7 @@ module.exports = function (grunt, options) {
                 },
                 {
                     expand: true,
-                    src: ['**/required/**/*'],
+                    src: ['components/**/required/**/*', 'extensions/**/required/**/*', 'menu/<%= menu %>/required/**/*', 'theme/<%= theme %>/required/**/*'],
                     cwd: '<%= sourcedir %>',
                     dest: '<%= outputdir %>',
                     filter: function(filepath) {


### PR DESCRIPTION
Replacing the **/* wildcard with the specific folder names to search in for the 'required' and 'libraries' folders.