### PR TITLE
add a data-adapt-id attribute to the HTML for pages, menus, articles, blocks + components

### DIFF
--- a/src/core/js/views/adaptView.js
+++ b/src/core/js/views/adaptView.js
@@ -1,8 +1,14 @@
 define([
-    'coreJS/adapt'
+    'core/js/adapt'
 ], function(Adapt) {
 
     var AdaptView = Backbone.View.extend({
+
+        attributes: function() {
+            return {
+                "data-adapt-id": this.model.get('_id')
+            };
+        },
 
         initialize: function() {
             this.listenTo(Adapt, 'remove', this.remove);

--- a/src/core/js/views/articleView.js
+++ b/src/core/js/views/articleView.js
@@ -4,13 +4,7 @@ define([
 ], function(AdaptView, BlockView) {
 
     var ArticleView = AdaptView.extend({
-
-        attributes: function() {
-            return {
-                "data-adapt-id": this.model.get('_id')
-            };
-        },
-
+        
         className: function() {
             return "article " +
             this.model.get('_id') +

--- a/src/core/js/views/articleView.js
+++ b/src/core/js/views/articleView.js
@@ -1,17 +1,23 @@
-define(function(require) {
-
-    var AdaptView = require('coreViews/adaptView');
-    var BlockView = require('coreViews/blockView');
+define([
+    'core/js/views/adaptView',
+    'core/js/views/blockView'
+], function(AdaptView, BlockView) {
 
     var ArticleView = AdaptView.extend({
 
+        attributes: function() {
+            return {
+                "data-adapt-id": this.model.get('_id')
+            };
+        },
+
         className: function() {
-            return "article "
-            + this.model.get('_id')
-            + " " + this.model.get('_classes')
-            + " " + this.setVisibility()
-            + " nth-child-"
-            + this.model.get("_nthChild");
+            return "article " +
+            this.model.get('_id') +
+            " " + this.model.get('_classes') +
+            " " + this.setVisibility() +
+            " nth-child-" +
+            this.model.get("_nthChild");
         }
 
     }, {

--- a/src/core/js/views/blockView.js
+++ b/src/core/js/views/blockView.js
@@ -4,12 +4,6 @@ define([
 
     var BlockView = AdaptView.extend({
 
-        attributes: function() {
-            return {
-                "data-adapt-id": this.model.get('_id')
-            };
-        },
-
         className: function() {
             return "block " + 
             this.model.get('_id') +

--- a/src/core/js/views/blockView.js
+++ b/src/core/js/views/blockView.js
@@ -1,16 +1,22 @@
 define([
     'core/js/views/adaptView'
-    ], function(AdaptView) {
+], function(AdaptView) {
 
     var BlockView = AdaptView.extend({
 
+        attributes: function() {
+            return {
+                "data-adapt-id": this.model.get('_id')
+            };
+        },
+
         className: function() {
-            return "block "
-            + this.model.get('_id')
-            + " " + this.model.get('_classes')
-            + " " + this.setVisibility()
-            + " nth-child-"
-            + this.model.get("_nthChild");
+            return "block " + 
+            this.model.get('_id') +
+            " " + this.model.get('_classes') + 
+            " " + this.setVisibility() +
+            " nth-child-" +
+            this.model.get("_nthChild");
         }
 
     }, {

--- a/src/core/js/views/componentView.js
+++ b/src/core/js/views/componentView.js
@@ -1,18 +1,24 @@
-define(function(require) {
-
-    var Adapt = require("coreJS/adapt");
-    var AdaptView = require('coreViews/adaptView');
+define([
+    'core/js/adapt',
+    'core/js/views/adaptView'
+], function(Adapt, AdaptView) {
 
     var ComponentView = AdaptView.extend({
 
+        attributes: function() {
+            return {
+                "data-adapt-id": this.model.get('_id')
+            };
+        },
+
         className: function() {
-            return "component "
-            + this.model.get('_component')
-            + "-component " + this.model.get('_id')
-            + " " + this.model.get('_classes')
-            + " " + this.setVisibility()
-            + " component-" + this.model.get('_layout')
-            + " nth-child-" + this.model.get("_nthChild");
+            return "component " + 
+            this.model.get('_component') + 
+            "-component " + this.model.get('_id') + 
+            " " + this.model.get('_classes') + 
+            " " + this.setVisibility() + 
+            " component-" + this.model.get('_layout') + 
+            " nth-child-" + this.model.get("_nthChild");
         },
 
         initialize: function(){

--- a/src/core/js/views/componentView.js
+++ b/src/core/js/views/componentView.js
@@ -5,12 +5,6 @@ define([
 
     var ComponentView = AdaptView.extend({
 
-        attributes: function() {
-            return {
-                "data-adapt-id": this.model.get('_id')
-            };
-        },
-
         className: function() {
             return "component " + 
             this.model.get('_component') + 

--- a/src/core/js/views/menuView.js
+++ b/src/core/js/views/menuView.js
@@ -5,12 +5,6 @@ define([
 
     var MenuView = AdaptView.extend({
 
-        attributes: function() {
-            return {
-                "data-adapt-id": this.model.get('_id')
-            };
-        },
-
     	className: function() {
             var visible = "visibility-hidden";
             if (this.model.get('_isVisible')) {

--- a/src/core/js/views/menuView.js
+++ b/src/core/js/views/menuView.js
@@ -1,20 +1,26 @@
-define(function(require) {
-
-    var AdaptView = require('coreViews/adaptView');
-    var Adapt = require('coreJS/adapt');
+define([
+    'core/js/adapt',
+    'core/js/views/adaptView'
+], function(Adapt, AdaptView) {
 
     var MenuView = AdaptView.extend({
+
+        attributes: function() {
+            return {
+                "data-adapt-id": this.model.get('_id')
+            };
+        },
 
     	className: function() {
             var visible = "visibility-hidden";
             if (this.model.get('_isVisible')) {
                 visible = "";
             }
-    		return 'menu '
-            + 'menu-'
-            + this.model.get('_id')
-            + " " + this.model.get('_classes')
-            + " " + this.setVisibility();
+    		return 'menu ' +
+            'menu-' +
+            this.model.get('_id') +
+            " " + this.model.get('_classes') +
+            " " + this.setVisibility();
     	},
 
         preRender: function() {

--- a/src/core/js/views/pageView.js
+++ b/src/core/js/views/pageView.js
@@ -5,12 +5,6 @@ define([
 ], function(Adapt, AdaptView, ArticleView) {
 
     var PageView = AdaptView.extend({
-
-        attributes: function() {
-            return {
-                "data-adapt-id": this.model.get('_id')
-            };
-        },
         
         className: function() {
             return "page " + 

--- a/src/core/js/views/pageView.js
+++ b/src/core/js/views/pageView.js
@@ -1,16 +1,22 @@
-define(function(require) {
-
-    var AdaptView = require('coreViews/adaptView');
-    var ArticleView = require('coreViews/articleView');
-    var Adapt = require('coreJS/adapt');
+define([
+    'core/js/adapt',
+    'core/js/views/adaptView',
+    'core/js/views/articleView'
+], function(Adapt, AdaptView, ArticleView) {
 
     var PageView = AdaptView.extend({
 
+        attributes: function() {
+            return {
+                "data-adapt-id": this.model.get('_id')
+            };
+        },
+        
         className: function() {
-            return "page "
-            + this.model.get('_id')
-            + " " + this.model.get('_classes')
-            + " " + this.setVisibility();
+            return "page " + 
+            this.model.get('_id') + 
+            " " + this.model.get('_classes') + 
+            " " + this.setVisibility();
         },
 
         preRender: function() {


### PR DESCRIPTION
see #1380

also switch to AMD style module definitions, stop using shortcut paths

move concatenation operators from beginning of lines to end of lines as JSHint's recommendation