### PR TITLE
Updated amend for #1486.

### DIFF
--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -467,7 +467,10 @@ define([
                 try {
                     var model = Adapt.findById(id);
 
-                    if (!model.get("_isAvailable")) continue;
+                    this.stopListening(model, "change:_isComplete");
+                    this.listenTo(model, "change:_isComplete", this.onIsComplete);
+
+                    if (!model.get("_isAvailable") || model.get("_isOptional")) continue;
                     if (!model.get("_isComplete")) return true;
                 }
                 catch (e) {


### PR DESCRIPTION
Locking doesn't account for optional models.

Also, fixed an issue created in #1488, where only listening to a models immediate children prevented unlocking models outside of this hierachy. Now should also listen to changes for those models listed in `_lockedBy`.