### PR TITLE
Fixes #1917, adds a 'drawer:remove' event to handle drawer tidy-up

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt_framework",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Adapt Learning output framework",
   "repository": {
     "type": "git",

--- a/src/core/js/drawer.js
+++ b/src/core/js/drawer.js
@@ -18,17 +18,13 @@ define([
         Adapt.trigger('drawer:triggerCustomView', view, hasBackButton);
     };
 
-    var init = function() {
-        var drawerView = new DrawerView({collection: DrawerCollection});
-
-        Adapt.on('app:languageChanged', function() {
-            drawerView.remove();
-            drawerView = new DrawerView({collection: DrawerCollection});
-        });
-    };
-
-    Adapt.once('adapt:start', function() {
-        init();
+    Adapt.on({
+        'adapt:start': function() {
+             new DrawerView({ collection: DrawerCollection });
+        },
+        'app:languageChanged': function() {
+            Adapt.trigger('drawer:remove');
+        }
     });
 
     Adapt.drawer = Drawer;

--- a/src/core/js/drawer.js
+++ b/src/core/js/drawer.js
@@ -20,7 +20,7 @@ define([
 
     Adapt.on({
         'adapt:start': function() {
-             new DrawerView({ collection: DrawerCollection });
+            new DrawerView({ collection: DrawerCollection });
         },
         'app:languageChanged': function() {
             Adapt.trigger('drawer:remove');

--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -24,11 +24,15 @@ define([
         },
 
         setupEventListeners: function() {
-            this.listenTo(Adapt, 'navigation:toggleDrawer', this.toggleDrawer);
-            this.listenTo(Adapt, 'drawer:triggerCustomView', this.openCustomView);
-            this.listenTo(Adapt, 'drawer:closeDrawer', this.onCloseDrawer);
-            this.listenTo(Adapt, 'remove', this.onCloseDrawer);
-            this.listenTo(Adapt, 'accessibility:toggle', this.onAccessibilityToggle);
+            this.listenTo(Adapt, {
+                'navigation:toggleDrawer': this.toggleDrawer,
+                'drawer:triggerCustomView': this.openCustomView,
+                'drawer:closeDrawer': this.onCloseDrawer,
+                'remove': this.onCloseDrawer,
+                'drawer:remove': this.remove,
+                'accessibility:toggle': this.onAccessibilityToggle
+            });
+
             this._onKeyUp = _.bind(this.onKeyUp, this);
             this.setupEscapeKey();
         },


### PR DESCRIPTION
The Drawer wasn't tidying up after itself and left multiple views dangling each time a language was changed while a course was in progress.

This remedies it by triggering a 'drawer:remove' event to remove the drawer completely when 'app:languageChanged' is triggered.