### PR TITLE
Added ES5 shim for IE 8

### DIFF
--- a/src/core/js/libraries/es5-shim.min.js
+++ b/src/core/js/libraries/es5-shim.min.js
@@ -1,0 +1,78 @@
+/**
+https://github.com/inexorabletash/polyfill/blob/master/es5.js, 24th November 2016
+
+https://github.com/inexorabletash/polyfill/blob/master/LICENSE.md
+*/
+Object.getPrototypeOf||(Object.getPrototypeOf=function(t){if(t!==Object(t))throw TypeError("Object.getPrototypeOf called on non-object")
+return t.__proto__||t.constructor.prototype||Object.prototype}),"function"!=typeof Object.getOwnPropertyNames&&(Object.getOwnPropertyNames=function(t){if(t!==Object(t))throw TypeError("Object.getOwnPropertyNames called on non-object")
+var r,e=[]
+for(r in t)Object.prototype.hasOwnProperty.call(t,r)&&e.push(r)
+return e}),"function"!=typeof Object.create&&(Object.create=function(t,r){function e(){}if("object"!=typeof t)throw TypeError()
+e.prototype=t
+var o=new e
+if(t&&(o.constructor=e),void 0!==r){if(r!==Object(r))throw TypeError()
+Object.defineProperties(o,r)}return o}),function(){if(!Object.defineProperty||!function(){try{return Object.defineProperty({},"x",{}),!0}catch(t){return!1}}()){var t=Object.defineProperty
+Object.defineProperty=function(r,e,o){if(t)try{return t(r,e,o)}catch(n){}if(r!==Object(r))throw TypeError("Object.defineProperty called on non-object")
+return Object.prototype.__defineGetter__&&"get"in o&&Object.prototype.__defineGetter__.call(r,e,o.get),Object.prototype.__defineSetter__&&"set"in o&&Object.prototype.__defineSetter__.call(r,e,o.set),"value"in o&&(r[e]=o.value),r}}}(),"function"!=typeof Object.defineProperties&&(Object.defineProperties=function(t,r){if(t!==Object(t))throw TypeError("Object.defineProperties called on non-object")
+var e
+for(e in r)Object.prototype.hasOwnProperty.call(r,e)&&Object.defineProperty(t,e,r[e])
+return t}),Object.keys||(Object.keys=function(t){if(t!==Object(t))throw TypeError("Object.keys called on non-object")
+var r,e=[]
+for(r in t)Object.prototype.hasOwnProperty.call(t,r)&&e.push(r)
+return e}),Function.prototype.bind||(Function.prototype.bind=function(t){if("function"!=typeof this)throw TypeError("Bind must be called on a function")
+var r=Array.prototype.slice.call(arguments,1),e=this,o=function(){},n=function(){return e.apply(this instanceof o?this:t,r.concat(Array.prototype.slice.call(arguments)))}
+return this.prototype&&(o.prototype=this.prototype),n.prototype=new o,n}),Array.isArray=Array.isArray||function(t){return!(!t||"[object Array]"!==Object.prototype.toString.call(Object(t)))},Array.prototype.indexOf||(Array.prototype.indexOf=function(t){if(void 0===this||null===this)throw TypeError()
+var r=Object(this),e=r.length>>>0
+if(0===e)return-1
+var o=0
+if(arguments.length>0&&(o=+arguments[1],isNaN(o)?o=0:0!==o&&o!==1/0&&o!==-(1/0)&&(o=(o>0||-1)*Math.floor(Math.abs(o)))),o>=e)return-1
+for(var n=o>=0?o:Math.max(e-Math.abs(o),0);e>n;n++)if(n in r&&r[n]===t)return n
+return-1}),Array.prototype.lastIndexOf||(Array.prototype.lastIndexOf=function(t){if(void 0===this||null===this)throw TypeError()
+var r=Object(this),e=r.length>>>0
+if(0===e)return-1
+var o=e
+arguments.length>1&&(o=+arguments[1],o!==o?o=0:0!==o&&o!==1/0&&o!==-(1/0)&&(o=(o>0||-1)*Math.floor(Math.abs(o))))
+for(var n=o>=0?Math.min(o,e-1):e-Math.abs(o);n>=0;n--)if(n in r&&r[n]===t)return n
+return-1}),Array.prototype.every||(Array.prototype.every=function(t){if(void 0===this||null===this)throw TypeError()
+var r=Object(this),e=r.length>>>0
+if("function"!=typeof t)throw TypeError()
+var o,n=arguments[1]
+for(o=0;e>o;o++)if(o in r&&!t.call(n,r[o],o,r))return!1
+return!0}),Array.prototype.some||(Array.prototype.some=function(t){if(void 0===this||null===this)throw TypeError()
+var r=Object(this),e=r.length>>>0
+if("function"!=typeof t)throw TypeError()
+var o,n=arguments[1]
+for(o=0;e>o;o++)if(o in r&&t.call(n,r[o],o,r))return!0
+return!1}),Array.prototype.forEach||(Array.prototype.forEach=function(t){if(void 0===this||null===this)throw TypeError()
+var r=Object(this),e=r.length>>>0
+if("function"!=typeof t)throw TypeError()
+var o,n=arguments[1]
+for(o=0;e>o;o++)o in r&&t.call(n,r[o],o,r)}),Array.prototype.map||(Array.prototype.map=function(t){if(void 0===this||null===this)throw TypeError()
+var r=Object(this),e=r.length>>>0
+if("function"!=typeof t)throw TypeError()
+var o=[]
+o.length=e
+var n,i=arguments[1]
+for(n=0;e>n;n++)n in r&&(o[n]=t.call(i,r[n],n,r))
+return o}),Array.prototype.filter||(Array.prototype.filter=function(t){if(void 0===this||null===this)throw TypeError()
+var r=Object(this),e=r.length>>>0
+if("function"!=typeof t)throw TypeError()
+var o,n=[],i=arguments[1]
+for(o=0;e>o;o++)if(o in r){var p=r[o]
+t.call(i,p,o,r)&&n.push(p)}return n}),Array.prototype.reduce||(Array.prototype.reduce=function(t){if(void 0===this||null===this)throw TypeError()
+var r=Object(this),e=r.length>>>0
+if("function"!=typeof t)throw TypeError()
+if(0===e&&1===arguments.length)throw TypeError()
+var o,n=0
+if(arguments.length>=2)o=arguments[1]
+else for(;;){if(n in r){o=r[n++]
+break}if(++n>=e)throw TypeError()}for(;e>n;)n in r&&(o=t.call(void 0,o,r[n],n,r)),n++
+return o}),Array.prototype.reduceRight||(Array.prototype.reduceRight=function(t){if(void 0===this||null===this)throw TypeError()
+var r=Object(this),e=r.length>>>0
+if("function"!=typeof t)throw TypeError()
+if(0===e&&1===arguments.length)throw TypeError()
+var o,n=e-1
+if(arguments.length>=2)o=arguments[1]
+else for(;;){if(n in this){o=this[n--]
+break}if(--n<0)throw TypeError()}for(;n>=0;)n in r&&(o=t.call(void 0,o,r[n],n,r)),n--
+return o}),String.prototype.trim||(String.prototype.trim=function(){return(this+"").replace(/^\s+/,"").replace(/\s+$/,"")}),Date.now||(Date.now=function(){return+new Date}),Date.prototype.toISOString||(Date.prototype.toISOString=function(){function t(t){return("00"+t).slice(-2)}function r(t){return("000"+t).slice(-3)}return this.getUTCFullYear()+"-"+t(this.getUTCMonth()+1)+"-"+t(this.getUTCDate())+"T"+t(this.getUTCHours())+":"+t(this.getUTCMinutes())+":"+t(this.getUTCSeconds())+"."+r(this.getUTCMilliseconds())+"Z"})

