### PR TITLE
issue/1892: added notify subview support

### DIFF
--- a/src/core/js/notify.js
+++ b/src/core/js/notify.js
@@ -70,7 +70,9 @@ define([
 	function addNotifyView(type, notifyObject) {
 
 		// default to _isCancellable = true
-		notifyObject._isCancellable = (_isCancellable === undefined ? true : _isCancellable);
+		if (notifyObject._isCancellable === undefined) {
+			notifyObject._isCancellable = true;
+		}
 		notifyObject._type = type;
 
 		if (type === 'push') {

--- a/src/core/js/notify.js
+++ b/src/core/js/notify.js
@@ -68,6 +68,9 @@ define([
 	});
 
 	function addNotifyView(type, notifyObject) {
+
+		// default to _isCancellable = true
+		notifyObject._isCancellable = (_isCancellable === undefined ? true : _isCancellable);
 		notifyObject._type = type;
 
 		if (type === 'push') {

--- a/src/core/js/views/notifyView.js
+++ b/src/core/js/views/notifyView.js
@@ -143,11 +143,7 @@ define([
 
             Adapt.trigger('notify:opened', this);
 
-            if (this.$('img').length > 0) {
-                this.$el.imageready( _.bind(loaded, this));
-            } else {
-                loaded.call(this);
-            }
+            this.$el.imageready( _.bind(loaded, this));
 
             function loaded() {
                 if (this.disableAnimation) {

--- a/src/core/js/views/notifyView.js
+++ b/src/core/js/views/notifyView.js
@@ -21,6 +21,8 @@ define([
         setupEventListeners: function() {
             this.listenTo(Adapt, {
                 'remove page:scrollTo': this.closeNotify,
+                'notify:resize': this.resetNotifySize,
+                'notify:close': this.closeNotify,
                 'device:resize': this.resetNotifySize,
                 'accessibility:toggle': this.onAccessibilityToggle
             });
@@ -123,6 +125,8 @@ define([
 
         showNotify: function() {
 
+            this.addSubView();
+
             Adapt.trigger('notify:opened', this);
 
             if (this.$('img').length > 0) {
@@ -171,6 +175,15 @@ define([
 
         },
 
+        addSubView: function() {
+
+            this.subView = this.model.get("view");
+            if (!this.subView) return;
+            
+            this.$(".notify-popup-content-inner").append(this.subView.$el);
+
+        },
+
         closeNotify: function (event) {
 
             if (this.disableAnimation) {
@@ -197,6 +210,19 @@ define([
 
             Adapt.trigger('popup:closed');
             Adapt.trigger('notify:closed');
+        },
+
+        remove: function() {
+            this.removeSubView();
+            Backbone.View.prototype.remove.apply(this, arguments);
+        },
+
+        removeSubView: function() {
+
+            if (!this.subView) return;
+            this.subView.remove();
+            this.subView = null;
+
         }
 
     });

--- a/src/core/js/views/notifyView.js
+++ b/src/core/js/views/notifyView.js
@@ -22,6 +22,7 @@ define([
             this.listenTo(Adapt, {
                 'remove page:scrollTo': this.closeNotify,
                 'notify:resize': this.resetNotifySize,
+                'notify:cancel': this.cancelNotify,
                 'notify:close': this.closeNotify,
                 'device:resize': this.resetNotifySize,
                 'accessibility:toggle': this.onAccessibilityToggle
@@ -51,14 +52,14 @@ define([
             if (event.which != 27) return;
             event.preventDefault();
 
-            this.closeNotify();
+            this.cancelNotify();
         },
 
         events: {
             'click .notify-popup-alert-button':'onAlertButtonClicked',
             'click .notify-popup-prompt-button': 'onPromptButtonClicked',
             'click .notify-popup-done': 'onCloseButtonClicked',
-            'click .notify-shadow': 'onCloseButtonClicked'
+            'click .notify-shadow': 'onShadowClicked'
         },
 
         render: function() {
@@ -94,6 +95,19 @@ define([
 
         onCloseButtonClicked: function(event) {
             event.preventDefault();
+            //tab index preservation, notify must close before subsequent callback is triggered
+            this.cancelNotify();
+        },
+
+        onShadowClicked: function(event) {
+            event.preventDefault();
+            this.cancelNotify();
+        },
+
+        cancelNotify: function() {
+            if (this.model.get("_isCancellable") === false) {
+                return;
+            }
             //tab index preservation, notify must close before subsequent callback is triggered
             this.closeNotify();
             Adapt.trigger('notify:cancelled');
@@ -177,7 +191,7 @@ define([
 
         addSubView: function() {
 
-            this.subView = this.model.get("view");
+            this.subView = this.model.get("_view");
             if (!this.subView) return;
             
             this.$(".notify-popup-content-inner").append(this.subView.$el);

--- a/src/core/templates/notify.hbs
+++ b/src/core/templates/notify.hbs
@@ -40,11 +40,13 @@
             </div>
         </div>
         {{! toolbar moved for AA purposes - last tabbable element}}
+        {{#if _isCancellable}}
         {{#if_value_equals _type "popup"}}
             <button class="base notify-popup-done" aria-label="{{_globals._accessibility._ariaLabels.closePopup}}">
                 <div class="notify-popup-icon-close icon icon-cross"></div>
             </button>
         {{/if_value_equals}}
+        {{/if}}
     </div>
 </div>
 


### PR DESCRIPTION
#1892 
#1840 

* handle a pre-instantiated sub view
```js
define([
    'core/js/adapt'
], function(Adapt) {

    var PopupView = Backbone.View.extend({

        initialize: function() {
              this.listenToOnce(Adapt, "notify:opened", this.onOpened);
        },

        onOpened: function(notifyView) {
              // notifyView.subView === this
        },

        remove: function() {
              // called when notify is closed
        }

    });

    return PopupView;

});

Adapt.trigger("notify:popup", {
    _view: new PopupView({ model: new Backbone.Model({}) })
});

```
* allow sub view to force the notify to resize
```js
Adapt.trigger("notify:resize");
```
* allow sub view to close the notify
```js
Adapt.trigger("notify:close");
```
* allow sub view to cancel the notify (triggers notify:cancelled)
```js
Adapt.trigger("notify:cancel");
```
* provide a hook to sub view to run when popup is opened
```js
Adapt.listenTo("notify:opened", callback);
```
* provide hook to to sub view to run when popup is closed
```js
Adapt.listenTo("notify:closed", callback);
```
* provide mechanism to stop notify being cancellable
```js
Adapt.trigger("notify:popup", {
    _isCancellable: false
});
```