### PR TITLE
fixes issue/#2075 : deprecated a11y_text

### DIFF
--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -105,12 +105,8 @@ define([
             var helpers = {
 
                 a11y_text: function(text) {
-                    //ALLOW ENABLE/DISABLE OF a11y_text HELPER
-                    if (config && config._isTextProcessorEnabled === false) {
-                        return text;
-                    } else {
-                        return $.a11y_text(text);
-                    }
+                    Adapt.log.warn("DEPRECATED: a11y_text is no long required. https://tink.uk/understanding-screen-reader-interaction-modes/");
+                    return text;
                 },
 
                 a11y_normalize: function(text) {
@@ -122,11 +118,11 @@ define([
                 },
 
                 a11y_aria_label: function(text) {
-                    return new Handlebars.SafeString('<div class="aria-label prevent-default'+getIgnoreClass()+'" '+getTabIndex()+' role="region">'+text+'</div>');
+                    return new Handlebars.SafeString('<div class="aria-label prevent-default role="region">'+text+'</div>');
                 },
 
                 a11y_aria_label_relative: function(text) {
-                    return new Handlebars.SafeString('<div class="aria-label relative prevent-default'+getIgnoreClass()+'" '+getTabIndex()+' role="region">'+text+'</div>');
+                    return new Handlebars.SafeString('<div class="aria-label relative prevent-default role="region">'+text+'</div>');
                 },
 
                 a11y_wrap_focus: function(text) {
@@ -156,7 +152,7 @@ define([
                         }
                     }
 
-                    return new Handlebars.SafeString(' role="heading" aria-level="'+level+'" '+getTabIndex()+' ');
+                    return new Handlebars.SafeString(' role="heading" aria-level="'+level+'"');
                 },
 
                 a11y_attrs_tabbable: function() {
@@ -173,10 +169,6 @@ define([
 
             var getTabIndex = function() {
                 return this.isActive() ? 'tabindex="0"' : 'tabindex="-1"';
-            }.bind(this);
-
-            var getIgnoreClass = function() {
-                return $.a11y.options.isTabbableTextEnabled ? '' : ' a11y-ignore';
             }.bind(this);
 
         },
@@ -213,7 +205,6 @@ define([
 
             if (this.isActive()) {
                 _.extend($.a11y.options, {
-                    isTabbableTextEnabled: true,
                     isUserInputControlEnabled: true,
                     isFocusControlEnabled: true,
                     isFocusLimited: true,
@@ -227,7 +218,6 @@ define([
                 });
             } else {
                 _.extend($.a11y.options, {
-                    isTabbableTextEnabled: false,
                     isUserInputControlEnabled: true,
                     isFocusControlEnabled: true,
                     isFocusLimited: false,

--- a/src/core/js/helpers.js
+++ b/src/core/js/helpers.js
@@ -66,7 +66,7 @@ define([
             case "%": return lvalue % rvalue;
             }
         },
-        
+
         /**
          * Equivalent to:
          *  if (conditionA || conditionB)
@@ -115,9 +115,8 @@ define([
          * Allow JSON to be a template and accessible text
          */
         compile_a11y_text: function(template, context) {
-            if (!template) return "";
-            if (template instanceof Object) template = template.toString();
-            return Handlebars.helpers.a11y_text.call(this, helpers.compile.call(this, template, context));
+            Adapt.log.warn("DEPRECATED: a11y_text is no long required. https://tink.uk/understanding-screen-reader-interaction-modes/");
+            return helpers.compile.call(this, template, context);
         },
 
         /**

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -171,127 +171,6 @@
             return $('body');
         }
 
-        //PERFORMS CALCULATIONS TO TURN HTML/TEXT STRINGS INTO TABBABLE CONTENT
-        /**
-         * Re written to group child nodes according to their readability
-         * @param  {string} text any html string
-         * @return {string}      returns html string with tabbable wrappers where appropriate
-         */
-        function makeHTMLOrTextAccessible(text) {
-
-            return getInnerHTML( makeChildNodesAccessible( wrapInDivAndMakeIntoDOMNode(text) ) );
-
-            function wrapInDivAndMakeIntoDOMNode(text) {
-                var $element;
-                try {
-                    // CONVERT ELEMENT TO DOM NODE
-                    $element = $("<div>"+text+"</div>");
-                } catch (e) {
-                    throw e;
-                }
-                return $element;
-            }
-
-            function getInnerHTML($element) {
-                var rtn = "";
-                for (var i = 0; i < $element[0].children.length; i++) {
-                    rtn += $element[0].children[i].outerHTML;
-                }
-                return rtn;
-            }
-
-            function makeChildNodesAccessible($element) {
-                //CAPTURE DOMNODE CHILDREN
-                var children = $element.children();
-
-
-                if (children.length === 0) {
-                    //IF NO CHILDREN, ASSUME TEXT ONLY, WRAP IN SPAN TAG
-                    var textContent = $element.text();
-                    if (stringTrim(textContent) === "") return $element;
-                    removeChildNodes($element);
-                    $element.append( makeElementTabbable($("<span>"+textContent+"</span>")) );
-                    return $element;
-                }
-
-
-                //IF ONLY STYLE TAGS WRAP IN SPAN
-                var styleChildCount = 0;
-                for (var c = 0; c < children.length; c++) {
-                    if ($(children[c]).is(domSelectors.wrapStyleElements)) styleChildCount++;
-                }
-                if (styleChildCount === children.length) {
-                    return $("<span>").append(makeElementTabbable($element));
-                }
-
-                //SEARCH FOR TEXT ONLY NODES AND MAKE TABBABLE
-                var newChildren = [];
-                var newCluster = [];
-                for (var i = 0; i < $element[0].childNodes.length; i++) {
-                    var child = $element[0].childNodes[i];
-                    var cloneChild = $(child.outerHTML)[0];
-                    switch(child.nodeType) {
-                    case 3: //TEXT NODE
-                        //IF TEXT NODE WRAP IN A TABBABLE SPAN
-                        if (!stringTrim(child.textContent)) break;
-                        newCluster.push( child.textContent );
-                        break;
-                    case 1: //DOM NODE
-                        var $child = $(cloneChild);
-                        if ($child.is(domSelectors.wrapStyleElements) || $child.is(domSelectors.wrapIgnoreElements)) {
-                            //IGNORE NATIVELY TABBABLE ELEMENTS AND STYLING ELEMENTS
-                            newCluster.push( $child[0].outerHTML );
-                        } else {
-                            var childChildren = $child.children();
-                            if (childChildren.length === 0) {
-                                //DO NOT DESCEND INTO TEXT ONLY NODES
-                                var textContent = $child.text();
-                                if (stringTrim(textContent) !== "") makeElementTabbable($child);
-                            } else {
-                                //DESCEND INTO NODES WITH CHILDREN
-                                makeChildNodesAccessible($child);
-                            }
-                            if (newCluster.length) {
-                                newChildren.push(makeElementTabbable($("<span>"+newCluster.join("")+"</span>")))
-                                newCluster.length = 0;
-                            }
-                            newChildren.push( $child );
-                        }
-                        break;
-                    }
-                }
-                if (newCluster.length) {
-                    newChildren.push(makeElementTabbable($("<span>"+newCluster.join("")+"</span>")))
-                    newCluster.length = 0;
-                }
-
-                removeChildNodes($element);
-                $element.append(newChildren);
-
-                return $element;
-
-                function removeChildNodes($element) {
-                    var childNodes = $element[0].childNodes.length;
-                    for (var i = childNodes - 1; i > -1 ; i--) {
-                        if ($element[0].childNodes[i].remove) $element[0].childNodes[i].remove();
-                        else if ($element[0].removeChild) $element[0].removeChild($element[0].childNodes[i]); //safari fix
-                        else if ($element[0].childNodes[i].removeNode) $element[0].childNodes[i].removeNode(true); //ie 11 fix
-                    }
-                    return $element;
-                }
-
-                //MAKES AN ELEMENT TABBABLE
-                function makeElementTabbable($element) {
-                    $element.attr({
-                        "role": "region",
-                        "tabindex": 0,
-                    }).addClass("prevent-default");
-                    return $element;
-                }
-            }
-        }
-
-
     // JQUERY UTILITY FUNCTIONS
         $.fn.scrollDisable = function() {
             if (this.length === 0) return this;
@@ -724,7 +603,6 @@
             animateDuration: 250,
             OS: "",
             isTouchDevice: false,
-            isTabbableTextEnabled: false,
             isUserInputControlEnabled: true,
             isFocusControlEnabled: true,
             isFocusLimited: false,
@@ -946,32 +824,36 @@
 
         //CONVERTS HTML OR TEXT STRING TO ACCESSIBLE HTML STRING
         $.a11y_text = function (text) {
-            var options = $.a11y.options;
+            console.log("DEPRECATED: a11y_text is no long required. https://tink.uk/understanding-screen-reader-interaction-modes/");
+            return text;
+            // var options = $.a11y.options;
 
-            if (!options.isTabbableTextEnabled) return text;
+            // if (!options.isTabbableTextEnabled) return text;
 
-            return makeHTMLOrTextAccessible(text)
+            // return makeHTMLOrTextAccessible(text)
         };
 
         //CONVERTS DOM NODE TEXT TO ACCESSIBLE DOM NODES
         $.fn.a11y_text = function(text) {
-            var options = $.a11y.options;
-
-            if (!options.isTabbableTextEnabled) {
-                if (text) {
-                    this.html(text);
-                }
-
-                return this;
-            }
-
-            for (var i = 0; i < this.length; i++) {
-                // If an argument is given then convert that to accessible text
-                // Otherwise convert existing content
-                text = text || this[i].innerHTML;
-                this[i].innerHTML = makeHTMLOrTextAccessible(text);
-            }
+            console.log("DEPRECATED: a11y_text is no long required. https://tink.uk/understanding-screen-reader-interaction-modes/");
             return this;
+            // var options = $.a11y.options;
+
+            // if (!options.isTabbableTextEnabled) {
+            //     if (text) {
+            //         this.html(text);
+            //     }
+
+            //     return this;
+            // }
+
+            // for (var i = 0; i < this.length; i++) {
+            //     // If an argument is given then convert that to accessible text
+            //     // Otherwise convert existing content
+            //     text = text || this[i].innerHTML;
+            //     this[i].innerHTML = makeHTMLOrTextAccessible(text);
+            // }
+            // return this;
         };
 
 

--- a/src/core/js/views/buttonsView.js
+++ b/src/core/js/views/buttonsView.js
@@ -100,7 +100,7 @@ define([
                         }, this));
                     }
                 }
-              
+
             } else {
 
                 var propertyName = textPropertyName[buttonState.asString];
@@ -154,7 +154,7 @@ define([
             }
 
             if (shouldDisplayAttempts) {
-                this.$('.buttons-display-inner').a11y_text(attemptsString);
+                this.$('.buttons-display-inner').html(attemptsString);
             }
 
         },

--- a/src/core/templates/article.hbs
+++ b/src/core/templates/article.hbs
@@ -14,7 +14,7 @@
         {{#if body}}
         <div class="article-body">
             <div class="article-body-inner">
-                {{{compile_a11y_text body this}}}
+                {{{compile body this}}}
             </div>
         </div>
         {{/if}}
@@ -22,7 +22,7 @@
         {{#if instruction}}
         <div class="article-instruction">
             <div class="article-instruction-inner">
-                {{{compile_a11y_text instruction this}}}
+                {{{compile instruction this}}}
             </div>
         </div>
         {{/if}}

--- a/src/core/templates/block.hbs
+++ b/src/core/templates/block.hbs
@@ -13,7 +13,7 @@
     {{#if body}}
         <div class="block-body">
             <div class="block-body-inner">
-                {{{compile_a11y_text body this}}}
+                {{{compile body this}}}
             </div>
         </div>
     {{/if}}
@@ -21,7 +21,7 @@
     {{#if instruction}}
         <div class="block-instruction">
             <div class="block-instruction-inner">
-                {{{compile_a11y_text instruction this}}}
+                {{{compile instruction this}}}
             </div>
         </div>
     {{/if}}

--- a/src/core/templates/drawerItem.hbs
+++ b/src/core/templates/drawerItem.hbs
@@ -3,6 +3,6 @@
 		<div class="drawer-item-title-inner h5">{{{title}}}</div>
 	</div>
 	<div class="drawer-item-description">
-		<div class="drawer-item-description-inner">{{{a11y_text description}}}</div>
+		<div class="drawer-item-description-inner">{{{description}}}</div>
 	</div>
 </button>

--- a/src/core/templates/notify.hbs
+++ b/src/core/templates/notify.hbs
@@ -20,7 +20,7 @@
                 {{/if}}
                 {{#if body}}
                     <div class="notify-popup-body">
-                        <div class="notify-popup-body-inner">{{{compile_a11y_text body this}}}</div>
+                        <div class="notify-popup-body-inner">{{{compile body this}}}</div>
                     </div>
                 {{/if}}
 

--- a/src/core/templates/notifyPush.hbs
+++ b/src/core/templates/notifyPush.hbs
@@ -7,10 +7,10 @@
 			{{{compile title this}}}
 		</div>
 	</div>
-	
+
 	<div class="notify-push-body">
 		<div class="notify-push-body-inner">
-			{{{compile_a11y_text body this}}}
+			{{{compile body this}}}
 		</div>
 	</div>
 </div>

--- a/src/core/templates/page.hbs
+++ b/src/core/templates/page.hbs
@@ -20,9 +20,9 @@
 					<div class="page-body">
 						<div class="page-body-inner">
 							{{#if pageBody}}
-								{{{compile_a11y_text pageBody this}}}
+								{{{compile pageBody this}}}
 							{{else}}
-								{{{compile_a11y_text body this}}}
+								{{{compile body this}}}
 							{{/if}}
 						</div>
 					</div>
@@ -31,7 +31,7 @@
 					{{#if instruction}}
 					<div class="page-instruction">
 						<div class="page-instruction-inner">
-							{{{compile_a11y_text instruction this}}}
+							{{{compile instruction this}}}
 						</div>
 					</div>
 					{{/if}}

--- a/src/core/templates/partials/component.hbs
+++ b/src/core/templates/partials/component.hbs
@@ -2,7 +2,7 @@
 {{import_globals}}
 <div class="{{_component}}-header component-header">
     <div class="{{_component}}-header-inner component-header-inner">
-        
+
         {{#if displayTitle}}
         <div class="{{_component}}-title component-title">
             <div class="{{_component}}-title-inner component-title-inner" {{{a11y_attrs_heading "component"}}}>
@@ -10,19 +10,19 @@
             </div>
         </div>
         {{/if}}
-        
+
         {{#if body}}
         <div class="{{_component}}-body component-body">
             <div class="{{_component}}-body-inner component-body-inner">
-                {{{compile_a11y_text body this}}}
+                {{{compile body this}}}
             </div>
         </div>
         {{/if}}
-        
+
         {{#if instruction}}
         <div class="{{_component}}-instruction component-instruction">
             <div class="{{_component}}-instruction-inner component-instruction-inner">
-                {{{compile_a11y_text instruction this}}}
+                {{{compile instruction this}}}
             </div>
         </div>
         {{/if}}


### PR DESCRIPTION
#2075 

* Deprecated a11y_text and associated helpers
* Removed references from core templates
* Remove tabbing from header helpers
* Removed _isTextProcessorEnabled option