### PR TITLE
Fixes #1719

### DIFF
--- a/grunt/tasks/schema-defaults.js
+++ b/grunt/tasks/schema-defaults.js
@@ -25,7 +25,7 @@ module.exports = function(grunt) {
                 var currentPluginPath = path;
 
                 // if specific plugin has been specified with grunt.option, don't carry on
-                if (!Helpers.isPluginIncluded(path)) return;
+                if (!Helpers.isPluginIncluded(path + "/")) return;
 
                 var currentSchemaPath = currentPluginPath + "/" + "properties.schema";
                 var currentBowerPath = currentPluginPath + "/" + "bower.json";


### PR DESCRIPTION
Adding "/" to path to fix #1719 if config.json[build] is defined, as it is by the AT on export. 