### PR TITLE
Resolution to the #1463

### DIFF
--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -1,4 +1,22 @@
 module.exports = function (grunt, options) {
+    
+    
+    var renameAssets = function (destFolder, srcFileName) {
+        var collateAtName = "assets";
+        var collateAtFolder = collateAtName + "/";
+        var startOfCollatePath = srcFileName.indexOf(collateAtFolder) + collateAtFolder.length;
+        var collatedFilePath = destFolder + srcFileName.substr(startOfCollatePath);
+        //ignore the folder alone
+        var testEndsWithCollateName = new RegExp("((?:\\\\|\/)" + collateAtName + ")(?:$|\\\\$|\\\/$)");
+        if (testEndsWithCollateName.test(srcFileName)) {
+            //we have path ending with .../[name] or .../[name]/ discard it
+            return destFolder;
+        }
+        return collatedFilePath;
+    }
+    
+    
+    
     return {
         index: {
             files: [
@@ -54,19 +72,7 @@ module.exports = function (grunt, options) {
                         return grunt.config('helpers').includedFilter(filepath);
                     },
                     
-                    rename: function(destFolder, srcFileName) {
-                        var name = "assets",
-                            folder = name + "/",
-                            endOfFolder = srcFileName.indexOf(folder) + folder.length,
-                            output = destFolder + srcFileName.substr(endOfFolder);
-                        //ignore the folder alone
-                        var re = new RegExp("((?:\\\\|\/)" + name + ")(?:$|\\\\$|\\\/$)");
-                        if (re.test(srcFileName)) {
-                            //we have path ending with .../[name] or .../[name]/ discard it
-                            return destFolder;
-                        }
-                        return output;
-                    }
+                    rename: renameAssets
                 }
             ]
         },
@@ -93,19 +99,7 @@ module.exports = function (grunt, options) {
                         return grunt.config('helpers').includedFilter(filepath);
                     },
                     
-                    rename: function(destFolder, srcFileName) {
-                        var name = "assets",
-                            folder = name + "/",
-                            endOfFolder = srcFileName.indexOf(folder) + folder.length,
-                            output = destFolder + srcFileName.substr(endOfFolder);
-                        //ignore the folder alone
-                        var re = new RegExp("((?:\\\\|\/)" + name + ")(?:$|\\\\$|\\\/$)");
-                        if (re.test(srcFileName)) {
-                            //we have path ending with .../[name] or .../[name]/ discard it
-                            return destFolder;
-                        }
-                        return output;
-                    }
+                    rename: renameAssets
                 }
             ]
         },
@@ -132,19 +126,7 @@ module.exports = function (grunt, options) {
                         return grunt.config('helpers').includedFilter(filepath);
                     },
                     
-                    rename: function(destFolder, srcFileName) {
-                        var name = "assets",
-                            folder = name + "/",
-                            endOfFolder = srcFileName.indexOf(folder) + folder.length,
-                            output = destFolder + srcFileName.substr(endOfFolder);
-                        //ignore the folder alone
-                        var re = new RegExp("((?:\\\\|\/)" + name + ")(?:$|\\\\$|\\\/$)");
-                        if (re.test(srcFileName)) {
-                            //we have path ending with .../[name] or .../[name]/ discard it
-                            return destFolder;
-                        }
-                        return output;
-                    }
+                    rename: renameAssets
                 }
             ]
         },

--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -53,7 +53,20 @@ module.exports = function (grunt, options) {
                     filter: function(filepath) {
                         return grunt.config('helpers').includedFilter(filepath);
                     },
-                    flatten: true
+                    
+                    rename: function(destFolder, srcFileName) {
+                        var name = "assets",
+                            folder = name + "/",
+                            endOfFolder = srcFileName.indexOf(folder) + folder.length,
+                            output = destFolder + srcFileName.substr(endOfFolder);
+                        //ignore the folder alone
+                        var re = new RegExp("((?:\\\\|\/)" + name + ")(?:$|\\\\$|\\\/$)");
+                        if (re.test(srcFileName)) {
+                            //we have path ending with .../[name] or .../[name]/ discard it
+                            return destFolder;
+                        }
+                        return output;
+                    }
                 }
             ]
         },
@@ -79,7 +92,20 @@ module.exports = function (grunt, options) {
                     filter: function(filepath) {
                         return grunt.config('helpers').includedFilter(filepath);
                     },
-                    flatten: true
+                    
+                    rename: function(destFolder, srcFileName) {
+                        var name = "assets",
+                            folder = name + "/",
+                            endOfFolder = srcFileName.indexOf(folder) + folder.length,
+                            output = destFolder + srcFileName.substr(endOfFolder);
+                        //ignore the folder alone
+                        var re = new RegExp("((?:\\\\|\/)" + name + ")(?:$|\\\\$|\\\/$)");
+                        if (re.test(srcFileName)) {
+                            //we have path ending with .../[name] or .../[name]/ discard it
+                            return destFolder;
+                        }
+                        return output;
+                    }
                 }
             ]
         },
@@ -105,7 +131,20 @@ module.exports = function (grunt, options) {
                     filter: function(filepath) {
                         return grunt.config('helpers').includedFilter(filepath);
                     },
-                    flatten: true
+                    
+                    rename: function(destFolder, srcFileName) {
+                        var name = "assets",
+                            folder = name + "/",
+                            endOfFolder = srcFileName.indexOf(folder) + folder.length,
+                            output = destFolder + srcFileName.substr(endOfFolder);
+                        //ignore the folder alone
+                        var re = new RegExp("((?:\\\\|\/)" + name + ")(?:$|\\\\$|\\\/$)");
+                        if (re.test(srcFileName)) {
+                            //we have path ending with .../[name] or .../[name]/ discard it
+                            return destFolder;
+                        }
+                        return output;
+                    }
                 }
             ]
         },


### PR DESCRIPTION
Extending the solution used for 'required' and 'libraries' I've modified the copy routines for assets in components, extensions and menus. The regex used prevents the folder assets itself to be copied into the build assets.