### PR TITLE
issue/1603: removed jquery.a11y ie8 hack

### DIFF
--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -227,8 +227,7 @@
                     var cloneChild = $(child.outerHTML)[0];
                     switch(child.nodeType) {
                     case 3: //TEXT NODE
-                        // preserve whitespace in ie8 by adding initial zero-width space
-                        var childContent = child.textContent || "&#8203;" + child.nodeValue;
+                        var childContent = child.textContent;
                         //IF TEXT NODE WRAP IN A TABBABLE SPAn
                         newChildren.push( makeElementTabbable($("<span>"+childContent+"</span>")) );
                         added = true;

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -227,7 +227,7 @@
                     var cloneChild = $(child.outerHTML)[0];
                     switch(child.nodeType) {
                     case 3: //TEXT NODE
-                        //IF TEXT NODE WRAP IN A TABBABLE SPAn
+                        //IF TEXT NODE WRAP IN A TABBABLE SPAN
                         newChildren.push( makeElementTabbable($("<span>"+child.textContent+"</span>")) );
                         added = true;
                         break;

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -227,9 +227,8 @@
                     var cloneChild = $(child.outerHTML)[0];
                     switch(child.nodeType) {
                     case 3: //TEXT NODE
-                        var childContent = child.textContent;
                         //IF TEXT NODE WRAP IN A TABBABLE SPAn
-                        newChildren.push( makeElementTabbable($("<span>"+childContent+"</span>")) );
+                        newChildren.push( makeElementTabbable($("<span>"+child.textContent+"</span>")) );
                         added = true;
                         break;
                     case 1: //DOM NODE


### PR DESCRIPTION
#1603 

to test:
* check that Jaws can still read text in IE11, test with vanilla project should be fine.