### PR TITLE
Fixes #2212 - prepends the current working directory to the script path

### DIFF
--- a/grunt/tasks/scripts.js
+++ b/grunt/tasks/scripts.js
@@ -32,7 +32,7 @@ module.exports = function(grunt) {
                 if (!script) return done();
 
                 try {
-                    var buildModule = require(path.join(plugindir, script));
+                    var buildModule = require(path.join(process.cwd(), plugindir, script));
                     buildModule(fs, path, grunt.log.writeln, {
                        sourcedir: options.sourcedir,
                        outputdir: options.outputdir,


### PR DESCRIPTION
Without the full path to the JS this was causing an error.