--- a/src/core/js/scriptLoader.js
+++ b/src/core/js/scriptLoader.js
@@ -85,7 +85,7 @@
         ], loadAdapt);
     }
 
-    //6. Load adapt
+    //7. Load adapt
     function loadAdapt() {
         switch (IE) {
         case 8: case 9:

--- a/src/core/js/scriptLoader.js
+++ b/src/core/js/scriptLoader.js
@@ -54,11 +54,23 @@
         if(window.jQuery === undefined) {
             setTimeout(checkJQueryStatus, 100);
         } else {
-            loadFoundationLibraries();
+            loadShim();
         }
     }
 
-    //5. Load foundation libraries and templates
+    //5. Load IE 8 shim
+    function loadShim() {
+        Modernizr.load([
+            {
+                test: IE == 8,
+                yep: 'libraries/es5-shim.min.js',
+                nope: '',
+                complete: loadFoundationLibraries()
+            }
+        ]);
+    }
+
+    //6. Load foundation libraries and templates
     function loadFoundationLibraries() {
         require([
             "underscore",

--- a/src/index.html
+++ b/src/index.html
@@ -11,9 +11,6 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 		<link href="adapt/css/adapt.css" type="text/css" rel="stylesheet">
 		<script src="libraries/modernizr.js" type="text/javascript"></script>
-		<!--[if lt IE 9 ]>
-		<script src="libraries/es5-shim.min.js" type="text/javascript"></script>
-		<![endif]-->
 		<script src="adapt/js/scriptLoader.js" type="text/javascript"></script>
 	</head>
 

--- a/src/index.html
+++ b/src/index.html
@@ -11,6 +11,9 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 		<link href="adapt/css/adapt.css" type="text/css" rel="stylesheet">
 		<script src="libraries/modernizr.js" type="text/javascript"></script>
+		<!--[if lt IE 9 ]>
+		<script src="libraries/es5-shim.min.js" type="text/javascript"></script>
+		<![endif]-->
 		<script src="adapt/js/scriptLoader.js" type="text/javascript"></script>
 	</head>
 


### PR DESCRIPTION
I've added the shim from https://github.com/inexorabletash/polyfill/blob/master/es5.js.

This provides implementations for:
- Object.getPrototypeOf
- Object getOwnPropertyNames
- Object.create
- Object.defineProperty
- Object.defineProperties
- Object.keys
- Function.prototype.bind
- Array.isArray
- Array.prototype.indexOf
- Array.prototype.lastIndexOf
- Array.prototype.every
- Array.prototype.some
- Array.prototype.forEach
- Array.prototype.map
- Array.prototype.filter
- Array.prototype.reduce
- Array.prototype.reduceRight
- String.prototype.trim
- Date.now
- Date.prototype.toISOString