### PR TITLE
issue-1461: stop grunt stripping whitespace from json

### DIFF
--- a/grunt/tasks/create-json-config.js
+++ b/grunt/tasks/create-json-config.js
@@ -34,6 +34,6 @@ module.exports = function(grunt) {
             }
         });
 
-        grunt.file.write(grunt.config('outputdir') + 'course/config.json', JSON.stringify(configJson, null, "    "));
+        grunt.file.write(grunt.config('outputdir') + 'course/config.json', JSON.stringify(configJson, null, 4));
     });
 }

--- a/grunt/tasks/create-json-config.js
+++ b/grunt/tasks/create-json-config.js
@@ -34,6 +34,6 @@ module.exports = function(grunt) {
             }
         });
 
-        grunt.file.write(grunt.config('outputdir') + 'course/config.json', JSON.stringify(configJson));
+        grunt.file.write(grunt.config('outputdir') + 'course/config.json', JSON.stringify(configJson, null, "    "));
     });
 }

--- a/grunt/tasks/less.js
+++ b/grunt/tasks/less.js
@@ -74,7 +74,7 @@ module.exports = function(grunt) {
 
 			function complete(error, output) {
 				if (error) {
-					grunt.fail.fatal(JSON.stringify(error, false, " "));
+					grunt.fail.fatal(JSON.stringify(error, null, 1));
 					return;
 				}
 

--- a/grunt/tasks/schema-defaults.js
+++ b/grunt/tasks/schema-defaults.js
@@ -63,7 +63,7 @@ module.exports = function(grunt) {
             var currentCourseJson = _.deepExtend(defaultsObject, grunt.file.readJSON(currentCourseJsonFile));
 
             //write modified course json to build
-            grunt.file.write(currentCourseJsonFile, JSON.stringify(currentCourseJson));
+            grunt.file.write(currentCourseJsonFile, JSON.stringify(currentCourseJson, null, "    "));
         });
     });
 }

--- a/grunt/tasks/schema-defaults.js
+++ b/grunt/tasks/schema-defaults.js
@@ -63,7 +63,7 @@ module.exports = function(grunt) {
             var currentCourseJson = _.deepExtend(defaultsObject, grunt.file.readJSON(currentCourseJsonFile));
 
             //write modified course json to build
-            grunt.file.write(currentCourseJsonFile, JSON.stringify(currentCourseJson, null, "    "));
+            grunt.file.write(currentCourseJsonFile, JSON.stringify(currentCourseJson, null, 4));
         });
     });
 }

--- a/grunt/tasks/tracking-insert.js
+++ b/grunt/tasks/tracking-insert.js
@@ -45,8 +45,8 @@ module.exports = function(grunt) {
             }
             course._latestTrackingId = options._latestTrackingId;
             grunt.log.writeln("Task complete. The latest tracking ID is " + course._latestTrackingId);
-            grunt.file.write(coursePath, JSON.stringify(course, null, "    "));
-            grunt.file.write(blocksPath, JSON.stringify(blocks, null, "    "));
+            grunt.file.write(coursePath, JSON.stringify(course, null, 4));
+            grunt.file.write(blocksPath, JSON.stringify(blocks, null, 4));
         }
         
     });

--- a/grunt/tasks/tracking-remove.js
+++ b/grunt/tasks/tracking-remove.js
@@ -14,8 +14,8 @@ module.exports = function(grunt) {
             }
             delete course._latestTrackingId;
             grunt.log.writeln("Tracking IDs removed.");
-            grunt.file.write(coursePath, JSON.stringify(course, null, "    "));
-            grunt.file.write(blocksPath, JSON.stringify(blocks, null, "    "));
+            grunt.file.write(coursePath, JSON.stringify(course, null, 4));
+            grunt.file.write(blocksPath, JSON.stringify(blocks, null, 4));
         }
         
         var blocksFiles = grunt.file.expand(options.blocksFile);

--- a/grunt/tasks/tracking-reset.js
+++ b/grunt/tasks/tracking-reset.js
@@ -28,8 +28,8 @@ module.exports = function(grunt) {
             }
             course._latestTrackingId = options._latestTrackingId;
             grunt.log.writeln("The latest tracking ID is " + course._latestTrackingId);
-            grunt.file.write(coursePath, JSON.stringify(course, null, "    "));
-            grunt.file.write(blocksPath, JSON.stringify(blocks, null, "    "));
+            grunt.file.write(coursePath, JSON.stringify(course, null, 4));
+            grunt.file.write(blocksPath, JSON.stringify(blocks, null, 4));
         }
 
     });

--- a/grunt/tasks/translate/exportFile.js
+++ b/grunt/tasks/translate/exportFile.js
@@ -70,7 +70,7 @@ module.exports = function (grunt) {
     }
     
     function _exportRaw (filename) {
-      grunt.file.write(path.join("languagefiles", grunt.config("translate.masterLang"), filename+".json"), JSON.stringify(global.translate.exportTextData," ", 4));
+      grunt.file.write(path.join("languagefiles", grunt.config("translate.masterLang"), filename+".json"), JSON.stringify(global.translate.exportTextData, null, 4));
       next();
     }
     

--- a/grunt/tasks/translate/saveCourseData.js
+++ b/grunt/tasks/translate/saveCourseData.js
@@ -16,7 +16,7 @@ module.exports = function (grunt) {
       "components"
     ].forEach(function (filename) {
       var src = path.join(srcPath, "course", targetLang, filename+".json");
-      grunt.file.write(src, JSON.stringify(global.translate.courseData[filename],"",4));
+      grunt.file.write(src, JSON.stringify(global.translate.courseData[filename], null, 4));
     });
     
   });


### PR DESCRIPTION
issue: https://github.com/adaptlearning/adapt_framework/issues/1461

* create-json-config and schema-defaults both inadvertently strip the whitespace from the course.json and config.json files making them unreadable, i've added spaces 4 pretty print
* have swapped all occurrences of JSON.stringify to use  (json, null, integer)

