### PR TITLE
Defers parsing the config JSON until the replace task runs (fixes #1324)

### DIFF
--- a/grunt/config/replace.js
+++ b/grunt/config/replace.js
@@ -10,75 +10,69 @@ module.exports = function (grunt, options) {
     courseDir = path.join(options.outputdir, 'course');
   }
 
-  var pathToConfig = path.join(courseDir, 'config.json')
+  var pathToConfig = path.join(courseDir, 'config.json');
 
-  try {
-    // Verify that the configuration file exists.
-    fs.accessSync(pathToConfig);
-    
-    var configJson = grunt.file.readJSON(pathToConfig);
-    var defaultLanguage = configJson._defaultLanguage || 'en';
-    var courseJson = grunt.file.readJSON(path.join(courseDir, defaultLanguage, 'course.json'));
-    
-    // Backwards compatibility for courses missing 'description'
-    if (!courseJson.hasOwnProperty('description')) {
-      courseJson.description = '';
-    }
-
-    // A shim for edge cases where xAPI has not been configured.
-    if (!configJson.hasOwnProperty('_xapi')) {
-      configJson._xapi = {
-        '_activityID': '',
-        '_isEnabled': false
-      };
-    } else {
-      // xAPI has been enabled, check if the activityID has been set.
-      if (configJson._xapi.hasOwnProperty('_activityID') && configJson._xapi._activityID == '') {
-        grunt.log.writeln('WARNING: xAPI activityID has not been set');
+  var generatePatterns = function() {
+    try {
+      // Verify that the configuration file exists.
+      fs.accessSync(pathToConfig);
+      
+      var configJson = grunt.file.readJSON(pathToConfig);
+      var defaultLanguage = configJson._defaultLanguage || 'en';
+      var courseJson = grunt.file.readJSON(path.join(courseDir, defaultLanguage, 'course.json'));
+      
+      // Backwards compatibility for courses missing 'description'
+      if (!courseJson.hasOwnProperty('description')) {
+        courseJson.description = '';
       }
+
+      // A shim for edge cases where xAPI has not been configured.
+      if (!configJson.hasOwnProperty('_xapi')) {
+        configJson._xapi = {
+          '_activityID': '',
+          '_isEnabled': false
+        };
+      } else {
+        // xAPI has been enabled, check if the activityID has been set.
+        if (configJson._xapi.hasOwnProperty('_activityID') && configJson._xapi._activityID == '') {
+          grunt.log.writeln('WARNING: xAPI activityID has not been set');
+        }
+      }
+
+      // Ensure that only whitelisted attributes can be replaced.
+      courseJson = _.pick(courseJson, 'title', 'displayTitle', 'body', 'description');
+      configJson = _.pick(configJson, '_xapi', '_spoor');
+      
+      // Combine the course and config JSON so both can be passed to replace.  
+      return {
+        'course': courseJson,
+        'config': configJson
+      };
+    } catch (ex) {
+      return {};
     }
+  };
 
-    // Ensure that only whitelisted attributes can be replaced.
-    courseJson = _.pick(courseJson, 'title', 'displayTitle', 'body', 'description');
-    configJson = _.pick(configJson, '_xapi', '_spoor');
-    
-    // Combine the course and config JSON so both can be passed to replace.  
-    var json = {
-      'course': courseJson,
-      'config': configJson
-    };
-
-    return {
-      dist: {
-        options: {
-          silent: true,
-          patterns: [
-            {
-              json: json
-            }
-          ]
-        },
-        files: [
+  return {
+    dist: {
+      options: {
+        silent: true,
+        patterns: [
           {
-            expand: true,
-            flatten: true,
-            src: [path.join(options.outputdir, '*.xml')],
-            dest: options.outputdir
+            json: function (done) {
+              done(generatePatterns());
+            }
           }
         ]
-      }
+      },
+      files: [
+        {
+          expand: true,
+          flatten: true,
+          src: [path.join(options.outputdir, '*.xml')],
+          dest: options.outputdir
+        }
+      ]
     }
-  } catch(ex) {
-    // If it does not, early return an empty configuration object, 
-    // so the replace task can still run.
-    return {
-      dist: {
-        options: {
-          silent: true,
-          patterns: []
-        },
-        files: []
-      }
-    }
-  }
+  };
 }


### PR DESCRIPTION
It appears that when the replace task is loaded, it immediately goes and searches for the config JSON file, but that file isn't built yet.

Parsing the config JSON needs to be deferred until the replace task executes.

(refer to issue #1324)