### PR TITLE
use a11y_aria_label/a11y_wrap_focus helpers where applicable #1836

### DIFF
--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -117,11 +117,11 @@ define([
             });
 
             Handlebars.registerHelper('a11y_aria_label', function(text) {
-                return '<div class="aria-label prevent-default" '+getTabIndex()+' role="region">'+text+'</div>';
+                return '<div class="aria-label prevent-default'+getIgnoreClass()+'" '+getTabIndex()+' role="region">'+text+'</div>';
             });
 
             Handlebars.registerHelper('a11y_aria_label_relative', function(text) {
-                return '<div class="aria-label relative prevent-default" '+getTabIndex()+' role="region">'+text+'</div>';
+                return '<div class="aria-label relative prevent-default'+getIgnoreClass()+'" '+getTabIndex()+' role="region">'+text+'</div>';
             });
 
             Handlebars.registerHelper('a11y_wrap_focus', function(text) {
@@ -138,6 +138,10 @@ define([
 
             var getTabIndex = function() {
                 return this.isActive() ? 'tabindex="0"' : 'tabindex="-1"';
+            }.bind(this);
+
+            var getIgnoreClass = function() {
+                return $.a11y.options.isTabbableTextEnabled ? '' : ' a11y-ignore';
             }.bind(this);
         },
 

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -117,25 +117,28 @@ define([
             });
 
             Handlebars.registerHelper('a11y_aria_label', function(text) {
-                return '<div class="aria-label prevent-default" tabindex="0" role="region">'+text+'</div>';
+                return '<div class="aria-label prevent-default" '+getTabIndex()+' role="region">'+text+'</div>';
             });
 
             Handlebars.registerHelper('a11y_aria_label_relative', function(text) {
-                return '<div class="aria-label relative prevent-default" tabindex="0" role="region">'+text+'</div>';
+                return '<div class="aria-label relative prevent-default" '+getTabIndex()+' role="region">'+text+'</div>';
             });
 
             Handlebars.registerHelper('a11y_wrap_focus', function(text) {
-                return '<a id="a11y-focusguard" class="a11y-ignore a11y-ignore-focus" tabindex="0" role="button">&nbsp;</a>';
+                return '<a id="a11y-focusguard" class="a11y-ignore a11y-ignore-focus" '+getTabIndex()+' role="button">&nbsp;</a>';
             });
 
             Handlebars.registerHelper('a11y_attrs_heading', function(level) {
-                return ' role="heading" aria-level="'+level+'" tabindex="0" ';
+                return ' role="heading" aria-level="'+level+'" '+getTabIndex()+' ';
             });
 
             Handlebars.registerHelper('a11y_attrs_tabbable', function() {
-                return ' role="region" tabindex="0" ';
+                return ' role="region" '+getTabIndex()+' ';
             });
 
+            var getTabIndex = function() {
+                return this.isActive() ? 'tabindex="0"' : 'tabindex="-1"';
+            }.bind(this);
         },
 
         setupToggleButton: function() {

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -125,7 +125,7 @@ define([
             });
 
             Handlebars.registerHelper('a11y_wrap_focus', function(text) {
-                return '<a id="a11y-focusguard" class="a11y-ignore a11y-ignore-focus" '+getTabIndex()+' role="button">&nbsp;</a>';
+                return '<a class="a11y-focusguard a11y-ignore a11y-ignore-focus" '+getTabIndex()+' role="button">&nbsp;</a>';
             });
 
             Handlebars.registerHelper('a11y_attrs_heading', function(level) {

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -674,20 +674,11 @@
 
             $.a11y.state.isFocusGuardSetup = true;
 
-            $('body').on("click", domSelectors.focusguard, function(event) {
+            $('body').on("click focus", domSelectors.focusguard, function(event) {
 
                 if (options.isDebug) console.log ("focusguard");
 
                 preventDefault(event)
-                $.a11y_focus(true);
-
-            });
-
-            $('body').on("focus", domSelectors.focusguard, function(event) {
-
-                if (options.isDebug) console.log ("focusguard");
-
-                preventDefault(event);
                 $.a11y_focus(true);
 
                 return false;

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -15,7 +15,7 @@
     // JQUERY SELECTORS
         var domSelectors = {
             "focuser": "#a11y-focuser",
-            "focusguard": "#a11y-focusguard",
+            "focusguard": ".a11y-focusguard",
             "selected": "#a11y-selected",
             "ignoreFocusElements": ".a11y-ignore-focus",
             "nativeSpaceElements": "textarea, input[type='text'], div[contenteditable=true]",
@@ -33,7 +33,7 @@
     // JQUERY INJECTED ELEMENTS
         var domInjectElements = {
             "focuser": '<a id="a11y-focuser" href="#" class="prevent-default a11y-ignore" tabindex="-1" role="presentation" aria-label=".">&nbsp;</a>',
-            "focusguard": '<a id="a11y-focusguard" class="a11y-ignore a11y-ignore-focus" tabindex="0" role="button">&nbsp;</a>',
+            "focusguard": '<a class="a11y-focusguard a11y-ignore a11y-ignore-focus" tabindex="0" role="button">&nbsp;</a>',
             "selected": '<a id="a11y-selected" href="#" class="prevent-default a11y-ignore" tabindex="-1">&nbsp;</a>',
             "arialabel": "<span class='aria-label prevent-default' tabindex='0' role='region'></span>"
         };
@@ -622,38 +622,26 @@
         }
 
         function a11y_reattachFocusGuard() {
-            var options = $.a11y.options;
-            var $focusguard = $(domSelectors.focusguard);
-
-            if ($focusguard.length === 0) {
-                $focusguard = $(domInjectElements.focusguard);
-            }
-
+            var $focusguard;
             var $currentFloor = $.a11y.state.floorStack[$.a11y.state.floorStack.length-1];
 
-            $focusguard.remove().appendTo($currentFloor).attr("tabindex", 0);
-
-            $focusguard.off("click").off("focus");
-
-            $focusguard.on("click", function(event) {
-
-                if (options.isDebug) console.log ("focusguard");
-
-                preventDefault(event)
-                $.a11y_focus(true);
-
-            });
-
-            $focusguard.on("focus", function(event) {
-
-                if (options.isDebug) console.log ("focusguard");
-
-                preventDefault(event);
-                $.a11y_focus(true);
-
-                return false;
-
-            });
+            if ($.a11y.state.floorStack.length == 1) {
+                // only a page/menu is present
+                if ($currentFloor.find(domSelectors.focusguard).length === 0) {
+                    // create and attach the focusguard
+                    $focusguard = $(domInjectElements.focusguard);
+                    $focusguard.appendTo($currentFloor).attr("tabindex", 0);
+                }
+            } else {
+                // we have a popup
+                if ($currentFloor.find(domSelectors.focusguard).length === 0) {
+                    // the popup is not using the helper
+                    console.warn("DEPRECATED (a11y_reattachFocusGuard) - Use the Handlebars helper a11y_wrap_focus after the last tabbable element in the popup");
+                    // create and attach the focusguard
+                    $focusguard = $(domInjectElements.focusguard);
+                    $focusguard.appendTo($currentFloor).attr("tabindex", 0);
+                }
+            }
         }
 
         function a11y_setupUserInputControlListeners() {
@@ -677,6 +665,34 @@
             $("body")
                 .on("mousedown touchstart", domSelectors.focusableElements, onFocusCapture) //IPAD TOUCH-DOWN FOCUS FIX FOR BUTTONS
                 .on("focus", domSelectors.globalTabIndexElements, onFocus);
+        }
+
+        function a11y_setupFocusGuard() {
+            var options = $.a11y.options;
+
+            if ($.a11y.state.isFocusGuardSetup) return;
+
+            $.a11y.state.isFocusGuardSetup = true;
+
+            $('body').on("click", domSelectors.focusguard, function(event) {
+
+                if (options.isDebug) console.log ("focusguard");
+
+                preventDefault(event)
+                $.a11y_focus(true);
+
+            });
+
+            $('body').on("focus", domSelectors.focusguard, function(event) {
+
+                if (options.isDebug) console.log ("focusguard");
+
+                preventDefault(event);
+                $.a11y_focus(true);
+
+                return false;
+
+            });
         }
 
         function a11y_injectControlElements() {
@@ -787,6 +803,7 @@
             if (iOS) options.OS = "mac";
 
             a11y_injectControlElements();
+            a11y_setupFocusGuard();
 
             if (options.isUserInputControlEnabled) {
                 a11y_setupUserInputControlListeners();
@@ -1109,8 +1126,10 @@
             if (this.length > 0) $(this[0]).limitedScrollTo();
 
             if (options.isScrollDisabledOnPopupEnabled) {
-                $('body').scrollDisable();
-                $(domSelectors.focusguard).css({
+                $('html').css('overflow-y', 'hidden');
+
+                $.a11y.state.floorStack[$.a11y.state.floorStack.length-2].scrollDisable();
+                $(domSelectors.focusguard, this).css({
                     "position":"fixed",
                     "bottom": "0px"
                 });
@@ -1125,7 +1144,10 @@
             var options = $.a11y.options;
             var state = $.a11y.state;
 
-            $.a11y.state.floorStack.pop();
+            // the body layer is the first element and must always exist
+            if ($.a11y.state.floorStack.length <= 1) return;
+
+            var $currentFloor = $.a11y.state.floorStack.pop();
 
             $(domSelectors.globalTabIndexElements).filter(domFilters.globalTabIndexElementFilter).each(function(index, item) {
                 var $item = $(item);
@@ -1170,15 +1192,19 @@
             $.a11y_update();
 
             if (options.isScrollDisabledOnPopupEnabled) {
-                $('body').scrollEnable();
-                $(domSelectors.focusguard).css({
+                if (state.floorStack.length == 1) $('html').css('overflow-y', '');
+
+                $.a11y.state.floorStack[$.a11y.state.floorStack.length-1].scrollEnable();
+                $(domSelectors.focusguard, $currentFloor).css({
                     "position":"",
                     "bottom": ""
                 });
             }
 
             defer(function() {
-
+                // Listeners for popup close may shift focus so respect this
+                if ($activeElement != $.a11y.state.$activeElement) return;
+                
                 if ($activeElement) {
                     state.$activeElement = $activeElement;
                     //scroll to focused element

--- a/src/core/less/base.less
+++ b/src/core/less/base.less
@@ -301,7 +301,7 @@
     }
 
 /*HIDDEN FOCUS GUARD*/
-#a11y-focusguard {
+.a11y-focusguard {
     left:0px !important;
     bottom:0px !important;
     width:auto !important;

--- a/src/core/templates/drawer.hbs
+++ b/src/core/templates/drawer.hbs
@@ -12,4 +12,5 @@
 		</button>
 		</div>
 	</div>
+	{{{a11y_wrap_focus}}}
 </div>

--- a/src/core/templates/drawer.hbs
+++ b/src/core/templates/drawer.hbs
@@ -1,5 +1,5 @@
 <div class="drawer-inner">
-	<span class='aria-label prevent-default' tabindex='0' role='region'>{{_globals._accessibility._ariaLabels.drawer}}</span>
+	{{{a11y_aria_label _globals._accessibility._ariaLabels.drawer}}}
 	<div class="drawer-holder">
 	</div>
 	<div class="drawer-toolbar clearfix">

--- a/src/core/templates/navigation.hbs
+++ b/src/core/templates/navigation.hbs
@@ -1,7 +1,8 @@
 {{! make the _globals object in course.json available to this template}}
 {{import_globals}}
 {{! All links in the nav bar should have an attribute of data-event, navigationView uses this to fire a global event}}
-<div class="navigation-inner clearfix" role="navigation" aria-label="{{_globals._accessibility._ariaLabels.navigation}}">
+<div class="navigation-inner clearfix" role="navigation">
+	{{{a11y_aria_label _globals._accessibility._ariaLabels.navigation}}}
     {{#if _accessibility._isSkipNavigationEnabled}}
         <button class="skip-nav-link a11y-ignore a11y-ignore-focus" data-event="skipNavigation" aria-label="{{_globals._accessibility._ariaLabels.skipNavigation}}">{{{_globals._accessibility.skipNavigationText}}}</button>
     {{/if}}

--- a/src/core/templates/navigation.hbs
+++ b/src/core/templates/navigation.hbs
@@ -1,7 +1,7 @@
 {{! make the _globals object in course.json available to this template}}
 {{import_globals}}
 {{! All links in the nav bar should have an attribute of data-event, navigationView uses this to fire a global event}}
-<div class="navigation-inner clearfix" role="navigation">
+<div class="navigation-inner clearfix">
 	{{{a11y_aria_label _globals._accessibility._ariaLabels.navigation}}}
     {{#if _accessibility._isSkipNavigationEnabled}}
         <button class="skip-nav-link a11y-ignore a11y-ignore-focus" data-event="skipNavigation" aria-label="{{_globals._accessibility._ariaLabels.skipNavigation}}">{{{_globals._accessibility.skipNavigationText}}}</button>

--- a/src/core/templates/navigation.hbs
+++ b/src/core/templates/navigation.hbs
@@ -2,7 +2,7 @@
 {{import_globals}}
 {{! All links in the nav bar should have an attribute of data-event, navigationView uses this to fire a global event}}
 <div class="navigation-inner clearfix">
-	{{{a11y_aria_label _globals._accessibility._ariaLabels.navigation}}}
+    {{{a11y_aria_label _globals._accessibility._ariaLabels.navigation}}}
     {{#if _accessibility._isSkipNavigationEnabled}}
         <button class="skip-nav-link a11y-ignore a11y-ignore-focus" data-event="skipNavigation" aria-label="{{_globals._accessibility._ariaLabels.skipNavigation}}">{{{_globals._accessibility.skipNavigationText}}}</button>
     {{/if}}

--- a/src/core/templates/notify.hbs
+++ b/src/core/templates/notify.hbs
@@ -1,6 +1,7 @@
 {{! make the _globals object in course.json available to this template}}
 {{import_globals}}
-<div {{#each _attributes}}{{@key}}="{{this}}" {{/each}} class="notify-popup notify-type-{{_type}} {{_classes}}" role="region" aria-label="{{_globals._accessibility._ariaLabels.feedbackPopUp}}">
+<div {{#each _attributes}}{{@key}}="{{this}}" {{/each}} class="notify-popup notify-type-{{_type}} {{_classes}}" role="region">
+    {{{a11y_aria_label _globals._accessibility._ariaLabels.feedbackPopUp}}}
     <div class="notify-popup-inner">
         <div class="notify-popup-content">
             <div class="notify-popup-content-inner">

--- a/src/core/templates/notify.hbs
+++ b/src/core/templates/notify.hbs
@@ -1,6 +1,6 @@
 {{! make the _globals object in course.json available to this template}}
 {{import_globals}}
-<div {{#each _attributes}}{{@key}}="{{this}}" {{/each}} class="notify-popup notify-type-{{_type}} {{_classes}}" role="region">
+<div {{#each _attributes}}{{@key}}="{{this}}" {{/each}} class="notify-popup notify-type-{{_type}} {{_classes}}">
     {{{a11y_aria_label _globals._accessibility._ariaLabels.feedbackPopUp}}}
     <div class="notify-popup-inner">
         <div class="notify-popup-content">
@@ -47,6 +47,8 @@
             </button>
         {{/if_value_equals}}
     </div>
+
+    {{{a11y_wrap_focus}}}
 </div>
 
 

--- a/src/core/templates/notifyPush.hbs
+++ b/src/core/templates/notifyPush.hbs
@@ -1,6 +1,6 @@
 {{! make the _globals object in course.json available to this template}}
 {{import_globals}}
-<div class="notify-push-inner" role="region">
+<div class="notify-push-inner">
 	{{{a11y_aria_label _globals._accessibility._ariaLabels.feedbackPopUp}}}
 	<div class="notify-push-title">
 		<div class="notify-push-title-inner h5" tabindex="0" role="heading" aria-level="1">

--- a/src/core/templates/notifyPush.hbs
+++ b/src/core/templates/notifyPush.hbs
@@ -1,7 +1,7 @@
 {{! make the _globals object in course.json available to this template}}
 {{import_globals}}
-<div class="notify-push-inner" role="region" aria-label="{{_globals._accessibility._ariaLabels.feedbackPopUp}}">
-	
+<div class="notify-push-inner" role="region">
+	{{{a11y_aria_label _globals._accessibility._ariaLabels.feedbackPopUp}}}
 	<div class="notify-push-title">
 		<div class="notify-push-title-inner h5" tabindex="0" role="heading" aria-level="1">
 			{{{compile title this}}}

--- a/src/core/templates/page.hbs
+++ b/src/core/templates/page.hbs
@@ -1,6 +1,7 @@
 {{! make the _globals object in course.json available to this template}}
 {{import_globals}}
-<div class="page-inner article-container" role="main" aria-label="{{_globals._accessibility._ariaLabels.page}}">
+<div class="page-inner article-container" role="main">
+	{{{a11y_aria_label _globals._accessibility._ariaLabels.page}}}
 	<div class="page-header">
 		<div class="page-header-inner clearfix">
 

--- a/src/core/templates/page.hbs
+++ b/src/core/templates/page.hbs
@@ -1,6 +1,6 @@
 {{! make the _globals object in course.json available to this template}}
 {{import_globals}}
-<div class="page-inner article-container" role="main">
+<div class="page-inner article-container">
 	{{{a11y_aria_label _globals._accessibility._ariaLabels.page}}}
 	<div class="page-header">
 		<div class="page-header-inner clearfix">


### PR DESCRIPTION
Addresses #1513

(Sorry chris, i completely messed up your original PR when I tried to rebase it with master)

Glossary:
* focusguard - the element which wraps the focus around at the bottom of the page, back to the top

Chris' changes:
* switched focusguard from being moved around to having it exist in the templates (this is backward compatible but will print a deprecated warning)
* switched focusguard event handling from per instance to single global
* extended accessibility helpers so that they output the correct z-index and a11y-ignore class for the active state of accessibility
* added {{focus_wrap}} to templates to make it clear where the focusguard behaviour will appear
* converted aria labels in templates to use {{a11y_aria_label}} helper
* changed scrollEnable + scrollDisable functionality for popups so that it acts on the previous scrolling container instead of always on the body

Ollie changes:
* indentation
* combined two event handler declarations into one
