### PR TITLE
issue/#2180 Return if no defined _children type

### DIFF
--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -260,7 +260,7 @@ define([
 
         /**
          * Returns all the descendant models of a specific type
-         * @param {string} descendants Valid values are 'contentObject', 'article', 'block' or 'component'
+         * @param {string} descendants Valid values are 'contentObjects', 'articles', 'blocks' or 'components'
          * @param {object} options an object that defines the search type and the properties/values to search on. Currently only the `where` search type (equivalent to `Backbone.Collection.where()`) is supported.
          * @return {array}
          * @example

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -276,7 +276,7 @@ define([
 
             var allDescendantsModels = this.getAllDescendantModels();
             var returnedDescendants = allDescendantsModels.filter(function(model) {
-                return _.contains(typesm model.get("_type"));
+                return _.contains(types, model.get("_type"));
             });
 
             if (!options) {

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -268,34 +268,16 @@ define([
          * this.findDescendantModels('components', { where: { _isAvailable: true, _isOptional: false }});
          */
         findDescendantModels: function(descendants, options) {
-            var returnedDescendants;
-            var allDescendants = [];
-            var flattenedDescendants;
 
-            function searchChildren(models) {
-                for (var i = 0, len = models.length; i < len; i++) {
-                    var model = models[i];
-                    allDescendants.push(model.getChildren().models);
-                    flattenedDescendants = _.flatten(allDescendants);
-                }
+            var types = [
+                descendants.slice(0, -1),
+                descendants
+            ];
 
-                returnedDescendants = flattenedDescendants;
-
-                if (models.length === 0 ||
-                    models[0]._children === descendants ||
-                    models[0]._children === undefined) {
-                    return;
-                } else {
-                    allDescendants = [];
-                    searchChildren(returnedDescendants);
-                }
-            }
-
-            if (this._children === descendants) {
-                returnedDescendants = this.getChildren().models;
-            } else {
-                searchChildren(this.getChildren().models);
-            }
+            var allDescendantsModels = this.getAllDescendantModels();
+            var returnedDescendants = allDescendantsModels.filter(function(model) {
+                return _.contains(typesm model.get("_type"));
+            });
 
             if (!options) {
                 return returnedDescendants;

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -270,8 +270,7 @@ define([
         findDescendantModels: function(descendants, options) {
 
             var types = [
-                descendants.slice(0, -1),
-                descendants
+                descendants.slice(0, -1)
             ];
             if (descendants === 'contentObjects') {
                 types.push.apply(types, ['page', 'menu']);

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -281,7 +281,9 @@ define([
 
                 returnedDescendants = flattenedDescendants;
 
-                if (models.length === 0 || models[0]._children === descendants) {
+                if (models.length === 0 ||
+                    models[0]._children === descendants ||
+                    models[0]._children === undefined) {
                     return;
                 } else {
                     allDescendants = [];

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -260,7 +260,7 @@ define([
 
         /**
          * Returns all the descendant models of a specific type
-         * @param {string} descendants Valid values are 'contentObjects', 'articles', 'blocks' or 'components'
+         * @param {string} descendants Valid values are 'contentObjects', 'pages', 'menus', 'articles', 'blocks' or 'components'
          * @param {object} options an object that defines the search type and the properties/values to search on. Currently only the `where` search type (equivalent to `Backbone.Collection.where()`) is supported.
          * @return {array}
          * @example
@@ -273,6 +273,9 @@ define([
                 descendants.slice(0, -1),
                 descendants
             ];
+            if (descendants === 'contentObjects') {
+                types.push.apply(types, ['page', 'menu']);
+            }
 
             var allDescendantsModels = this.getAllDescendantModels();
             var returnedDescendants = allDescendantsModels.filter(function(model) {


### PR DESCRIPTION
#2180 
* Stop findDescendantModels descending into models with no defined _children type - itemsComponentModel specifically at the moment.