### PR TITLE
schema amends: change boolean selects to checkboxes 

### DIFF
--- a/src/core/schema/article.model.schema
+++ b/src/core/schema/article.model.schema
@@ -38,25 +38,22 @@
       "help": "Used to style or manipulate the look and feel of this Article. These are predefined in the theme."
     },
     "_isOptional": {
-      "type": "bool",
+      "type": "boolean",
       "default": "false",
       "isSetting": true,
-      "inputType": {
-        "type": "Boolean",
-        "options": [true, false]
-      },
+      "inputType": "Checkbox",
       "validators": [],
       "title": "Is this optional?",
-      "help": "If set to 'true' this article, any block, and components within it, do not have to be completed"
+      "help": "An optional article does not have to be completed, nor do any of the blocks and components contained within it."
     },
     "_isAvailable": {
-      "type": "bool",
+      "type": "boolean",
       "default": "true",
       "isSetting": true,
-      "inputType": {"type": "Boolean", "options": [true, false]},
+      "inputType": "Checkbox",
       "validators": [],
       "title": "Is this available?",
-      "help": "If set to 'false' this will not be displayed"
+      "help": "Controls whether this article and its contents are available in the course or not."
     },
     "_extensions": {
       "type": "object"

--- a/src/core/schema/article.model.schema
+++ b/src/core/schema/article.model.schema
@@ -39,7 +39,7 @@
     },
     "_isOptional": {
       "type": "boolean",
-      "default": "false",
+      "default": false,
       "isSetting": true,
       "inputType": "Checkbox",
       "validators": [],
@@ -48,7 +48,7 @@
     },
     "_isAvailable": {
       "type": "boolean",
-      "default": "true",
+      "default": true,
       "isSetting": true,
       "inputType": "Checkbox",
       "validators": [],

--- a/src/core/schema/block.model.schema
+++ b/src/core/schema/block.model.schema
@@ -1,5 +1,5 @@
 {
-  "type":"object",
+  "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema",
   "id": "http://jsonschema.net",
   "$ref": "http://localhost/system/content.schema",
@@ -13,57 +13,57 @@
         "editorOnly": true
     },
     "title": {
-      "type":"string",
-      "required":true,
+      "type": "string",
+      "required": true,
       "default": "New Block Title",
-      "inputType":"Text",
+      "inputType": "Text",
       "validators": ["required"],
       "translatable": true
     },
     "displayTitle": {
-      "type":"string",
-      "required":false,
+      "type": "string",
+      "required": false,
       "default": "New Block Title",
-      "inputType":"DisplayTitle",
+      "inputType": "DisplayTitle",
       "validators": [],
       "help": "When viewing an block - this is the title that will be displayed on the page",
       "translatable": true
     },
     "body":{
-      "type":"string",
+      "type": "string",
       "default" : "",
-      "inputType":"TextArea",
+      "inputType": "TextArea",
       "validators": [],
       "translatable": true
     },
     "_classes": {
-      "type":"string",
-      "default":"",
+      "type": "string",
+      "default": "",
       "isSetting": true,
-      "inputType":"Text",
+      "inputType": "Text",
       "validators": [],
       "title": "Classes"
     },
     "_isOptional": {
-      "type": "bool",
+      "type": "boolean",
       "default": "false",
       "isSetting": true,
-      "inputType": {"type": "Boolean", "options": [true, false]},
+      "inputType": "Checkbox",
       "validators": [],
       "title": "Is this optional?",
-      "help": "If set to 'true' this block, and components within it, do not have to be completed"
+      "help": "An optional block does not have to be completed, nor do any of the components contained within it."
     },
     "_isAvailable": {
-      "type": "bool",
+      "type": "boolean",
       "default": "true",
       "isSetting": true,
-      "inputType": {"type": "Boolean", "options": [true, false]},
+      "inputType": "Checkbox",
       "validators": [],
       "title": "Is this available?",
-      "help": "If set to 'false' this will not be displayed"
+      "help": "Controls whether this block and its contents are available in the course or not."
     },
     "_extensions": {
-      "type":"object"
+      "type": "object"
     }
   }
 }

