### PR TITLE
 Log component name on Adapt.register error

### DIFF
--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -208,7 +208,7 @@ define([
         // Used to register components
         // Store the component view
         if (Adapt.componentStore[name])
-            throw Error('This component already exists in your project');
+            throw Error('The component "' + name + '" already exists in your project');
 
         if (object.view) {
             //use view+model object


### PR DESCRIPTION
Fixes #2041.

I haven't done anything about the following, but happy to update this PR if there's interest:

> I also wonder whether this should throw an error, as this breaks the app completely. It may be useful to just log a warning, and throw an error at the point we attempt to render the component?