### PR TITLE
issue/1987: lazy graphic loading implementation

### DIFF
--- a/src/core/js/app.js
+++ b/src/core/js/app.js
@@ -16,6 +16,7 @@ require([
     'core/js/logging',
     'core/js/tracking',
     'core/js/device',
+    'core/js/graphics',
     'core/js/drawer',
     'core/js/notify',
     'core/js/popupManager',

--- a/src/core/js/graphics.js
+++ b/src/core/js/graphics.js
@@ -1,181 +1,182 @@
 define([
-  'core/js/adapt',
-  'handlebars',
-  'inview'
-],function(Adapt, Handlebars) {
+    'core/js/adapt',
+    'handlebars',
+    'inview'
+], function(Adapt, Handlebars) {
 
-  var Graphics = Backbone.Controller.extend({
+    var Graphics = Backbone.Controller.extend({
 
-    initialize: function() {
-      _.bindAll(this, "_onScroll", "_delayedThreholdIncrease", "_checkImage");
-      this._onScroll = _.throttle(this._onScroll, 100);
-      this._delayedThreholdIncrease = _.debounce(this._delayedThreholdIncrease, 500);
-      this._offscreenPixelThreshold = 0;
-      this._registerHelpers();
-      this.listenTo(Adapt, "app:dataReady", this._onDataReady);
-    },
+        initialize: function() {
+            _.bindAll(this, "_onScroll", "_delayedThreholdIncrease", "_checkImage");
+            this._onScroll = _.throttle(this._onScroll, 100);
+            this._delayedThreholdIncrease = _.debounce(this._delayedThreholdIncrease, 500);
+            this._offscreenPixelThreshold = 0;
+            this._registerHelpers();
+            this.listenTo(Adapt, "app:dataReady", this._onDataReady);
+        },
 
-    _registerHelpers: function() {
+        _registerHelpers: function() {
 
-      var helpers = {
+            var helpers = {
 
-        "graphic": function(options) {
+                "graphic": function(options) {
 
-          var noArgs = (arguments.length === 1);
-          // if no options were passed and no local _graphic object is defined, return
-          if (noArgs && typeof this._graphic !== "object") return "";
-          // if no options were passed and the _graphic object is defined, use it
-          if (noArgs && this._graphic) options = this._graphic;
-          // if options were passed but were not an object, return
-          if (!options || typeof options !== "object") return "";
+                    var noArgs = (arguments.length === 1);
+                    // if no options were passed and no local _graphic object is defined, return
+                    if (noArgs && typeof this._graphic !== "object") return "";
+                    // if no options were passed and the _graphic object is defined, use it
+                    if (noArgs && this._graphic) options = this._graphic;
+                    // if options were passed but were not an object, return
+                    if (!options || typeof options !== "object") return "";
 
-          var imageWidth = Adapt.graphics.getImageSize();
+                    var imageWidth = Adapt.graphics.getImageSize();
 
-          // 'small' or 'large' or 'src' or '_src'
-          var rtn = options[imageWidth] || options.src || options._src || "";
+                    // 'small' or 'large' or 'src' or '_src'
+                    var rtn = options[imageWidth] || options.src || options._src || "";
 
-          if (!Adapt.graphics.isActive() || options._canLazyLoad === false) {
-            return new Handlebars.SafeString('src="'+rtn+'"');
-          }
+                    if (!Adapt.graphics.isActive() || options._canLazyLoad === false) {
+                    return new Handlebars.SafeString('src="'+rtn+'"');
+                    }
 
-          // produce a dummy image of the right size or ratio to put in place
-          var width = options._width || 16;
-          var height = options._height || 9;
-          var canvas = $('<canvas width="'+width+'" height="'+height+'" >')[0];
-          var context = canvas.getContext("2d");
-          context.fillStyle = options._color || "#ffffff";
-          context.fillRect(0, 0, width, height);
-          var data = canvas.toDataURL("image/jpeg", 0.1);
-          return new Handlebars.SafeString('src="'+data+'" data-adapt-graphics="'+rtn+'"');
+                    // produce a dummy image of the right size or ratio to put in place
+                    var width = options._width || 16;
+                    var height = options._height || 9;
+                    var canvas = $('<canvas width="'+width+'" height="'+height+'" >')[0];
+                    var context = canvas.getContext("2d");
+                    context.fillStyle = options._color || "#ffffff";
+                    context.fillRect(0, 0, width, height);
+                    var data = canvas.toDataURL("image/jpeg", 0.1);
+                    return new Handlebars.SafeString('src="'+data+'" data-adapt-graphics="'+rtn+'"');
 
+                }
+
+            };
+
+            for (var name in helpers) {
+                Handlebars.registerHelper(name, helpers[name]);
+            }
+
+        },
+
+        getImageSize: function() {
+            var screenWidth = Adapt.device.screenSize;
+            return screenWidth === 'medium' ? 'small' : screenWidth;
+        },
+
+        _onDataReady: function() {
+            if (!this.isActive()) return;
+            this._setUpEventListeners();
+        },
+
+        isActive: function() {
+            if (!this.isEnabled()) return false;
+            var graphics = Adapt.config.get("_graphics");
+            var className = graphics._className;
+            var $html = $("html");
+            if (!className || $html.is(className) || $html.hasClass(className)) return true;
+            return false;
+        },
+
+        isEnabled: function() {
+            var graphics = Adapt.config.get("_graphics");
+            if (!graphics || !graphics._isEnabled) return false;
+            return true;
+        },
+
+        _setUpEventListeners() {
+            this.listenTo(Adapt, {
+                "pageView:postRender menuView:postRender": this._onPostRender,
+                "remove": this._onRemove
+            });
+        },
+
+        _onPostRender: function(view) {
+            // wait for page / menu to be ready
+            if (view.model.get("_isReady")) return this._startScrollListener ();
+            this.listenToOnce(view.model, "change:_isReady", this._startScrollListener );
+        },
+
+        _startScrollListener: function() {
+            this._offscreenPixelThreshold = 0;
+            $(window).on("scroll", this._onScroll);
+            this._onScroll();
+        },
+
+        _onScroll: function() {
+            var $progImages = $("img[data-adapt-graphics], video[data-adapt-graphics-poster]");
+            if (!$progImages.length) return this._stopScrollListener();
+            $progImages.each(this._checkImage);
+            if (!this._offscreenPixelThreshold) this._delayedThreholdIncrease();
+        },
+
+        _stopScrollListener: function() {
+            $(window).off("scroll", this._onScroll);
+        },
+
+        _checkImage: function(index, img) {
+            var $img = $(img);
+
+            var measurements = this._getElementMeasurements($img);
+
+            var percentInview = measurements.percentInview;
+            var bottom = measurements.bottom;
+            var top = measurements.top;
+
+            var isFarOffscreenBottom = (bottom < this._offscreenPixelThreshold);
+            var isFarOffscreenTop = (top < this._offscreenPixelThreshold);
+            var isFarOffscreen = (isFarOffscreenBottom || isFarOffscreenTop);
+
+            var isNotInview = (!percentInview);
+
+            if (isNotInview && isFarOffscreen) return;
+
+            // replace dummy image with image for video tag
+            if ($img.is("video")) {
+                img.poster = $img.attr("data-adapt-graphics-poster");
+                $img.removeAttr("data-adapt-graphics-poster");
+                return;
+            }
+
+            // replace dummy image with image for img tag
+            img.src = $img.attr("data-adapt-graphics");
+            $img.removeAttr("data-adapt-graphics");
+
+        },
+
+        _getElementMeasurements: function($img) {
+            var hasSpace = this._isElementOccupyingSpace($img[0]);
+            if (hasSpace) return $img.onscreen();
+
+            // the image is currently hidden
+            var $parent = $(this._findSpaciousParent($img[0]));
+            if (!$parent.length) return;
+            
+            // use spacious parent measurements
+            return $parent.onscreen();
+        },
+
+        _isElementOccupyingSpace: function(el) {
+            return Boolean(el.clientHeight || el.clientWidth)
+        },
+
+        _findSpaciousParent: function(el) {
+            while (el = el.parentNode) {
+                if (this._isElementOccupyingSpace(el)) return el;
+            }
+        },
+
+        _delayedThreholdIncrease: function() {
+            // increase the offscreen threshold for loading images
+            this._offscreenPixelThreshold = -window.innerHeight*2;
+            this._onScroll();
+        },
+
+        _onRemove: function() {
+            this._stopScrollListener();
         }
 
-      };
+    });
 
-      for (var name in helpers) {
-        Handlebars.registerHelper(name, helpers[name]);
-      }
-
-    },
-
-    getImageSize: function() {
-      var screenWidth = Adapt.device.screenSize;
-      return screenWidth === 'medium' ? 'small' : screenWidth;
-    },
-
-    _onDataReady: function() {
-      if (!this.isActive()) return;
-      this._setUpEventListeners();
-    },
-
-    isActive: function() {
-      if (!this.isEnabled()) return false;
-      var graphics = Adapt.config.get("_graphics");
-      var className = graphics._className;
-      var $html = $("html");
-      if (!className || $html.is(className) || $html.hasClass(className)) return true;
-      return false;
-    },
-
-    isEnabled: function() {
-      var graphics = Adapt.config.get("_graphics");
-      if (!graphics || !graphics._isEnabled) return false;
-      return true;
-    },
-
-    _setUpEventListeners() {
-      this.listenTo(Adapt, {
-        "pageView:postRender menuView:postRender": this._onPostRender,
-        "remove": this._onRemove
-      });
-    },
-
-    _onPostRender: function(view) {
-      // wait for page / menu to be ready
-      if (view.model.get("_isReady")) return this._startScrollListener ();
-      this.listenToOnce(view.model, "change:_isReady", this._startScrollListener );
-    },
-
-    _startScrollListener: function() {
-      this._offscreenPixelThreshold = 0;
-      $(window).on("scroll", this._onScroll);
-      this._onScroll();
-    },
-
-    _onScroll: function() {
-      var $progImages = $("img[data-adapt-graphics], video[data-adapt-graphics-poster]");
-      if (!$progImages.length) return this._stopScrollListener();
-      $progImages.each(this._checkImage);
-      if (!this._offscreenPixelThreshold) this._delayedThreholdIncrease();
-    },
-
-    _stopScrollListener: function() {
-      $(window).off("scroll", this._onScroll);
-    },
-
-    _checkImage: function(index, img) {
-      var $img = $(img);
-
-      var measurements = this._getElementMeasurements($img);
-
-      var percentInview = measurements.percentInview;
-      var bottom = measurements.bottom;
-      var top = measurements.top;
-
-      var isFarOffscreenBottom = (bottom < this._offscreenPixelThreshold);
-      var isFarOffscreenTop = (top < this._offscreenPixelThreshold);
-      var isFarOffscreen = (isFarOffscreenBottom || isFarOffscreenTop);
-
-      var isNotInview = (!percentInview);
-
-      if (isNotInview && isFarOffscreen) return;
-
-      // replace dummy image with image for video tag
-      if ($img.is("video")) {
-        img.poster = $img.attr("data-adapt-graphics-poster");
-        $img.removeAttr("data-adapt-graphics-poster");
-        return;
-      }
-
-      // replace dummy image with image for img tag
-      img.src = $img.attr("data-adapt-graphics");
-      $img.removeAttr("data-adapt-graphics");
-
-    },
-
-    _getElementMeasurements: function($img) {
-      var hasSpace = this._isElementOccupyingSpace($img[0]);
-      if (hasSpace) return $img.onscreen();
-
-      // the image is currently hidden
-      var $parent = $(this._findSpaciousParent($img[0]));
-      if (!$parent.length) return;
-      // use spacious parent measurements
-      return $parent.onscreen();
-    },
-
-    _isElementOccupyingSpace: function(el) {
-      return Boolean(el.clientHeight || el.clientWidth)
-    },
-
-    _findSpaciousParent: function(el) {
-      while (el = el.parentNode) {
-        if (this._isElementOccupyingSpace(el)) return el;
-      }
-    },
-
-    _delayedThreholdIncrease: function() {
-      // increase the offscreen threshold for loading images
-      this._offscreenPixelThreshold = -window.innerHeight*2;
-      this._onScroll();
-    },
-
-    _onRemove: function() {
-      this._stopScrollListener();
-    }
-
-  });
-
-  return Adapt.graphics = new Graphics();
+    return Adapt.graphics = new Graphics();
 
 });

--- a/src/core/js/graphics.js
+++ b/src/core/js/graphics.js
@@ -84,18 +84,19 @@ define([
     },
 
     _setUpEventListeners() {
-      this.listenTo(Adapt, "pageView:postRender menuView:postRender", this._onPostRender);
-      this.listenTo(Adapt, "remove", this._onRemove);
+      this.listenTo(Adapt, {
+        "pageView:postRender menuView:postRender": this._onPostRender,
+        "remove": this._onRemove
+      });
     },
 
     _onPostRender: function(view) {
       // wait for page / menu to be ready
-      if (view.model.get("_isReady")) return this._start();
-      this.listenToOnce(view.model, "change:_isReady", this._start);
+      if (view.model.get("_isReady")) return this._startScrollListener ();
+      this.listenToOnce(view.model, "change:_isReady", this._startScrollListener );
     },
 
-    _start: function() {
-      // start listening for scrolls
+    _startScrollListener: function() {
       this._offscreenPixelThreshold = 0;
       $(window).on("scroll", this._onScroll);
       this._onScroll();
@@ -103,13 +104,12 @@ define([
 
     _onScroll: function() {
       var $progImages = $("img[data-adapt-graphics], video[data-adapt-graphics-poster]");
-      if (!$progImages.length) return this._stop();
+      if (!$progImages.length) return this._stopScrollListener();
       $progImages.each(this._checkImage);
       if (!this._offscreenPixelThreshold) this._delayedThreholdIncrease();
     },
 
-    _stop: function() {
-      // stop listening for scrolls
+    _stopScrollListener: function() {
       $(window).off("scroll", this._onScroll);
     },
 
@@ -171,7 +171,7 @@ define([
     },
 
     _onRemove: function() {
-      this._stop();
+      this._stopScrollListener();
     }
 
   });

--- a/src/core/js/graphics.js
+++ b/src/core/js/graphics.js
@@ -35,7 +35,7 @@ define([
                     var rtn = options[imageWidth] || options.src || options._src || "";
 
                     if (!Adapt.graphics.isActive() || options._canLazyLoad === false) {
-                    return new Handlebars.SafeString('src="'+rtn+'"');
+                        return new Handlebars.SafeString('src="'+rtn+'"');
                     }
 
                     // produce a dummy image of the right size or ratio to put in place
@@ -93,7 +93,7 @@ define([
         _onPostRender: function(view) {
             // wait for page / menu to be ready
             if (view.model.get("_isReady")) return this._startScrollListener ();
-            this.listenToOnce(view.model, "change:_isReady", this._startScrollListener );
+            this.listenToOnce(view.model, "change:_isReady", this._startScrollListener);
         },
 
         _startScrollListener: function() {

--- a/src/core/js/graphics.js
+++ b/src/core/js/graphics.js
@@ -34,7 +34,9 @@ define([
           // 'small' or 'large' or 'src' or '_src'
           var rtn = options[imageWidth] || options.src || options._src || "";
 
-          if (!Adapt.graphics.isActive()) return new Handlebars.SafeString('src="'+rtn+'"');
+          if (!Adapt.graphics.isActive() || options._canLazyLoad === false) {
+            return new Handlebars.SafeString('src="'+rtn+'"');
+          }
 
           // produce a dummy image of the right size or ratio to put in place
           var width = options._width || 16;

--- a/src/core/js/graphics.js
+++ b/src/core/js/graphics.js
@@ -1,0 +1,179 @@
+define([
+  'core/js/adapt',
+  'handlebars',
+  'inview'
+],function(Adapt, Handlebars) {
+
+  var Graphics = Backbone.Controller.extend({
+
+    initialize: function() {
+      _.bindAll(this, "_onScroll", "_delayedThreholdIncrease", "_checkImage");
+      this._onScroll = _.throttle(this._onScroll, 100);
+      this._delayedThreholdIncrease = _.debounce(this._delayedThreholdIncrease, 500);
+      this._offscreenPixelThreshold = 0;
+      this._registerHelpers();
+      this.listenTo(Adapt, "app:dataReady", this._onDataReady);
+    },
+
+    _registerHelpers: function() {
+
+      var helpers = {
+
+        "graphic": function(options) {
+
+          var noArgs = (arguments.length === 1);
+          // if no options were passed and no local _graphic object is defined, return
+          if (noArgs && typeof this._graphic !== "object") return "";
+          // if no options were passed and the _graphic object is defined, use it
+          if (noArgs && this._graphic) options = this._graphic;
+          // if options were passed but were not an object, return
+          if (!options || typeof options !== "object") return "";
+
+          var imageWidth = Adapt.graphics.getImageSize();
+
+          // 'small' or 'large' or 'src' or '_src'
+          var rtn = options[imageWidth] || options.src || options._src || "";
+
+          if (!Adapt.graphics.isActive()) return new Handlebars.SafeString('src="'+rtn+'"');
+
+          // produce a dummy image of the right size or ratio to put in place
+          var width = options._width || 16;
+          var height = options._height || 9;
+          var canvas = $('<canvas width="'+width+'" height="'+height+'" >')[0];
+          var context = canvas.getContext("2d");
+          context.fillStyle = options._color || "#ffffff";
+          context.fillRect(0, 0, width, height);
+          var data = canvas.toDataURL("image/jpeg", 0.1);
+          return new Handlebars.SafeString('src="'+data+'" data-adapt-graphics="'+rtn+'"');
+
+        }
+
+      };
+
+      for (var name in helpers) {
+        Handlebars.registerHelper(name, helpers[name]);
+      }
+
+    },
+
+    getImageSize: function() {
+      var screenWidth = Adapt.device.screenSize;
+      return screenWidth === 'medium' ? 'small' : screenWidth;
+    },
+
+    _onDataReady: function() {
+      if (!this.isActive()) return;
+      this._setUpEventListeners();
+    },
+
+    isActive: function() {
+      if (!this.isEnabled()) return false;
+      var graphics = Adapt.config.get("_graphics");
+      var className = graphics._className;
+      var $html = $("html");
+      if (!className || $html.is(className) || $html.hasClass(className)) return true;
+      return false;
+    },
+
+    isEnabled: function() {
+      var graphics = Adapt.config.get("_graphics");
+      if (!graphics || !graphics._isEnabled) return false;
+      return true;
+    },
+
+    _setUpEventListeners() {
+      this.listenTo(Adapt, "pageView:postRender menuView:postRender", this._onPostRender);
+      this.listenTo(Adapt, "remove", this._onRemove);
+    },
+
+    _onPostRender: function(view) {
+      // wait for page / menu to be ready
+      if (view.model.get("_isReady")) return this._start();
+      this.listenToOnce(view.model, "change:_isReady", this._start);
+    },
+
+    _start: function() {
+      // start listening for scrolls
+      this._offscreenPixelThreshold = 0;
+      $(window).on("scroll", this._onScroll);
+      this._onScroll();
+    },
+
+    _onScroll: function() {
+      var $progImages = $("img[data-adapt-graphics], video[data-adapt-graphics-poster]");
+      if (!$progImages.length) return this._stop();
+      $progImages.each(this._checkImage);
+      if (!this._offscreenPixelThreshold) this._delayedThreholdIncrease();
+    },
+
+    _stop: function() {
+      // stop listening for scrolls
+      $(window).off("scroll", this._onScroll);
+    },
+
+    _checkImage: function(index, img) {
+      var $img = $(img);
+
+      var measurements = this._getElementMeasurements($img);
+
+      var percentInview = measurements.percentInview;
+      var bottom = measurements.bottom;
+      var top = measurements.top;
+
+      var isFarOffscreenBottom = (bottom < this._offscreenPixelThreshold);
+      var isFarOffscreenTop = (top < this._offscreenPixelThreshold);
+      var isFarOffscreen = (isFarOffscreenBottom || isFarOffscreenTop);
+
+      var isNotInview = (!percentInview);
+
+      if (isNotInview && isFarOffscreen) return;
+
+      // replace dummy image with image for video tag
+      if ($img.is("video")) {
+        img.poster = $img.attr("data-adapt-graphics-poster");
+        $img.removeAttr("data-adapt-graphics-poster");
+        return;
+      }
+
+      // replace dummy image with image for img tag
+      img.src = $img.attr("data-adapt-graphics");
+      $img.removeAttr("data-adapt-graphics");
+
+    },
+
+    _getElementMeasurements: function($img) {
+      var hasSpace = this._isElementOccupyingSpace($img[0]);
+      if (hasSpace) return $img.onscreen();
+
+      // the image is currently hidden
+      var $parent = $(this._findSpaciousParent($img[0]));
+      if (!$parent.length) return;
+      // use spacious parent measurements
+      return $parent.onscreen();
+    },
+
+    _isElementOccupyingSpace: function(el) {
+      return Boolean(el.clientHeight || el.clientWidth)
+    },
+
+    _findSpaciousParent: function(el) {
+      while (el = el.parentNode) {
+        if (this._isElementOccupyingSpace(el)) return el;
+      }
+    },
+
+    _delayedThreholdIncrease: function() {
+      // increase the offscreen threshold for loading images
+      this._offscreenPixelThreshold = -window.innerHeight*2;
+      this._onScroll();
+    },
+
+    _onRemove: function() {
+      this._stop();
+    }
+
+  });
+
+  return Adapt.graphics = new Graphics();
+
+});

--- a/src/course/config.json
+++ b/src/course/config.json
@@ -26,6 +26,10 @@
         "_hideEasing": "easeInQuart",
         "_duration": 400
     },
+    "_graphics": {
+        "_isEnabled": true,
+        "_className": ".os-ios, .os-android"
+    },
     "_spoor": {
         "_isEnabled": true,
         "_tracking": {


### PR DESCRIPTION
#1987 

### To Test
1. Change all template occurances of `<img src="{{_graphic.src}}"` to `<img {{graphic}}` (accordion, gmcq, graphic, narrative, menu and hotgraphic templates)
2. Remove image swapping functionality 
[graphic](https://github.com/adaptlearning/adapt-contrib-graphic/blob/master/js/adapt-contrib-graphic.js#L56-L58)
[gmcq](https://github.com/adaptlearning/adapt-contrib-gmcq/blob/master/js/adapt-contrib-gmcq.js#L50-L61)
3. Optionally add any of these to your `_graphic` objects in the json
```js
"_graphic": {
    "_width": 900, // natural width of dummy image
    "_height": 506, // natural height of dummy image
    "_color": "#ff00ff", // dummy image fill colour
    "large": "", // preferred source path for large devices
    "small": "", // preferred source path for small and medium devices
    "src": "", // fallback source path
    "_src": "", // fallback source path
    "_canLazyLoad": false // disable lazy load for this graphic
}
```
4. Change `config.json` `_className` property to target more devices

### Enhancement
* Centralised and reusable API for large/small/src/_src images
* Speed up page load when applied (ideally for mobile users)
* Cheap. Lightweight.
* Easy to extend and centralise image alt text and attribution if we wanted

### Issues
* By doing this we lose dynamic switching of images from graphic and gmcq on device size changes.... I'm not sure if that is important but it should be something easy to add back in, this time centrally.
* It should be noted that if the dummy image isn't the same ratio as the actual image, it'll cause a resize to trigger when the actual image gets inserted, might need to not have lazy loading unless height and width are specified?
* We should change all `img` tags where necessary to be `width:100%;` at the moment if the image is too small it doesn't stretch to fit the space.
* This is only enabled on ios and android devices, probably need to disable it by default
* Might want to cache the dummy images as they are created, need to do a performance profile of the canvas code

### Example
[https://rawgit.com/oliverfoster/lazy-images/master/index.html](https://rawgit.com/oliverfoster/lazy-images/master/index.html)
* Lazy loading on all browsers
* Lazy load on accordion, graphic, hotgraphic, narrative, gmcq and menu
* No heights or widths specified (so you get to see a resize)
* Scroll quickly, you can see the images lazy load