### PR TITLE
amends logging module to use matching methods of the console object

### DIFF
--- a/src/core/js/logging.js
+++ b/src/core/js/logging.js
@@ -8,7 +8,7 @@ define([
         _config: {
             _isEnabled: true,
             _level: LOG_LEVEL.INFO.asLowerCase, // Default log level
-            _console: true, // Log to console
+            _console: true // Log to console
         },      
         
         initialize: function() {

--- a/src/core/js/logging.js
+++ b/src/core/js/logging.js
@@ -97,8 +97,12 @@ define([
             var log = [level.asUpperCase + ':'];
             data && log.push.apply(log, data);
 
-            console.log.apply(console, log);
-
+            // is there a matching console method we can use e.g. console.error()?
+            if(console[level.asLowerCase]) {
+                console[level.asLowerCase].apply(console, log);
+            } else {
+                console.log.apply(console, log);
+            }
         }
 
     });


### PR DESCRIPTION
... when a matching method is available e.g. `Adapt.log.error('this is an error')` will use `console.error` in browsers that support it - but `Adapt.log.fatal('doh!')` fall back to using `console.log`