### PR TITLE
Fixes #1564 - Ensures core assets, fonts and templates are copied

### DIFF
--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -55,9 +55,7 @@ module.exports = function (grunt, options) {
                     expand: true,
                     src: ['<%= sourcedir %>core/assets/**'],
                     dest: '<%= outputdir %>adapt/css/assets/',
-                    filter: function(filepath) {
-                        return grunt.config('helpers').includedFilter(filepath);
-                    },
+                    filter: 'isFile',
                     flatten: true
                 }
             ]
@@ -136,9 +134,7 @@ module.exports = function (grunt, options) {
                     expand: true,
                     src: ['<%= sourcedir %>core/fonts/**'],
                     dest: '<%= outputdir %>adapt/css/fonts/',
-                    filter: function(filepath) {
-                        return grunt.config('helpers').includedFilter(filepath);
-                    },
+                    filter: 'isFile',
                     flatten: true
                 }
             ]

--- a/grunt/config/handlebars.js
+++ b/grunt/config/handlebars.js
@@ -25,7 +25,7 @@ module.exports = function(grunt) {
                     dest: '<%= outputdir %>templates.js',
                     filter: function(filepath) {
                         if (filepath.indexOf(grunt.config('sourcedir') + 'core/') > -1) {
-                            // Always include core teomplates.
+                            // Always include core templates.
                             return true;
                         }
 

--- a/grunt/config/handlebars.js
+++ b/grunt/config/handlebars.js
@@ -24,6 +24,11 @@ module.exports = function(grunt) {
                     follow: true,
                     dest: '<%= outputdir %>templates.js',
                     filter: function(filepath) {
+                        if (filepath.indexOf(grunt.config('sourcedir') + 'core/') > -1) {
+                            // Always include core teomplates.
+                            return true;
+                        }
+
                         return grunt.config('helpers').includedFilter(filepath);
                     }
                 }


### PR DESCRIPTION
The includedFilter() helper function would cause problems by running the filter on essential core files.  This affects the authoring tool where the config.json contains the list of plugins to include.