### PR TITLE
issue/1521: remove navigation from #wrapper

### DIFF
--- a/src/core/js/app.js
+++ b/src/core/js/app.js
@@ -118,11 +118,24 @@ require([
             Adapt.log.error('Error during app:dataReady trigger', e);
         }
 
-        Adapt.navigation = new NavigationView();// This should be triggered after 'app:dataReady' as plugins might want to manipulate the navigation
+        addNavigationBar();
 
         Adapt.initialize();
 
         Adapt.off('adaptCollection:dataLoaded courseModel:dataLoaded');
+    }
+
+    function addNavigationBar() {
+
+        var adaptConfig = Adapt.course.get("_navigation");
+
+        if (adaptConfig && adaptConfig._isDefaultNavigationDisabled) {
+            Adapt.trigger("navigation:initialize");
+            return;
+        }
+
+        Adapt.navigation = new NavigationView();// This should be triggered after 'app:dataReady' as plugins might want to manipulate the navigation
+
     }
 
     function configureInview() {

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -15,6 +15,8 @@ define([
             this.showLoading();
             // Store #wrapper element to cache for later
             this.$wrapper = $('#wrapper');
+            this.$html = $('html');
+
             Adapt.once('app:dataReady', function() {
                 document.title = Adapt.course.get('title');
             });
@@ -309,6 +311,17 @@ define([
                     + ' location-id-'
                     + Adapt.location._currentId :
                     'location-' + Adapt.location._currentLocation;
+
+            var previousClasses = Adapt.location._previousClasses;
+            if (previousClasses) {
+                this.$html.removeClass(previousClasses);
+            }
+            Adapt.location._previousClasses = classes;
+
+            this.$html
+                .addClass(classes)
+                .attr('data-location', Adapt.location._currentLocation);
+                
             this.$wrapper
                 .removeClass()
                 .addClass(classes)

--- a/src/core/js/views/navigationView.js
+++ b/src/core/js/views/navigationView.js
@@ -29,7 +29,7 @@ define([
                     _globals: Adapt.course.get("_globals"),
                     _accessibility: Adapt.config.get("_accessibility")
                 }
-            )).appendTo('#wrapper');
+            )).insertBefore('#wrapper');
 
             _.defer(_.bind(function() {
                 Adapt.trigger('navigationView:postRender', this);


### PR DESCRIPTION
fixed #1521 

1. allow default navigation bar to be disabled ```course._navigation._isDefaultNavigationDisabled```
2. add ``navigation:initialize`` event for navigation bar plugins to know when to start
3. put ``#wrapper`` location classes on ``html`` tag to allow styling of navigation as usual
4. insert ``.navigation`` container before the ``#wrapper`` div so that the tab order is preserved