### PR TITLE
Show multiple tasks from grunt/tasks/task-file.js in "grunt help"

### DIFF
--- a/grunt/tasks/help.js
+++ b/grunt/tasks/help.js
@@ -45,19 +45,22 @@ module.exports = function(grunt) {
 function getTaskData() {
     var taskData = {};
     var files = fs.readdirSync(__dirname);
-    var re = new RegExp(/grunt.register(Multi)?Task\('(.+?)', '(.*?)',/);
+    var re = /grunt.register(Multi)?Task\('(.+?)', '(.*?)',/g;
 
     for(var i = 0, count = files.length; i < count; i++) {
+        // reset RegExp
+        re.lastIndex = 0;
         
         var filePath = path.join(__dirname, files[i]);
         var fileStat = fs.statSync(filePath);
         
         //skip directories
         if (fileStat.isDirectory()) continue;
-        
-        var file = fs.readFileSync(filePath, 'utf8');
-        var match = file.match(re);
-        if(match) taskData[match[2]] = match[3] || '';
+
+        var match = '';
+        while(match = re.exec(file)) {
+            taskData[match[2]] = match[3] || '';
+        }
         
     }
     return taskData;

--- a/grunt/tasks/help.js
+++ b/grunt/tasks/help.js
@@ -57,6 +57,7 @@ function getTaskData() {
         //skip directories
         if (fileStat.isDirectory()) continue;
 
+        var file = fs.readFileSync(filePath, 'utf8');
         var match = '';
         while(match = re.exec(file)) {
             taskData[match[2]] = match[3] || '';

--- a/grunt/tasks/translate.js
+++ b/grunt/tasks/translate.js
@@ -12,7 +12,7 @@ module.exports = function(grunt) {
       "_exportLangFiles"
     ]);
 
-    grunt.registerTask("translate:import", "Import Language files and create a translated duplicte of a master Course.", [
+    grunt.registerTask('translate:import', 'Import Language files and create a translated duplicte of a master Course.', [
       "_getTranslateConfig",
       "_loadLanguageFiles",
       "_loadMasterCourse",

--- a/grunt/tasks/translate.js
+++ b/grunt/tasks/translate.js
@@ -12,7 +12,7 @@ module.exports = function(grunt) {
       "_exportLangFiles"
     ]);
 
-    grunt.registerTask('translate:import', 'Import Language files and create a translated duplicte of a master Course.', [
+    grunt.registerTask('translate:import', 'Import translated language files. For more details, please visit https://github.com/adaptlearning/adapt_framework/wiki/Course-Localisation', [
       "_getTranslateConfig",
       "_loadLanguageFiles",
       "_loadMasterCourse",


### PR DESCRIPTION
grunt help shows not all tasks from "grunt/tasks/translate.js". It takes only first task from there (**translate:export**). See below:

```
$ grunt help
Running "help" task

Adapt Learning automated build process

See below for the list of available tasks:

build               Creates a production-ready build of the course
*
*    
translate:export    Export Course Data into Language files ready to be translated

Run a task using: grunt [task name]

For more information, see https://github.com/adaptlearning/adapt_framework/wiki
```

Now it displays both tasks:

```
$ grunt help
Running "help" task

Adapt Learning automated build process

See below for the list of available tasks:

build               Creates a production-ready build of the course  
*
*                                 
translate:export    Export Course Data into Language files ready to be translated
translate:import    Import Language files and create a translated duplicte of a  
                    master Course.                                              

Run a task using: grunt [task name]

For more information, see https://github.com/adaptlearning/adapt_framework/wiki
```


