### PR TITLE
Allow ordering of drawer items (#1393)

### DIFF
--- a/src/core/js/drawer.js
+++ b/src/core/js/drawer.js
@@ -6,6 +6,10 @@ define([
     var DrawerCollection = new Backbone.Collection();
     var Drawer = {};
 
+    DrawerCollection.comparator = function (item) {
+        return item.get('drawerOrder');
+    };
+
     Drawer.addItem = function(drawerObject, eventCallback) {
         drawerObject.eventCallback = eventCallback;
         DrawerCollection.add(drawerObject);

--- a/src/core/js/drawer.js
+++ b/src/core/js/drawer.js
@@ -3,12 +3,8 @@ define([
     'core/js/views/drawerView'
 ], function(Adapt, DrawerView) {
 
-    var DrawerCollection = new Backbone.Collection();
+    var DrawerCollection = new Backbone.Collection(null, { comparator: 'drawerOrder' });
     var Drawer = {};
-
-    DrawerCollection.comparator = function (item) {
-        return item.get('drawerOrder');
-    };
 
     Drawer.addItem = function(drawerObject, eventCallback) {
         drawerObject.eventCallback = eventCallback;


### PR DESCRIPTION
Example of ordering resources extensions in course.json:

  "_resources": {
    "_isEnabled": true,
    "_drawerOrder": 1,
    "title": "Resources",
    "description": "Click here to view resources for this course",
    "_filterButtons": {
      "all": "All",
      "document": "Documents",
      "media": "Media",
      "link": "Links"
    },

New drawerObject to be defined in extension js e.g. adapt-contrib-resources.js:

        var drawerObject = {
            title: courseResources.title,
            description: courseResources.description,
            className: 'resources-drawer',
            drawerOrder: courseResources._drawerOrder
        };

New _drawerOrder to be added to extension schemas (for extensions that populate the drawer):

                "_drawerOrder": {
                  "type": "number",
                  "required": false,
                  "title": "Drawer order",
                  "inputType": "Number",
                  "default": 0,
                  "help": "The order in which this extension should appear as a drawer item",
                  "validators": ["number"]
                },

Related PRs on Glossary and Resources extensions:

- https://github.com/adaptlearning/adapt-contrib-resources/pull/51
- https://github.com/adaptlearning/adapt-contrib-glossary/pull/30