### PR TITLE
issue/1998: remove buggy ios fixes

### DIFF
--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -368,29 +368,11 @@
             var scrollToPosition = elementTop - topOffset - (windowAvailableHeight / 2);
             if (scrollToPosition < 0) scrollToPosition = 0;
 
-            var isElementTopOutOfView = (elementTop < scrollTopWithTopOffset || elementTop > scrollBottomWithTopOffset);
 
-            if (!isElementTopOutOfView) {
-                if ($element.is("select, input[type='text'], textarea") && iOS) { //ios 9.0.4 bugfix for keyboard and picker input
-                    defer(function(){
-                        if (options.isDebug) console.log("limitedScrollTo select fix", this.scrollToPosition);
-                        $.scrollTo(this.scrollToPosition, { duration: 0 });
-                    }, {scrollToPosition:scrollToPosition}, 1000);
-                }
-                return;
-            };
-
-            if ($element.is("select, input[type='text'], textarea") && iOS) {  //ios 9.0.4 bugfix for keyboard and picker input
-                defer(function(){
-                    if (options.isDebug) console.log("limitedScrollTo select fix", this.scrollToPosition);
-                    $.scrollTo(this.scrollToPosition, { duration: 0 });
-                }, {scrollToPosition:scrollToPosition}, 1000);
-            } else {
-                if (options.isDebug) console.log("limitedScrollTo", scrollToPosition);
+            if (options.isDebug) console.log("limitedScrollTo", scrollToPosition);
             defer(function() {
-                    $.scrollTo(this.scrollToPosition, { duration: 0 });
-                }, {scrollToPosition:scrollToPosition});
-            }
+                $.scrollTo(this.scrollToPosition, { duration: 0 });
+            }, {scrollToPosition:scrollToPosition});
 
             return this;
         };
@@ -720,41 +702,6 @@
             });
         }
 
-        function a11y_iosFalseClickFix() {  //ios 9.0.4 bugfix for invalid clicks on input overlays
-            //with voiceover on, ios will allow clicks on :before and :after content text. this causes the first tabbable element to recieve focus
-            //redirect focus back to last item in this instance
-            var isPerformingRedirect = false;
-            var options = $.a11y.options;
-
-            $("body").on("click", "*", function(event) {
-                if (isPerformingRedirect) return;
-
-                onFocusCapture(event);
-
-                var $active = $.a11y.state.$activeElement;
-                if (!$active.is(domSelectors.globalTabIndexElements)) return;
-
-                if (options.isDebug) console.log("a11y_iosFalseClickFix", $active[0]);
-
-                isPerformingRedirect = true;
-
-                defer(function() {
-                    $active.focus();
-                    isPerformingRedirect = false;
-                }, 500);
-
-            });
-        }
-
-        function a11y_iosFixes() {
-
-            if ($.a11y.state.isIOSFixesApplied) return;
-
-            $.a11y.state.isIOSFixesApplied = true;
-            a11y_iosFalseClickFix();
-
-        }
-
         function a11y_debug() {
 
             if ($.a11y.state.isDebugApplied) return;
@@ -788,7 +735,6 @@
             isScrollDisabledOnPopupEnabled: false,
             isSelectedAlertsEnabled: false,
             isAlertsEnabled: false,
-            isIOSFixesEnabled: true,
             isDebug: false
         };
         $.a11y.state = {
@@ -819,10 +765,6 @@
 
             if (options.isFocusWrapEnabled) {
                 a11y_reattachFocusGuard();
-            }
-
-            if (iOS && options.isIOSFixesEnabled) {
-                a11y_iosFixes();
             }
 
             if (options.isDebug) {

--- a/src/core/less/base.less
+++ b/src/core/less/base.less
@@ -29,7 +29,7 @@
 }
 
 .accessibility {
-    .focused, *:focus {
+    *:focus {
         outline: @focus-outline;
     }
 }

--- a/src/core/less/base.less
+++ b/src/core/less/base.less
@@ -29,7 +29,7 @@
 }
 
 .accessibility {
-    *:focus {
+    :focus {
         outline: @focus-outline;
     }
 }

--- a/src/core/less/base.less
+++ b/src/core/less/base.less
@@ -28,8 +28,8 @@
     display:none!important;
 }
 
-.accessibility.no-touchevents {
-    .focused, button:focus, select:focus, textarea:focus, a:focus, input:focus + label {
+.accessibility {
+    .focused, *:focus {
         outline: @focus-outline;
     }
 }


### PR DESCRIPTION
#1998 

* removed ios9 focus correction from user input controls (text or select)
* removed ios9 focus correction for interacting with `:before` and `:after` elements
* removed restrictions on focus outline as the rest of the code doesn't apply the same restrictions
* removed redundant ie8 class selector for focused elements (ie8 didn't have the `:focus` selector and had a legacy fix to add a `.focused` class, which has since been removed)