### PR TITLE
Fixes #1561, corrects 'device:resize' on iOS devices

### DIFF
--- a/src/core/js/device.js
+++ b/src/core/js/device.js
@@ -126,8 +126,16 @@ define([
 
     var onWindowResize = _.debounce(function onScreenSizeChanged() {
         // Calculate the screen properties.
+        var previousWidth = Adapt.device.screenWidth;
+        var previousHeight = Adapt.device.screenHeight;
+
         Adapt.device.screenWidth = getScreenWidth();
         Adapt.device.screenHeight = getScreenHeight();
+
+        if (previousWidth === Adapt.device.screenWidth && previousHeight === Adapt.device.screenHeight) {
+            // Do not trigger a change if the viewport hasn't actually changed.  Scrolling on iOS will trigger a resize.
+            return;
+        }
 
         var newScreenSize = checkScreenSize();
 


### PR DESCRIPTION
Scroll events were triggering this due to the position of the address bar.  Given that the viewport size hasn't really changed this commit compares the height and width before and after the event, and only triggers device:resize if either have changed.