### PR TITLE
issue/1944: fixed build.min.js output and includes bug

### DIFF
--- a/grunt/config/build-config.js
+++ b/grunt/config/build-config.js
@@ -5,7 +5,7 @@ module.exports = function (grunt, options) {
             src: [
                 '<%= sourcedir %>components/**/bower.json',
                 '<%= sourcedir %>extensions/**/bower.json',
-                '<%= sourcedir %>menu/<%= menu %>/**/bower.json',                    
+                '<%= sourcedir %>menu/<%= menu %>/**/bower.json',
                 '<%= sourcedir %>theme/<%= theme %>/**/bower.json'
             ],
             filter: function(filepath) {

--- a/grunt/helpers.js
+++ b/grunt/helpers.js
@@ -157,11 +157,10 @@ module.exports = function(grunt) {
         for (var i = 0; i < exports.defaults.pluginTypes.length; i++) {
             var pluginTypeDir = path.join(configData.sourcedir, exports.defaults.pluginTypes[i]);
             // grab a list of the installed (and included) plugins for this type
-            var plugins = _.intersection(fs.readdirSync(pluginTypeDir),buildIncludes);
+            var plugins = _.intersection(fs.readdirSync(pluginTypeDir), buildIncludes);
             for (var j = 0; j < plugins.length; j++) {
                 try {
-                    var bowerJson = require(path.join(pluginTypeDir, plugins[j], 'bower.json'));
-
+                    var bowerJson = JSON.parse(fs.readFileSync(path.join(pluginTypeDir, plugins[j], 'bower.json')));
                     for (var key in bowerJson.dependencies) {
                         if (!_.contains(buildIncludes, key)) dependencies.push(key);
                     }
@@ -271,7 +270,7 @@ module.exports = function(grunt) {
             // grunt.log.writeln('Included ' + chalk.green(pluginPath));
             return true;
         }
-        
+
         // The LESS 'plugins' folder exists, so check that any plugins in this folder are allowed.
         var hasPluginSubDirectory = !!pluginPath.match(getNestedIncludedRegExp());
         if (hasPluginSubDirectory) {
@@ -299,7 +298,7 @@ module.exports = function(grunt) {
         }
 
         return isIncluded;
-     
+
     };
 
     exports.includedFilter = function(filepath) {

--- a/grunt/helpers.js
+++ b/grunt/helpers.js
@@ -160,7 +160,7 @@ module.exports = function(grunt) {
             var plugins = _.intersection(fs.readdirSync(pluginTypeDir), buildIncludes);
             for (var j = 0; j < plugins.length; j++) {
                 try {
-                    var bowerJson = JSON.parse(fs.readFileSync(path.join(pluginTypeDir, plugins[j], 'bower.json')));
+                    var bowerJson = grunt.file.readJSON(path.join(pluginTypeDir, plugins[j], 'bower.json'));
                     for (var key in bowerJson.dependencies) {
                         if (!_.contains(buildIncludes, key)) dependencies.push(key);
                     }

--- a/grunt/tasks/build-config.js
+++ b/grunt/tasks/build-config.js
@@ -22,7 +22,7 @@ module.exports = function(grunt) {
 
         // add bower json
         buildConfig.plugins = [];
-        grunt.file.expand({follow: true}, options.src).forEach(function(bowerJSONPath) {
+        grunt.file.expand({follow: true, filter: options.filter}, options.src).forEach(function(bowerJSONPath) {
             var plugin = grunt.file.readJSON(bowerJSONPath);
             if (allowedProperties.bower) {
                 plugin = _.pick(plugin, allowedProperties.bower);


### PR DESCRIPTION
#1944

This is two separate issues.
1. `getIncludes` was using `require` to fetch JSON rather than a parser
2. `build-config` task wasn't applying the includes filter