### PR TITLE
Fixes #1817, resolves race condition in Drawer (Patch for 'legacy')

### DIFF
--- a/src/core/js/drawer.js
+++ b/src/core/js/drawer.js
@@ -27,7 +27,7 @@ define([
         });
     };
 
-    Adapt.once('app:dataReady', function() {
+    Adapt.once('adapt:start', function() {
         init();
     });
 


### PR DESCRIPTION
The init() function now listens out for adapt:start rather than app:dataReady.