--- a/src/core/schema/block.model.schema
+++ b/src/core/schema/block.model.schema
@@ -46,7 +46,7 @@
     },
     "_isOptional": {
       "type": "boolean",
-      "default": "false",
+      "default": false,
       "isSetting": true,
       "inputType": "Checkbox",
       "validators": [],
@@ -55,7 +55,7 @@
     },
     "_isAvailable": {
       "type": "boolean",
-      "default": "true",
+      "default": true,
       "isSetting": true,
       "inputType": "Checkbox",
       "validators": [],

--- a/src/core/schema/component.model.schema
+++ b/src/core/schema/component.model.schema
@@ -32,7 +32,7 @@
     },
     "_isOptional": {
       "type": "boolean",
-      "default": "false",
+      "default": false,
       "isSetting": true,
       "inputType": "Checkbox",
       "validators": [],
@@ -41,7 +41,7 @@
     },
     "_isAvailable": {
       "type": "boolean",
-      "default": "true",
+      "default": true,
       "isSetting": true,
       "inputType": "Checkbox",
       "validators": [],

--- a/src/core/schema/component.model.schema
+++ b/src/core/schema/component.model.schema
@@ -1,5 +1,5 @@
 {
-  "type":"object",
+  "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema",
   "id": "http://jsonschema.net",
   "$ref": "http://localhost/system/trackedObject.schema",
@@ -11,7 +11,7 @@
       "editorOnly": true
     },
     "_type": {
-      "type":"string",
+      "type": "string",
       "id": "http://jsonschema.net/_type"
     },
     "_component": {
@@ -23,66 +23,66 @@
       "type": "string"
     },
     "_classes": {
-      "type":"string",
-      "default":"",
+      "type": "string",
+      "default": "",
       "isSetting": true,
-      "inputType":"Text",
+      "inputType": "Text",
       "validators": [],
       "title": "Classes"
     },
     "_isOptional": {
-      "type": "bool",
+      "type": "boolean",
       "default": "false",
       "isSetting": true,
-      "inputType": {"type": "Boolean", "options": [true, false]},
+      "inputType": "Checkbox",
       "validators": [],
       "title": "Is this optional?",
-      "help": "If set to 'true' this component does not have to be completed"
+      "help": "An optional component does not have to be completed"
     },
     "_isAvailable": {
-      "type": "bool",
+      "type": "boolean",
       "default": "true",
       "isSetting": true,
-      "inputType": {"type": "Boolean", "options": [true, false]},
+      "inputType": "Checkbox",
       "validators": [],
       "title": "Is this available?",
-      "help": "If set to 'false' this will not be displayed"
+      "help": "Controls whether this component is available in the course or not."
     },
     "_parentId": {
-      "type":"objectid",
-      "required":true
+      "type": "objectid",
+      "required": true
     },
     "_courseId": {
-      "type":"objectid",
-      "required":true,
+      "type": "objectid",
+      "required": true,
       "editorOnly": true
     },
     "title": {
-      "type":"string",
-      "required":true,
+      "type": "string",
+      "required": true,
       "default": "New Component Title",
-      "inputType":"Text",
+      "inputType": "Text",
       "validators": ["required"],
       "translatable": true
     },
     "displayTitle": {
-      "type":"string",
-      "required":false,
+      "type": "string",
+      "required": false,
       "default": "New Component Title",
-      "inputType":"DisplayTitle",
+      "inputType": "DisplayTitle",
       "validators": [],
       "help": "When viewing a component - this is the title that will be displayed",
       "translatable": true
     },
     "body":{
-      "type":"string",
+      "type": "string",
       "default" : "",
-      "inputType":"TextArea",
+      "inputType": "TextArea",
       "validators": [],
       "translatable": true
     },
     "_extensions": {
-      "type":"object"
+      "type": "object"
     },
     "properties" : {
       "type": "object"

--- a/src/core/schema/config.model.schema
+++ b/src/core/schema/config.model.schema
@@ -47,7 +47,7 @@
       "properties" : {
         "_isEnabled": {
           "type": "boolean",
-          "default": "false",
+          "default": false,
           "isSetting": false,
           "inputType": "Checkbox",
           "validators": [],
@@ -56,7 +56,7 @@
         },
         "_isEnabledOnTouchDevices": {
           "type": "boolean",
-          "default": "false",
+          "default": false,
           "isSetting": false,
           "inputType": "Checkbox",
           "validators": [],
@@ -65,7 +65,7 @@
         },
         "_shouldSupportLegacyBrowsers": {
           "type": "boolean",
-          "default": "false",
+          "default": false,
           "isSetting": false,
           "inputType": "Checkbox",
           "validators": [],
@@ -74,7 +74,7 @@
         },
         "_isTextProcessorEnabled": {
            "type": "boolean",
-          "default": "false",
+          "default": false,
           "isSetting": false,
           "inputType": "Checkbox",
           "validators": [],
@@ -235,7 +235,7 @@
     },
     "_generateSourcemap": {
       "type": "boolean",
-      "default": "false",
+      "default": false,
       "isSetting": true,
       "inputType": "Checkbox",
       "validators": [],

--- a/src/core/schema/config.model.schema
+++ b/src/core/schema/config.model.schema
@@ -83,7 +83,7 @@
         },
         "_isSkipNavigationEnabled": {
           "type": "boolean",
-          "default": "true",
+          "default": true,
           "isSetting": false,
           "inputType": "Checkbox",
           "validators": [],
@@ -244,7 +244,7 @@
     },
     "_forceRouteLocking": {
       "type": "boolean",
-      "default": "true",
+      "default": true,
       "isSetting": true,
       "inputType": "Checkbox",
       "validators": [],
@@ -257,7 +257,7 @@
       "properties": {
         "_isEnabled": {
           "type": "boolean",
-          "default": "true",
+          "default": true,
           "required": true,
           "inputType": "Checkbox",
           "validators": [],
@@ -282,7 +282,7 @@
         },
         "_console": {
           "type": "boolean",
-          "default": "true",
+          "default": true,
           "inputType": "Checkbox",
           "validators": [],
           "title": "Write to console"

--- a/src/core/schema/config.model.schema
+++ b/src/core/schema/config.model.schema
@@ -46,49 +46,49 @@
       "title": "Accessibility",
       "properties" : {
         "_isEnabled": {
-          "type": "bool",
+          "type": "boolean",
           "default": "false",
           "isSetting": false,
-          "inputType": {"type": "Boolean", "options": [true, false]},
+          "inputType": "Checkbox",
           "validators": [],
           "title": "Enable accessibility?",
-          "help": "If set to 'true', accessibility features will be enabled in this course"
+          "help": "If enabled, accessibility features will be enabled in this course"
         },
         "_isEnabledOnTouchDevices": {
-          "type": "bool",
+          "type": "boolean",
           "default": "false",
           "isSetting": false,
-          "inputType": {"type": "Boolean", "options": [true, false]},
+          "inputType": "Checkbox",
           "validators": [],
           "title": "Enable accessibility on touch devices?",
-          "help": "If set to 'true', accessibility features will be enabled on touch devices - useful if you need accessibility on mobile browsers."
+          "help": "If enabled, accessibility features will be enabled on touch devices - useful if you need accessibility on mobile browsers."
         },
         "_shouldSupportLegacyBrowsers": {
-          "type": "bool",
+          "type": "boolean",
           "default": "false",
           "isSetting": false,
-          "inputType": {"type": "Boolean", "options": [true, false]},
+          "inputType": "Checkbox",
           "validators": [],
           "title": "Support legacy browsers?",
-          "help": "If set to 'true' the course will make special allowances for Internet Explorer 8"
+          "help": "Is accessibility support for IE8 required?"
         },
         "_isTextProcessorEnabled": {
-           "type": "bool",
+           "type": "boolean",
           "default": "false",
           "isSetting": false,
-          "inputType": {"type": "Boolean", "options": [true, false]},
+          "inputType": "Checkbox",
           "validators": [],
           "title": "Enable text reader support?",
-          "help": "If set to 'true' the course will add focusing to assist text reader software"
+          "help": "If enabled, the course will add focusing to assist text reader software"
         },
         "_isSkipNavigationEnabled": {
-          "type": "bool",
+          "type": "boolean",
           "default": "true",
           "isSetting": false,
-          "inputType": {"type": "Boolean", "options": [true, false]},
+          "inputType": "Checkbox",
           "validators": [],
           "title": "Enable Skip Navigation link?",
-          "help": "If set to 'true' a 'Skip Navigation' link will appear allowing users to jump to content"
+          "help": "If enabled, a link will be added to the start of the page that allows assistive technology users to skip straight to the page content."
         }
       }
     },
@@ -234,19 +234,19 @@
       }
     },
     "_generateSourcemap": {
-      "type": "bool",
+      "type": "boolean",
       "default": "false",
       "isSetting": true,
-      "inputType": {"type": "Boolean", "options": [true, false]},
+      "inputType": "Checkbox",
       "validators": [],
       "title": "Generate sourcemap",
       "help": "Creates a JavaScript sourcemap for the output code - useful for debugging (in browsers that support it)."
     },
     "_forceRouteLocking": {
-      "type": "bool",
+      "type": "boolean",
       "default": "true",
       "isSetting": true,
-      "inputType": {"type": "Boolean", "options": [true, false]},
+      "inputType": "Checkbox",
       "validators": [],
       "title": "Enforce route locking",
       "help": "If menu locking is enabled, this setting prevents navigating to locked routes"
@@ -256,13 +256,10 @@
       "title": "Logging",
       "properties": {
         "_isEnabled": {
-          "type": "bool",
+          "type": "boolean",
           "default": "true",
           "required": true,
-          "inputType": {
-            "type": "Boolean",
-            "options": [true, false]
-          },
+          "inputType": "Checkbox",
           "validators": [],
           "title": "Enable logging"
         },
@@ -284,12 +281,9 @@
           }
         },
         "_console": {
-          "type": "bool",
+          "type": "boolean",
           "default": "true",
-          "inputType": {
-            "type": "Boolean",
-            "options": [true, false]
-          },
+          "inputType": "Checkbox",
           "validators": [],
           "title": "Write to console"
         }

--- a/src/core/schema/contentobject.model.schema
+++ b/src/core/schema/contentobject.model.schema
@@ -1,37 +1,37 @@
 {
-  "type":"object",
+  "type": "object",
   "$schema": "http://json-schema.org/draft-04/schema",
   "id": "http://jsonschema.net",
   "$ref": "http://localhost/system/content.schema",
   "properties": {
     "title": {
-      "type":"string",
-      "required":true,
+      "type": "string",
+      "required": true,
       "default": "New Menu/Page Title",
-      "inputType":"Text",
+      "inputType": "Text",
       "validators": ["required"],
       "translatable": true
     },
     "displayTitle": {
-      "type":"string",
-      "required":false,
+      "type": "string",
+      "required": false,
       "default": "New Menu/Page Title",
-      "inputType":"DisplayTitle",
+      "inputType": "DisplayTitle",
       "validators": [],
       "help": "When viewing a menu/page - this is the title that will be displayed on the menu/page",
       "translatable": true
     },
     "pageBody":{
-      "type":"string",
+      "type": "string",
       "default" : "",
-      "inputType":"TextArea",
+      "inputType": "TextArea",
       "validators": [],
       "translatable": true
     },
     "body":{
-      "type":"string",
+      "type": "string",
       "default" : "",
-      "inputType":"TextArea",
+      "inputType": "TextArea",
       "validators": [],
       "translatable": true
     },
@@ -87,30 +87,30 @@
       "help": "If the course is using a 'custom' Menu Lock Type, this should contain the unique ID of the item(s) which must be completed before this is unlocked"
     },
     "_classes": {
-      "type":"string",
-      "default":"",
+      "type": "string",
+      "default": "",
       "isSetting": true,
-      "inputType":"Text",
+      "inputType": "Text",
       "validators": [],
       "title": "Classes"
     },
     "_isOptional": {
-      "type": "bool",
+      "type": "boolean",
       "default": "false",
       "isSetting": true,
-      "inputType": {"type": "Boolean", "options": [true, false]},
+      "inputType": "Checkbox",
       "validators": [],
       "title": "Is this optional?",
-      "help": "If set to 'true' this does not have to be completed"
+      "help": "An optional page does not have to be completed, nor do any of the articles, blocks and components contained within it."
     },
     "_isAvailable": {
-      "type": "bool",
+      "type": "boolean",
       "default": "true",
       "isSetting": true,
-      "inputType": {"type": "Boolean", "options": [true, false]},
+      "inputType": "Checkbox",
       "validators": [],
       "title": "Is this available?",
-      "help": "If set to 'false' this will not be displayed"
+      "help": "Controls whether this page and its contents are available in the course or not."
     },
     "_extensions": {
       "type": "object"

--- a/src/core/schema/contentobject.model.schema
+++ b/src/core/schema/contentobject.model.schema
@@ -96,7 +96,7 @@
     },
     "_isOptional": {
       "type": "boolean",
-      "default": "false",
+      "default": false,
       "isSetting": true,
       "inputType": "Checkbox",
       "validators": [],
@@ -105,7 +105,7 @@
     },
     "_isAvailable": {
       "type": "boolean",
-      "default": "true",
+      "default": true,
       "isSetting": true,
       "inputType": "Checkbox",
       "validators": [],

--- a/src/core/schema/course.model.schema
+++ b/src/core/schema/course.model.schema
@@ -61,16 +61,10 @@
           "type": "boolean",
           "default": false,
           "editorOnly": true,
-          "inputType": {
-            "type": "Boolean",
-            "options": [
-              true,
-              false
-            ]
-          },
+          "inputType": "Checkbox",
           "validators": [],
           "title": "Enable start controller",
-          "help": "When this is set to 'true', you can control which page is rendered when a course loads, potentially bypassing the menu"
+          "help": "The start controller allows you to control which page is rendered when a course loads, potentially bypassing the menu"
         },
         "_startIds": {
           "type": "array",
@@ -88,13 +82,7 @@
                 "type": "boolean",
                 "default": false,
                 "editorOnly": true,
-                "inputType": {
-                  "type": "Boolean",
-                  "options": [
-                    true,
-                    false
-                  ]
-                },
+                "inputType": "Checkbox",
                 "validators": [],
                 "title": "Skip if complete",
                 "help": "When this is set to 'true', the page will not be selected as the first page if it has been already viewed/completed"
@@ -113,31 +101,19 @@
           "type": "boolean",
           "default": false,
           "editorOnly": true,
-          "inputType": {
-            "type": "Boolean",
-            "options": [
-              true,
-              false
-            ]
-          },
+          "inputType": "Checkbox",
           "validators": [],
           "title": "Force routing",
-          "help": "When this is set to 'true', the routing will be forced to the appropriate start page, regardless of the URL"
+          "help": "If enabled, the routing will be forced to the appropriate start page, regardless of the URL"
         },
         "_isMenuDisabled": {
           "type": "boolean",
           "default": false,
           "editorOnly": true,
-          "inputType": {
-            "type": "Boolean",
-            "options": [
-              true,
-              false
-            ]
-          },
+          "inputType": "Checkbox",
           "validators": [],
           "title": "Disable menu",
-          "help": "When this is set to 'true', the user will be prevented from seeing or navigating to the main menu"
+          "help": "Allows you to prevent the user from seeing - or navigating to - the main menu"
         }
       }
     },
@@ -651,16 +627,10 @@
       "type": "boolean",
       "default": false,
       "editorOnly": true,
-      "inputType": {
-        "type": "Boolean",
-        "options": [
-          true,
-          false
-        ]
-      },
+      "inputType": "Checkbox",
       "validators": [],
       "title": "Share with other users",
-      "help": "When this is set to 'true', your colleagues will be able to see this course from the 'Shared courses' option"
+      "help": "Controls whether or not your colleagues will be able to see this course from the 'Shared courses' option"
     },
     "themeSettings": {
       "type": "object"


### PR DESCRIPTION
see adaptlearning/adapt_authoring#1380

**please leave unmerged until all core plugins have been updated**

If approved, these changes will need to be copied to the authoring tool repository - as the framework's copies of the core schema files are only used for the 'export for translation' feature of the framework.