### PR TITLE
issue/1576: move trickle jquery.resize library and model functions into core

### DIFF
--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -228,19 +228,26 @@ define([
     };
 
     Adapt.parseRelativeString = function(relativeString) {
-        var separatorPosition = _.indexOf(relativeString, " ");
-        if (separatorPosition < 0) separatorPosition = relativeString.length;
-        var type = relativeString.substr(0, separatorPosition);
-        var offset = parseInt(relativeString.substr(type.length).trim()||0);
-        type = type.substr(1);
 
-        /*RETURN THE TYPE AND OFFSET
-        * "@component +1"  : 
-        * {
-        *       type: "component",
-        *       offset: 1
-        * }
-        */
+        // RETURN THE TYPE AND OFFSET
+        // "@component +1"  : 
+        // {
+        //       type: "component",
+        //       offset: 1
+        // }
+
+        if (relativeString[0] === "@") {
+            relativeString = relativeString.substr(1);
+        }
+
+        var type = relativeString.match(/(component|block|article|page|menu)/);
+        if (!type) {
+            Adapt.log.error("Could not match relative type", relativeString);
+        }
+        type = type[0];
+
+        var offset = parseInt(relativeString.substr(type.length).trim()||0);
+
         return { 
             type: type,
             offset: offset

--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -228,8 +228,10 @@ define([
     };
 
     Adapt.parseRelativeString = function(relativeString) {
-        var type = relativeString.substr(0, _.indexOf(relativeString, " "));
-        var offset = parseInt(relativeString.substr(type.length));
+        var separatorPosition = _.indexOf(relativeString, " ");
+        if (separatorPosition < 0) separatorPosition = relativeString.length;
+        var type = relativeString.substr(0, separatorPosition);
+        var offset = parseInt(relativeString.substr(type.length).trim()||0);
         type = type.substr(1);
 
         /*RETURN THE TYPE AND OFFSET

--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -242,11 +242,16 @@ define([
 
         var type = relativeString.match(/(component|block|article|page|menu)/);
         if (!type) {
-            Adapt.log.error("Could not match relative type", relativeString);
+            Adapt.log.error("Adapt.parseRelativeString() could not match relative type", relativeString);
+            return;
         }
         type = type[0];
 
         var offset = parseInt(relativeString.substr(type.length).trim()||0);
+        if (isNaN(offset)) {
+            Adapt.log.error("Adapt.parseRelativeString() could not parse relative offset", relativeString);
+            return;
+        }
 
         return { 
             type: type,

--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -228,12 +228,14 @@ define([
     };
 
     // Relative strings describe the number and type of hops in the model hierarchy
-    // "@component +1" means to move one component forward.
+    //
+    // "@component +1" means to move one component forward from the current model
     // This function would return the following:
     // {
     //       type: "component",
     //       offset: 1
     // }
+    // Trickle uses this function to determine where it should scrollTo after it unlocks
     Adapt.parseRelativeString = function(relativeString) {
 
         if (relativeString[0] === "@") {

--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -227,6 +227,25 @@ define([
 
     };
 
+    Adapt.parseRelativeString = function(relativeString) {
+        var type = relativeString.substr(0, _.indexOf(relativeString, " "));
+        var offset = parseInt(relativeString.substr(type.length));
+        type = type.substr(1);
+
+        /*RETURN THE TYPE AND OFFSET
+        * "@component +1"  : 
+        * {
+        *       type: "component",
+        *       offset: 1
+        * }
+        */
+        return { 
+            type: type,
+            offset: offset
+        };
+
+    };
+
     Adapt.remove = function() {
         Adapt.trigger('preRemove');
         Adapt.trigger('remove');

--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -227,14 +227,14 @@ define([
 
     };
 
+    // Relative strings describe the number and type of hops in the model hierarchy
+    // "@component +1" means to move one component forward.
+    // This function would return the following:
+    // {
+    //       type: "component",
+    //       offset: 1
+    // }
     Adapt.parseRelativeString = function(relativeString) {
-
-        // RETURN THE TYPE AND OFFSET
-        // "@component +1"  : 
-        // {
-        //       type: "component",
-        //       offset: 1
-        // }
 
         if (relativeString[0] === "@") {
             relativeString = relativeString.substr(1);

--- a/src/core/js/libraries/jquery.resize.js
+++ b/src/core/js/libraries/jquery.resize.js
@@ -1,0 +1,273 @@
+'use strict';
+// jquery.resize 2017-06-19 https://github.com/adaptlearning/jquery.resize
+
+(function() {
+
+    // skip if library is already handling resize events
+    if ($.event.special.resize) return;
+    // skip if old library has been loaded
+    if ($.fn.off.elementResizeOriginalOff) return;
+
+    // handler id generation
+    var expando = {
+
+        index: 0,
+
+        check: function(element) {
+            // check that the element has a valid jquery expando property, or make one
+
+            var hasExpando = (element[$.expando]);
+            if (hasExpando) return;
+
+            element[$.expando] = ++expando.index;
+
+        },
+
+        make: function(element, data) {
+            // make a unique event id from the element's expando property and the event handler guid
+
+            expando.check(element);
+            return data.guid + "-" + element[$.expando];
+
+        }
+
+    };
+
+    // handler functions
+    var handlers = {
+
+        registered: [],
+        shouldReProcess: true,
+
+        register: function(element, data) {
+
+            var $element = $(element);
+            handlers.registered.push({ 
+                id: expando.make(element, data),
+                $element: $element,
+                _measurement: measurements.get($element).uniqueMeasurementId,
+                _hasTriggered: false
+            });
+            handlers.shouldReProcess = true;
+
+        },
+
+        unregister: function(element, data) {
+
+            var registered = handlers.registered;
+
+            var findId = expando.make(element, data);
+            for (var i = registered.length-1, l = -1; i > l; i--) {
+                var item = registered[i]
+                if (item.id != findId) continue;
+                registered.splice(i,1);
+                handlers.shouldReProcess = true;
+            }
+
+        },
+
+        process: function() {
+
+            var registered = handlers.registered;
+            var registeredCount;
+
+            handlers.shouldReProcess = true;
+            while (handlers.shouldReProcess) {
+                handlers.shouldReProcess = false;
+                
+                registeredCount = registered.length;
+                if  (registeredCount == 0) return;
+                
+                for (var i = 0; i < registeredCount; i++) {
+                    var item = registered[i];
+                    var measure = measurements.get(item.$element);
+
+                    // check if measure has the same values as last
+                    var wasPreviouslyMeasured = (item._measurement !== undefined);
+
+                    if (wasPreviouslyMeasured && item._hasTriggered) {
+                        var hasMeasureChanged = (item._measurement != measure.uniqueMeasurementId);
+                        if (!hasMeasureChanged) {
+                            continue;
+                        }
+                    }
+
+                    item._measurement = measure.uniqueMeasurementId;
+                    item._hasTriggered = true;
+
+                    handlers.trigger(item);
+
+                    if (handlers.shouldReProcess) {
+                        break;
+                    }
+
+                }
+            }
+
+        },
+
+        trigger: function triggerResize(item) {
+            
+            item.$element.trigger('resize');
+
+        }
+
+    };
+
+    // checking loop management
+    var loop = {
+
+        lastStartEvent: 0,
+        timeoutHandle: null,
+        intervalDuration: 100,
+        hasRaf: false,
+
+        start: function() {
+
+            loop.lastStartEvent = (new Date()).getTime();
+            loop.repeat();
+
+        },
+
+        repeat: function() {
+            
+            loop.stop();
+
+            if (loop.hasRaf) {
+                loop.timeoutHandle = requestAnimationFrame(loop.main);
+            } else {
+                loop.timeoutHandle = setTimeout(loop.main, loop.intervalDuration);
+            }
+
+        },
+
+        hasExpired: function() {
+
+            var timeSinceLast = (new Date()).getTime() - loop.lastStartEvent;
+            if (timeSinceLast < 1500) return;
+            
+            loop.stop()
+            return true;
+        },
+
+        lastMain: (new Date()).getTime(),
+
+        isThrottled: function() {
+            var passedTime = (new Date()).getTime() - loop.lastMain;
+            if (passedTime > loop.intervalDuration) return false;
+            return true;
+        },
+
+        main: function() {
+
+            if (loop.isThrottled()) {
+                loop.repeat();
+                return;
+            }
+
+            loop.lastMain = (new Date()).getTime();
+
+            if (handlers.registered.length == 0) {
+                // nothing to check
+                loop.stop();
+                // slow down to save cycles
+                loop.intervalDuration = 200;
+                loop.repeat();
+            } else {
+                // something to check
+                loop.stop();
+                // speed up to make more responsive
+                loop.intervalDuration = 100;
+                loop.repeat();
+            }
+
+            handlers.process();
+
+        },
+
+        stop: function() {
+
+            var intervalAttached = (loop.timeoutHandle !== null);
+            if (!intervalAttached) return;
+
+            if (loop.hasRaf) {
+                cancelAnimationFrame(loop.timeoutHandle);
+                loop.timeoutHandle = null;
+            } else {
+                clearTimeout(loop.timeoutHandle);
+                loop.timeoutHandle = null;
+            }
+
+        }
+
+    };
+
+    // jQuery element + event handler attachment / removal
+    $.extend($.event.special, {
+
+        resize: {
+
+            noBubble: true,
+
+            add: function(data) {
+                // allow window resize to be handled by browser
+                if (this === window) return;
+                handlers.register(this, data);
+            },
+
+            remove: function(data) {
+                // allow window resize to be handled by browser
+                if (this === window) return;
+                handlers.unregister(this, data);
+            }
+
+        }
+
+    });
+
+    // jQuery interfaces
+    // element functions
+    $.extend($.fn, {
+
+        resize: function resize(callback) {
+
+            if (callback) {
+                // standard event attachment jquery api behaviour
+                this.on("resize", callback);
+                return this;
+            }
+
+            return this;
+
+        }
+
+    });
+
+    var measurements = {
+
+        featureDetect: function() {
+
+            loop.hasRaf = (window.requestAnimationFrame && window.cancelAnimationFrame);
+            
+        },
+
+        get: function($element) {
+
+            var height = $element.outerHeight();
+            var width = $element.outerWidth();
+
+            return {
+                uniqueMeasurementId: height+","+width
+            };
+
+        }
+
+    };
+
+    //attach event handlers
+    $(window).on({
+        "touchmove scroll mousedown keydown resize": loop.start
+    });
+    $(measurements.featureDetect);
+
+})();

--- a/src/core/js/libraries/jquery.resize.js
+++ b/src/core/js/libraries/jquery.resize.js
@@ -167,7 +167,7 @@
 
             loop.lastMain = (new Date()).getTime();
             
-            if (this.hasExpired()) {
+            if (loop.hasExpired()) {
                 loop.stop();
                 return;
             }

--- a/src/core/js/libraries/jquery.resize.js
+++ b/src/core/js/libraries/jquery.resize.js
@@ -1,5 +1,5 @@
 'use strict';
-// jquery.resize 2017-06-19 https://github.com/adaptlearning/jquery.resize
+// jquery.resize 2017-09-07 https://github.com/adaptlearning/jquery.resize
 
 (function() {
 
@@ -253,8 +253,9 @@
 
         get: function($element) {
 
-            var height = $element.outerHeight();
-            var width = $element.outerWidth();
+            var element = $element[0];
+            var height = element.clientHeight;
+            var width = element.clientWidth;
 
             return {
                 uniqueMeasurementId: height+","+width

--- a/src/core/js/libraries/jquery.resize.js
+++ b/src/core/js/libraries/jquery.resize.js
@@ -1,5 +1,5 @@
 'use strict';
-// jquery.resize 2017-09-07 https://github.com/adaptlearning/jquery.resize
+// jquery.resize 2017-10-05 https://github.com/adaptlearning/jquery.resize
 
 (function() {
 
@@ -166,6 +166,11 @@
             }
 
             loop.lastMain = (new Date()).getTime();
+            
+            if (this.hasExpired()) {
+                loop.stop();
+                return;
+            }
 
             if (handlers.registered.length == 0) {
                 // nothing to check

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -219,22 +219,19 @@ define([
         },
 
         
+        // Fetchs the sub structure of a model as a flattened array
+        // 
+        // Such that the tree:
+        //  { a1: { b1: [ c1, c2 ], b2: [ c3, c4 ] }, a2: { b3: [ c5, c6 ] } }
+        // 
+        // will become the array (parent first = false):
+        //  [ c1, c2, b1, c3, c4, b2, a1, c5, c6, b3, a2 ]
+        // 
+        // or (parent first = true):
+        //  [ a1, b1, c1, c2, b2, c3, c4, a2, b3, c5, c6 ]
+        // 
+        // This is useful when sequential operations are performed on the menu/page/article/block/component hierarchy.        
         getAllDescendantModels: function(isParentFirst) {
-
-            /*
-            * Fetchs the sub structure of a model as a flattened array
-            *
-            *   Such that the tree:
-            *       { a1: { b1: [ c1, c2 ], b2: [ c3, c4 ] }, a2: { b3: [ c5, c6 ] } }
-            *
-            *   will become the array (parent first = false):
-            *       [ c1, c2, b1, c3, c4, b2, a1, c5, c6, b3, a2 ]
-            *
-            *   or (parent first = true):
-            *       [ a1, b1, c1, c2, b2, c3, c4, a2, b3, c5, c6 ]
-            *
-            * This is useful when sequential operations are performed on the menu/page/article/block/component hierarchy.
-            */
 
             var descendants = [];
 
@@ -310,17 +307,17 @@ define([
             return returnedDescendants;
         },
 
+        // Returns a relative model from the Adapt hierarchy
+        //    
+        // Such that in the tree:
+        //  { a1: { b1: [ c1, c2 ], b2: [ c3, c4 ] }, a2: { b3: [ c5, c6 ] } }
+        // 
+        //  findRelative(modelC1, "@block +1") = modelB2;
+        //  findRelative(modelC1, "@component +4") = modelC5;
+        //
+        // See Adapt.parseRelativeString() for a description of relativeStrings
         findRelativeModel: function(relativeString, options) {
-            /*
-            * Returns a relative model from the Adapt hierarchy
-            *   
-            *   Such that in the tree:
-            *       { a1: { b1: [ c1, c2 ], b2: [ c3, c4 ] }, a2: { b3: [ c5, c6 ] } }
-            *
-            *       findRelative(modelC1, "@block +1") = modelB2;
-            *       findRelative(modelC1, "@component +4") = modelC5;
-            *
-            */
+            
             var types = [ "menu", "page", "article", "block", "component" ];
 
             options = options || {};

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -218,6 +218,60 @@ define([
             return returnedDescendants;
         },
 
+        
+        getAllDescendantModels: function(isParentFirst) {
+
+            /*
+            * Fetchs the sub structure of a model as a flattened array
+            *
+            *   Such that the tree:
+            *       { a1: { b1: [ c1, c2 ], b2: [ c3, c4 ] }, a2: { b3: [ c5, c6 ] } }
+            *
+            *   will become the array (parent first = false):
+            *       [ c1, c2, b1, c3, c4, b2, a1, c5, c6, b3, a2 ]
+            *
+            *   or (parent first = true):
+            *       [ a1, b1, c1, c2, b2, c3, c4, a2, b3, c5, c6 ]
+            *
+            * This is useful when sequential operations are performed on the menu/page/article/block/component hierarchy.
+            */
+
+            var descendants = [];
+
+            if (this.get("_type") === "component") {
+                descendants.push(this);
+                return descendants;
+            }
+
+            var children = this.getChildren();
+
+            for (var i = 0, l = children.models.length; i < l; i++) {
+
+                var child = children.models[i];
+                if (child.get("_type") === "component") {
+
+                    descendants.push(child);
+                    continue;
+
+                }
+
+                var subDescendants = child.getAllDescendantModels(isParentFirst);
+                if (isParentFirst === true) {
+                    descendants.push(child);
+                }
+
+                descendants = descendants.concat(subDescendants);
+                
+                if (isParentFirst !== true) {
+                    descendants.push(child);
+                }
+
+            }
+
+            return descendants;
+
+        },
+
         findDescendants: function (descendants) {
             Adapt.log.warn("DEPRECATED - Use findDescendantModels() as findDescendants() may be removed in the future");
 
@@ -254,6 +308,106 @@ define([
 
             // returns a collection of children
             return returnedDescendants;
+        },
+
+        findRelativeModel: function(relativeString, options) {
+            /*
+            * Returns a relative structural item from the Adapt hierarchy
+            *   
+            *   Such that in the tree:
+            *       { a1: { b1: [ c1, c2 ], b2: [ c3, c4 ] }, a2: { b3: [ c5, c6 ] } }
+            *
+            *       findRelative(modelC1, "@block +1") = modelB2;
+            *       findRelative(modelC1, "@component +4") = modelC5;
+            *
+            */
+            var types = [ "menu", "page", "article", "block", "component" ];
+
+            options = options || {};
+
+            var modelId = this.get("_id");
+            var modelType = this.get("_type");
+
+            //return a model relative to the specified one if opinionated
+            var rootModel = Adapt.course;
+            if (options.limitParentId) {
+                rootModel = Adapt.findById(options.limitParentId);
+            }
+
+            var relativeDescriptor = Adapt.parseRelativeString(relativeString);
+
+            var findAncestorType = (_.indexOf(types, modelType) > _.indexOf(types, relativeDescriptor.type));
+            var findSameType = (modelType === relativeDescriptor.type);
+
+            var searchBackwards = false;
+            var movementCount = 0;
+
+            // children first [c,c,b,a,c,c,b,a,p,c,c,b,a,c,c,b,a,p]
+            var pageDescendants = rootModel.getAllDescendantModels();
+
+            //choose search style
+            if (findSameType || findAncestorType) {
+                //examples a<>a or c<>b,a,p
+                //assume next is 0 index
+                //assume last is -1 index
+                searchBackwards = (relativeDescriptor.offset <= 0);
+            } else {
+                //finding descendant
+                //examples a<>c or a<>b
+                if (relativeDescriptor.offset < 1) {
+                    //assume last descendant is 0 index
+                    searchBackwards = true;
+                } else {
+                    //assume next descendant is +1 index
+                    movementCount = 1;
+                    searchBackwards = false;
+                }
+            }
+
+            //exclude not available and not visible if opinionated
+            if (options.filterNotVisible) {
+                pageDescendants = _.filter(pageDescendants, function(descendant) {
+                    return descendant.get("_isVisible");
+                });
+            } 
+            if (options.filterNotAvailable) {
+                pageDescendants = _.filter(pageDescendants, function(descendant) {
+                    return descendant.get("_isAvailable");
+                });
+            } 
+
+            //find current index in array
+            var modelIndex = _.findIndex(pageDescendants, function(pageDescendant) {
+                if (pageDescendant.get("_id") === modelId) {
+                    return true;
+                }
+                return false;
+            });
+
+            //search in appropriate order
+            if (searchBackwards) {
+                for (var i = modelIndex, l = -1; i > l; i--) {
+                    var descendant = pageDescendants[i];
+                    if (descendant.get("_type") === relativeDescriptor.type) {
+                        if (-movementCount === relativeDescriptor.offset) {
+                            return Adapt.findById(descendant.get("_id"));
+                        }
+                        movementCount++;
+                    }
+                }
+            } else {
+                for (var i = modelIndex, l = pageDescendants.length; i < l; i++) {
+                    var descendant = pageDescendants[i];
+                    if (descendant.get("_type") === relativeDescriptor.type) {
+                        if (movementCount === relativeDescriptor.offset) {
+                            return Adapt.findById(descendant.get("_id"));
+                        }
+                        movementCount++;
+                    }
+                }
+            }
+
+            return undefined;
         },
 
         getChildren: function () {

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -367,17 +367,10 @@ define([
                 pageDescendants = rootModel.getAllDescendantModels(false);
             }
 
-            // exclude not available and not visible if opinionated
-            if (options.filterNotVisible) {
-                pageDescendants = _.filter(pageDescendants, function(descendant) {
-                    return descendant.get("_isVisible");
-                });
-            } 
-            if (options.filterNotAvailable) {
-                pageDescendants = _.filter(pageDescendants, function(descendant) {
-                    return descendant.get("_isAvailable");
-                });
-            } 
+            // filter if opinionated
+            if (typeof options.filter === "function") {
+                pageDescendants = _.filter(pageDescendants, options.filter);
+            }
 
             // find current index in array
             var modelIndex = _.findIndex(pageDescendants, function(pageDescendant) {

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -336,7 +336,7 @@ define([
             var findAncestorType = (_.indexOf(types, modelType) > _.indexOf(types, relativeDescriptor.type));
             var findSiblingType = (modelType === relativeDescriptor.type);
 
-            var searchBackwards = (relativeDescriptor.offset < 0);;
+            var searchBackwards = (relativeDescriptor.offset < 0);
             var moveBy = Math.abs(relativeDescriptor.offset);
             var movementCount = 0;
 

--- a/src/core/js/scriptLoader.js
+++ b/src/core/js/scriptLoader.js
@@ -31,7 +31,6 @@
                 scrollTo: 'libraries/scrollTo.min',
                 bowser: 'libraries/bowser',
                 'enum': 'libraries/enum',
-                jqueryResize: 'libraries/jquery.resize',
                 jqueryMobile: 'libraries/jquery.mobile.custom'
             }
         });
@@ -96,7 +95,7 @@
             'imageReady',
             'inview',
             'jqueryMobile',
-            'jqueryResize',
+            'libraries/jquery.resize',
             'a11y',
             'scrollTo',
             'bowser',

--- a/src/core/js/scriptLoader.js
+++ b/src/core/js/scriptLoader.js
@@ -31,6 +31,7 @@
                 scrollTo: 'libraries/scrollTo.min',
                 bowser: 'libraries/bowser',
                 'enum': 'libraries/enum',
+                jqueryResize: 'libraries/jquery.resize',
                 jqueryMobile: 'libraries/jquery.mobile.custom'
             }
         });
@@ -95,6 +96,7 @@
             'imageReady',
             'inview',
             'jqueryMobile',
+            'jqueryResize',
             'a11y',
             'scrollTo',
             'bowser',


### PR DESCRIPTION
https://github.com/adaptlearning/adapt_framework/issues/1576

Added functions from trickle:
```
Adapt.parseRelativeString(relativeString);

AdaptModel.findRelativeModel(relativeString, { 
  filter: function(item, index) { return true; },
  loop: false,
  limitParentId: null
});

AdaptModel.getAllDescendantModels(isParentFirst);
```
Added jquery behaviour:
```
$(selector).on("resize", callback);
$(selector).off("resize", callback);
$(selector).resize(callback);
```