### PR TITLE
remove the call to event.stopPropagation

### DIFF
--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -519,9 +519,6 @@
         function onFocusCapture(event) {
             var options = $.a11y.options;
             var state = $.a11y.state;
-
-            //preventDefault(event);
-            event.stopPropagation();
             var $element = $(event.target);
             
             //search out intended click element


### PR DESCRIPTION
as it is preventing the select2 library used by [adapt-contrib-matching](https://github.com/adaptlearning/adapt-contrib-matching) from making sure only one `<select>` control can be open at once - fixes #1541