### PR TITLE
Fix for Adapt.scrollTo 'jump' bug

### DIFF
--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -106,9 +106,11 @@ define([
         }
 
         var navigationHeight = $(".navigation").outerHeight();
+        // prevent scroll issue when component description aria-label coincident with top of component
+        var ariaLabelBuffer = $(selector.is('.component')) ? 5 : 0;
 
-        if (!settings.offset) settings.offset = { top: -navigationHeight, left: 0 };
-        if (settings.offset.top === undefined) settings.offset.top = -navigationHeight;
+        if (!settings.offset) settings.offset = { top: -navigationHeight - ariaLabelBuffer, left: 0 };
+        if (settings.offset.top === undefined) settings.offset.top = -navigationHeight - ariaLabelBuffer;
         if (settings.offset.left === undefined) settings.offset.left = 0;
 
         if (settings.offset.left === 0) settings.axis = "y";

--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -105,12 +105,15 @@ define([
             settings.duration = $.scrollTo.defaults.duration;
         }
 
-        var navigationHeight = $(".navigation").outerHeight();
+        var offsetTop = -$(".navigation").outerHeight();
         // prevent scroll issue when component description aria-label coincident with top of component
-        var ariaLabelBuffer = $(selector).is('.component') ? 5 : 0;
+        if (Adapt.config.get('_accessibility')._isActive &&
+            $(selector).hasClass('component')) {
+            offsetTop -= $(selector).find('.aria-label').height() || 0;
+        }
 
-        if (!settings.offset) settings.offset = { top: -navigationHeight - ariaLabelBuffer, left: 0 };
-        if (settings.offset.top === undefined) settings.offset.top = -navigationHeight - ariaLabelBuffer;
+        if (!settings.offset) settings.offset = { top: offsetTop, left: 0 };
+        if (settings.offset.top === undefined) settings.offset.top = offsetTop;
         if (settings.offset.left === undefined) settings.offset.left = 0;
 
         if (settings.offset.left === 0) settings.axis = "y";

--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -107,7 +107,7 @@ define([
 
         var navigationHeight = $(".navigation").outerHeight();
         // prevent scroll issue when component description aria-label coincident with top of component
-        var ariaLabelBuffer = $(selector.is('.component')) ? 5 : 0;
+        var ariaLabelBuffer = $(selector).is('.component') ? 5 : 0;
 
         if (!settings.offset) settings.offset = { top: -navigationHeight - ariaLabelBuffer, left: 0 };
         if (settings.offset.top === undefined) settings.offset.top = -navigationHeight - ariaLabelBuffer;


### PR DESCRIPTION
This fix addresses an issue when navigating to components via page-level progress in certain circumstances. If the component description aria-label is aligned to the top of the component div (as happens in certain art directions), Adapt.scrollTo would centre the top of the component within the viewport rather than at the top of the viewport. N.B. this issue is normally only replicable when accessibility has been activated.