### PR TITLE
Resolves #2001, corrects issue with configModel defaults

### DIFF
--- a/src/core/js/models/configModel.js
+++ b/src/core/js/models/configModel.js
@@ -10,10 +10,6 @@ define([
                 medium: 760,
                 large: 1024
             },
-            _completionCriteria: {
-                _requireContentCompleted: true,
-                _requireAssessmentPassed: false
-            },
             _forceRouteLocking: false,
             _canLoadData: true,
             _disableAnimation: false


### PR DESCRIPTION
The course completion defaults are actually already defined in tracking.js.  It's best to leave them out of the config model defaults.