### PR TITLE
Additional fix #1723 - still insert text when accessibility is disabled

### DIFF
--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -956,7 +956,13 @@
         $.fn.a11y_text = function(text) {
             var options = $.a11y.options;
 
-            if (!options.isTabbableTextEnabled) return this;
+            if (!options.isTabbableTextEnabled) {
+                if (text) {
+                    this.html(text);
+                }
+
+                return this;
+            }
 
             for (var i = 0; i < this.length; i++) {
                 // If an argument is given then convert that to accessible text


### PR DESCRIPTION
Without this addition, calling `.a11y_text(someText)` will only insert the text if accessibility is enabled.

The desired behaviour is to insert the given text regardless, making it accessible if a11y is on.