### PR TITLE
Addresses #1732 - add "incorrect" aria label to globals

### DIFF
--- a/src/core/schema/course.model.schema
+++ b/src/core/schema/course.model.schema
@@ -361,6 +361,14 @@
                   "required": true,
                   "translatable": true
                 },
+                "incorrect": {
+                  "type": "string",
+                  "title": "",
+                  "default": "Incorrect",
+                  "inputType": "Text",
+                  "required": true,
+                  "translatable": true
+                },
                 "locked": {
                   "type": "string",
                   "title": "",


### PR DESCRIPTION
Now screen readers will be able to alert the user they got the question wrong in AT-authored courses