### PR TITLE
issue/1884: updated jquery.resize to latest bugfix

### DIFF
--- a/src/core/js/libraries/jquery.resize.js
+++ b/src/core/js/libraries/jquery.resize.js
@@ -1,5 +1,5 @@
 'use strict';
-// jquery.resize 2017-10-05 https://github.com/adaptlearning/jquery.resize
+// jquery.resize 2017-11-28 https://github.com/adaptlearning/jquery.resize
 
 (function() {
 
@@ -225,24 +225,6 @@
                 if (this === window) return;
                 handlers.unregister(this, data);
             }
-
-        }
-
-    });
-
-    // jQuery interfaces
-    // element functions
-    $.extend($.fn, {
-
-        resize: function resize(callback) {
-
-            if (callback) {
-                // standard event attachment jquery api behaviour
-                this.on("resize", callback);
-                return this;
-            }
-
-            return this;
 
         }
 


### PR DESCRIPTION
#1884 

To test. 
Before replacing this code should not console log:
```js
$(window).on("resize", function() {
  console.log("window resize triggered");
});
$(window).trigger('resize'); // should console log here
$(window).resize(); // won't console log here
```
After replacing it should console log:
```js
$(window).on("resize", function() {
  console.log("window resize triggered");
});
$(window).trigger('resize'); // should console log here
$(window).resize(); // should console log here
```


