### PR TITLE
accessibility: issue/#2107 allow defined focus from drawer close

### DIFF
--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -1146,21 +1146,8 @@
                 $.a11y.state.floorStack[$.a11y.state.floorStack.length-1].scrollEnable();
             }
 
-            defer(function() {
-                // Listeners for popup close may shift focus so respect this
-                if ($activeElement != $.a11y.state.$activeElement) return;
+            return $activeElement;
 
-                if ($activeElement) {
-                    state.$activeElement = $activeElement;
-                    //scroll to focused element
-                    state.$activeElement.focusOrNext().limitedScrollTo();
-                } else {
-                    $.a11y_focus();
-                }
-
-            }, this, 500);
-
-            return this;
         };
 
 

--- a/src/core/js/popupManager.js
+++ b/src/core/js/popupManager.js
@@ -11,11 +11,11 @@ define([
         $activeElement.a11y_popup();
     });
 
-    Adapt.on('popup:closed', function($toElement) {
+    Adapt.on('popup:closed', function($target) {
 
         //restore tab indexes
         var $launchedElement = $.a11y_popdown();
-        var $activeElement = $toElement || $launchedElement;
+        var $activeElement = $target || $launchedElement;
 
         if ($activeElement) {
             return $activeElement.focusOrNext();

--- a/src/core/js/popupManager.js
+++ b/src/core/js/popupManager.js
@@ -4,17 +4,25 @@ define([
 
     Adapt.on('popup:opened', function($element) {
 
-		//capture currently active element or element specified
+        //capture currently active element or element specified
         var $activeElement = $element || $(document.activeElement);
 
         //save tab indexes
         $activeElement.a11y_popup();
     });
 
-    Adapt.on('popup:closed', function() {
+    Adapt.on('popup:closed', function($toElement) {
 
         //restore tab indexes
-        $.a11y_popdown();
+        var $launchedElement = $.a11y_popdown();
+        var $activeElement = $toElement || $launchedElement;
+
+        if ($activeElement) {
+            return $activeElement.focusOrNext();
+        }
+
+        // focus on the first readable element
+        $.a11y_focus();
 
     });
 

--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -62,7 +62,7 @@ define([
 
         events: {
             'click .drawer-back': 'onBackButtonClicked',
-            'click .drawer-close':'onCloseDrawer'
+            'click .drawer-close':'onCloseClicked'
         },
 
         render: function() {
@@ -107,11 +107,13 @@ define([
             this.showDrawer(true);
         },
 
-        onCloseDrawer: function(event) {
-            if (event) {
-                event.preventDefault();
-            }
+        onCloseClicked: function(event) {
+            event.preventDefault();
             this.hideDrawer();
+        },
+
+        onCloseDrawer: function($activeElement) {
+            this.hideDrawer($activeElement);
         },
 
         toggleDrawer: function() {
@@ -162,7 +164,7 @@ define([
                 direction[this.drawerDir]=0;
                 this.$el.css(direction);
                 complete.call(this);
-                
+
             } else {
 
                 $('#shadow').velocity({opacity:1},{duration:this.drawerDuration, begin: _.bind(function() {
@@ -181,10 +183,10 @@ define([
             function complete() {
                 this.addShadowEvent();
                 Adapt.trigger('drawer:opened');
-                
+
                 //focus on first tabbable element in drawer
                 this.$el.a11y_focus();
-	    }
+        }
 
         },
 
@@ -202,10 +204,10 @@ define([
             }
         },
 
-        hideDrawer: function() {
+        hideDrawer: function($activeElement) {
             //only trigger popup:closed if drawer is visible
             if (this._isVisible) {
-                Adapt.trigger('popup:closed');
+                Adapt.trigger('popup:closed', $activeElement);
                 this._isVisible = false;
                 $('body').scrollEnable();
             } else {

--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -112,8 +112,8 @@ define([
             this.hideDrawer();
         },
 
-        onCloseDrawer: function($activeElement) {
-            this.hideDrawer($activeElement);
+        onCloseDrawer: function($toElement) {
+            this.hideDrawer($toElement);
         },
 
         toggleDrawer: function() {
@@ -204,10 +204,10 @@ define([
             }
         },
 
-        hideDrawer: function($activeElement) {
+        hideDrawer: function($toElement) {
             //only trigger popup:closed if drawer is visible
             if (this._isVisible) {
-                Adapt.trigger('popup:closed', $activeElement);
+                Adapt.trigger('popup:closed', $toElement);
                 this._isVisible = false;
                 $('body').scrollEnable();
             } else {


### PR DESCRIPTION
#2107 
* Allow `drawer:closeDrawer` to have a specified focus to element
* Moved some behaviour from `$.a11y_popdown()` to Adapt popup manager to facilitate correct focusing
