### PR TITLE
issue1100

### DIFF
--- a/src/core/js/views/adaptView.js
+++ b/src/core/js/views/adaptView.js
@@ -12,6 +12,7 @@ define([
             this._isRemoved = false;
             this.preRender();
             this.render();
+            this.setupOnScreenHandler();
         },
 
         preRender: function() {},
@@ -36,6 +37,25 @@ define([
             }, this));
 
             return this;
+        },
+
+        setupOnScreenHandler: function() {
+            var onscreen = this.model.get('_onScreen');
+
+            if (onscreen && onscreen._isEnabled) {
+
+                this.$el.on('onscreen', _.bind(function (e, m) {
+
+                    if (!m.onscreen) return;
+
+                    var minVerticalInview = onscreen._percentInviewVertical || 33;
+
+                    if (m.percentInviewVertical < minVerticalInview) return;
+
+                    this.$el.addClass( onscreen._classes || 'onscreen' ).off('onscreen');
+
+                }, this));
+            }
         },
 
         addChildren: function() {
@@ -93,6 +113,7 @@ define([
         },
 
         remove: function() {
+            this.$el.off('onscreen');
             this._isRemoved = true;
             this.model.setOnChildren('_isReady', false);
             this.model.set('_isReady', false);

--- a/src/core/js/views/adaptView.js
+++ b/src/core/js/views/adaptView.js
@@ -42,20 +42,19 @@ define([
         setupOnScreenHandler: function() {
             var onscreen = this.model.get('_onScreen');
 
-            if (onscreen && onscreen._isEnabled) {
+            if (!onscreen || !onscreen._isEnabled) return;
 
-                this.$el.on('onscreen', _.bind(function (e, m) {
+            this.$el.on('onscreen', _.bind(function (e, m) {
 
-                    if (!m.onscreen) return;
+                if (!m.onscreen) return;
 
-                    var minVerticalInview = onscreen._percentInviewVertical || 33;
+                var minVerticalInview = onscreen._percentInviewVertical || 33;
 
-                    if (m.percentInviewVertical < minVerticalInview) return;
+                if (m.percentInviewVertical < minVerticalInview) return;
 
-                    this.$el.addClass( onscreen._classes || 'onscreen' ).off('onscreen');
+                this.$el.addClass( onscreen._classes || 'onscreen' ).off('onscreen');
 
-                }, this));
-            }
+            }, this));
         },
 
         addChildren: function() {

--- a/src/core/js/views/adaptView.js
+++ b/src/core/js/views/adaptView.js
@@ -44,7 +44,7 @@ define([
 
             if (!onscreen || !onscreen._isEnabled) return;
 
-            this.$el.on('onscreen', _.bind(function (e, m) {
+            this.$el.on('onscreen.adaptView', _.bind(function (e, m) {
 
                 if (!m.onscreen) return;
 
@@ -52,7 +52,7 @@ define([
 
                 if (m.percentInviewVertical < minVerticalInview) return;
 
-                this.$el.addClass( onscreen._classes || 'onscreen' ).off('onscreen');
+                this.$el.addClass( onscreen._classes || 'onscreen' ).off('onscreen.adaptView');
 
             }, this));
         },
@@ -112,7 +112,7 @@ define([
         },
 
         remove: function() {
-            this.$el.off('onscreen');
+            this.$el.off('onscreen.adaptView');
             this._isRemoved = true;
             this.model.setOnChildren('_isReady', false);
             this.model.set('_isReady', false);

--- a/src/core/js/views/blockView.js
+++ b/src/core/js/views/blockView.js
@@ -11,40 +11,6 @@ define([
             + " " + this.setVisibility()
             + " nth-child-"
             + this.model.get("_nthChild");
-        },
-
-        onscreen: function(event, measurement) {
-            if (measurement.onscreen === false) return;
-
-            var onScreenConfig = this.model.get('_onScreen');
-            var classes = onScreenConfig._classes || 'onscreen';
-            var percentInviewVertical = onScreenConfig._percentInviewVertical || 33;
-
-            if (measurement.percentInviewVertical >= percentInviewVertical) {
-                this.$el.addClass(classes).off('onscreen');
-            }
-        },
-
-        enableOnScreen: function() {            
-            if (this.model.has('_onScreen')) {
-                if (this.model.get('_onScreen')._isEnabled === true) {
-                    return true;
-                }
-            }
-            return false;
-        },
-
-        postRender: function() {
-            if (this.enableOnScreen()) {
-                this.$el.on('onscreen', _.bind(this.onscreen, this));
-            }
-
-            AdaptView.prototype.postRender.apply(this, arguments);
-        },
-
-        remove: function() {
-            this.$el.off('onscreen');
-            AdaptView.prototype.remove.apply(this, arguments);
         }
 
     }, {

--- a/src/core/js/views/blockView.js
+++ b/src/core/js/views/blockView.js
@@ -1,6 +1,6 @@
-define(function(require) {
-
-	var AdaptView = require('coreViews/adaptView');
+define([
+    'core/js/views/adaptView'
+    ], function(AdaptView) {
 
     var BlockView = AdaptView.extend({
 
@@ -11,6 +11,40 @@ define(function(require) {
             + " " + this.setVisibility()
             + " nth-child-"
             + this.model.get("_nthChild");
+        },
+
+        onscreen: function(event, measurement) {
+            if (measurement.onscreen === false) return;
+
+            var onScreenConfig = this.model.get('_onScreen');
+            var classes = onScreenConfig._classes || 'onscreen';
+            var percentInviewVertical = onScreenConfig._percentInviewVertical || 33;
+
+            if (measurement.percentInviewVertical >= percentInviewVertical) {
+                this.$el.addClass(classes).off('onscreen');
+            }
+        },
+
+        enableOnScreen: function() {            
+            if (this.model.has('_onScreen')) {
+                if (this.model.get('_onScreen')._isEnabled === true) {
+                    return true;
+                }
+            }
+            return false;
+        },
+
+        postRender: function() {
+            if (this.enableOnScreen()) {
+                this.$el.on('onscreen', _.bind(this.onscreen, this));
+            }
+
+            AdaptView.prototype.postRender.apply(this, arguments);
+        },
+
+        remove: function() {
+            this.$el.off('onscreen');
+            AdaptView.prototype.remove.apply(this, arguments);
         }
 
     }, {


### PR DESCRIPTION
Update blockView to add css class if element is onScreen.

Block config:
```
{
        "_id": "b-05",
        "_parentId": "a-05",
        "_type": "block",
        "_classes": "animated",
        "title": "b-05",
        "displayTitle": "",
        "body": "",
        "_trackingId": 0,
        "_onScreen": {
            "_isEnabled": true,
            "_classes": "wobble",
            "_percentInviewVertical": 50  // defaults to 33%
        }
    }
```
Disabled by default.
The block config shows example using animate.css animtions.