### PR TITLE
Issue/2209-legacy - Fix toggleBtn not closing the drawer when only 1 drawer item

### DIFF
--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -139,9 +139,13 @@ define([
                 this.$('.drawer-back').addClass('display-none');
                 this._isCustomViewVisible = false;
                 this.emptyDrawer();
-                if(this.collection.models.length === 1) {
+                if (this.collection.models.length === 1) {
+                    // This callback triggers openCustomView() and sets
+                    // _isCustomViewVisible to true, causing toggleDrawer()
+                    // to re-render the drawer on every toggle button press
                     Adapt.trigger(this.collection.models[0].get('eventCallback'));
-                    // These are only drawer items so set customView to false
+                    // Set _isCustomViewVisible to false to prevent re-rendering
+                    // the drawer and fix the toggle functionality on toggle button press
                     this._isCustomViewVisible = false;
                 } else {
                     this.renderItems();

--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -141,6 +141,8 @@ define([
                 this.emptyDrawer();
                 if(this.collection.models.length === 1) {
                     Adapt.trigger(this.collection.models[0].get('eventCallback'));
+                    // These are only drawer items so set customView to false
+                    this._isCustomViewVisible = false;
                 } else {
                     this.renderItems();
                     Adapt.trigger('drawer:openedItemView');


### PR DESCRIPTION
Setting this._isCustomViewVisible = false; after that creates this UX:

A user can click toggleDrawer it will open and it will show the drawerItems
A user can click progressBar when drawer is open and it will show progressBar stats in the drawer
A user can then click toggleDrawer again and it will show the drawerItems again
A further click on toggleDrawer will hide the drawer
This should be in keeping with the link adaptlearning/adapt_framework#218 @tomgreenfield mentioned but also hiding the drawer using the toggleBtn

This was originally here: https://github.com/adaptlearning/adapt_framework/pull/2211

Not sure what happened or why it was closed (or if it was me who closed it) but regardless here is the new one.