### PR TITLE
Resolves #1868, reverts Grunt copy of core 'libraries'

### DIFF
--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -195,11 +195,23 @@ module.exports = function (grunt, options) {
                 }
             ]
         },
+        libraries: {
+            files: [
+                {
+                    expand: true,
+                    src: [
+                        '<%= sourcedir %>core/js/libraries/**/*'
+                    ],
+                    dest: '<%= outputdir %>libraries/',
+                    flatten: false
+                }
+            ]
+        },
         required: {
             files: [
                 {
                     expand: true,
-                    src: ['core/**/libraries/**/*', 'components/**/libraries/**/*', 'extensions/**/libraries/**/*', 'menu/<%= menu %>/libraries/**/*', 'theme/<%= theme %>/libraries/**/*'],
+                    src: ['components/**/libraries/**/*', 'extensions/**/libraries/**/*', 'menu/<%= menu %>/libraries/**/*', 'theme/<%= theme %>/libraries/**/*'],
                     cwd: '<%= sourcedir %>',
                     dest: '<%= outputdir %>/libraries/',
                     filter: function(filepath) {

--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -203,7 +203,7 @@ module.exports = function (grunt, options) {
                         '<%= sourcedir %>core/js/libraries/**/*'
                     ],
                     dest: '<%= outputdir %>libraries/',
-                    flatten: false
+                    rename: _.partial(collate, "libraries")
                 }
             ]
         },


### PR DESCRIPTION
An issue was introduced in aa1cc4e which passed the core 'libraries' folder through the plugin filter, which would prevent the core libraries copying to the build folder for AT users.