### PR TITLE
issue/#2035: bug in setActiveItem when no item active

### DIFF
--- a/src/core/js/models/itemsComponentModel.js
+++ b/src/core/js/models/itemsComponentModel.js
@@ -67,7 +67,8 @@ define([
         },
 
         setActiveItem: function(index) {
-            this.getActiveItem().toggleActive(false);
+            var activeItem = this.getActiveItem();
+            if (activeItem) activeItem.toggleActive(false);
             this.getItem(index).toggleActive(true);
         }
 


### PR DESCRIPTION
#2035 
Bug fix for error when no active item exists and setActiveItem is called.