### PR TITLE
Issue 1699 adds better support for non-Spoor based offlineStorage

### DIFF
--- a/src/core/js/models/configModel.js
+++ b/src/core/js/models/configModel.js
@@ -25,29 +25,34 @@ define([
             // Then check if course files can load
             // 'configModel:loadCourseData' event starts the core content collections and models being fetched
             this.fetch({
-                success: _.bind(function() {
-                  Adapt.trigger('offlineStorage:prepare');
-                  Adapt.wait.queue(_.bind(function() {
+                success: function() {
+                    Adapt.trigger('offlineStorage:prepare');
 
-                    Adapt.trigger('configModel:dataLoaded');
-                    if (this.get('_canLoadData')) {
-                        Adapt.trigger('configModel:loadCourseData');
-                    }
-                    if(this.get('_defaultDirection')=='rtl'){//We're going to use rtl style
-                    	$('html').addClass('dir-rtl');
-                    }
-                    // check if animations should be disabled
-                    var disableAnimationArray = this.get('_disableAnimationFor');
-                    if (disableAnimationArray && disableAnimationArray.length > 0) {
-                        for (var i=0; i < disableAnimationArray.length; i++) {
-                            if ($("html").is(disableAnimationArray[i])) {
-                                this.set('_disableAnimation', true);
-                                console.log('Animation disabled.');
+                    Adapt.wait.queue(function() {
+
+                        Adapt.trigger('configModel:dataLoaded');
+
+                        if (this.get('_canLoadData')) {
+                            Adapt.trigger('configModel:loadCourseData');
+                        }
+
+                        if (this.get('_defaultDirection') === 'rtl'){
+                            // We're going to use rtl style
+                            $('html').addClass('dir-rtl');
+                        }
+
+                        // Check if animations should be disabled
+                        var disableAnimationArray = this.get('_disableAnimationFor');
+                        if (disableAnimationArray && disableAnimationArray.length > 0) {
+                            for (var i = 0; i < disableAnimationArray.length; i++) {
+                                if ($("html").is(disableAnimationArray[i])) {
+                                    this.set('_disableAnimation', true);
+                                    console.log('Animation disabled.');
+                                }
                             }
                         }
-                    }
-                  }, this));
-                }, this),
+                    }.bind(this));
+                }.bind(this),
                 error: function() {
                     console.log('Unable to load course/config.json');
                 }

--- a/src/core/js/models/configModel.js
+++ b/src/core/js/models/configModel.js
@@ -26,6 +26,9 @@ define([
             // 'configModel:loadCourseData' event starts the core content collections and models being fetched
             this.fetch({
                 success: _.bind(function() {
+                  Adapt.trigger('offlineStorage:prepare');
+                  Adapt.wait.queue(_.bind(function() {
+
                     Adapt.trigger('configModel:dataLoaded');
                     if (this.get('_canLoadData')) {
                         Adapt.trigger('configModel:loadCourseData');
@@ -43,6 +46,7 @@ define([
                             }
                         }
                     }
+                  }, this));
                 }, this),
                 error: function() {
                     console.log('Unable to load course/config.json');

--- a/src/core/js/offlineStorage.js
+++ b/src/core/js/offlineStorage.js
@@ -27,6 +27,14 @@ define([
             this._handler = handler;
         },
 
+        /**
+         * Flag to indicate if an offlineStorage handler has been defined.
+         * @returns {boolean} true if an offlineStorage handler has been defined, false otherwise
+         */
+        hasHandler: function() {
+            return !_.isUndefined(this._handler);
+        },
+
         set: function(name, value) {
             if (!(this._handler && this._handler.set)) return;
             return this._handler.set.apply(this._handler, arguments);

--- a/src/core/js/offlineStorage.js
+++ b/src/core/js/offlineStorage.js
@@ -32,7 +32,7 @@ define([
          * @returns {boolean} true if an offlineStorage handler has been defined, false otherwise
          */
         hasHandler: function() {
-            return !_.isUndefined(this._handler);
+            return this._handler !== undefined;
         },
 
         set: function(name, value) {


### PR DESCRIPTION
A new event allows plugins to initialise offlineStorage conditionally, by waiting until they're ready.  Previously since Adapt.offlineStorage.ready is defaulted to true, plugins such as the Language Picker would skip any aynchronous offline storage setup.
- Added new 'offlineStorage:prepare' event, which is triggered before 'configModel:dataReady'
- Added Adapt.offlineStorage.hasHandler() function, this indicates if an offlineStorage handler has been setup