### PR TITLE
Follow symlinks when building templates

### DIFF
--- a/grunt/config/handlebars.js
+++ b/grunt/config/handlebars.js
@@ -21,6 +21,7 @@ module.exports = function(grunt) {
                         '<%= sourcedir %>menu/<%= menu %>/**/*.hbs',
                         '<%= sourcedir %>theme/<%= theme %>/**/*.hbs'
                     ],
+                    follow: true,
                     dest: '<%= outputdir %>templates.js',
                     filter: function(filepath) {
                         return grunt.config('helpers').includedFilter(filepath);


### PR DESCRIPTION
While developing plugins I will often symlink the plugin in to a test bed course. The grunt task for compiling templates was not following the symlink. This minor change addresses the issue.

https://github.com/isaacs/node-glob#options