### PR TITLE
accessibility: fixes #2233 Navigation refocuses on body

### DIFF
--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -195,12 +195,14 @@ define([
         // Then scrollTo element
         Adapt.once('pageView:ready', function() {
             _.defer(function() {
+                Adapt.router.set("_shouldNavigateFocus", true);
                 Adapt.scrollTo(selector, settings);
             });
         });
 
         var shouldReplaceRoute = settings.replace || false;
-
+        
+        Adapt.router.set("_shouldNavigateFocus", false);
         Backbone.history.navigate('#/id/' + currentPage.get('_id'), {trigger: true, replace: shouldReplaceRoute});
     };
 

--- a/src/core/js/models/routerModel.js
+++ b/src/core/js/models/routerModel.js
@@ -5,11 +5,13 @@ define([
  	var RouterModel = Backbone.Model.extend({
 
  		defaults: {
- 			_canNavigate: true
+ 			_canNavigate: true,
+			_shouldNavigateFocus: true
  		},
 
  		lockedAttributes: {
- 			_canNavigate: false
+ 			_canNavigate: false,
+			_shouldNavigateFocus: false
  		}
  		
  	});

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -375,7 +375,7 @@ define([
         },
 
         handleNavigationFocus: function() {
-            if (!Adapt.router.get("_shouldNavigateReFocus")) return;
+            if (!Adapt.router.get("_shouldNavigateFocus")) return;
             // Body will be forced to accept focus to start the
             // screen reader reading the page.
             $("body").focusNoScroll();

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -138,7 +138,8 @@ define([
                     Adapt.once('menuView:ready', function() {
                         // Allow navigation.
                         Adapt.router.set('_canNavigate', true, { pluginName: 'adapt' });
-                    });
+                        this.handleNavigationFocus();
+                    }.bind(this));
 
                     Adapt.trigger('router:menu', Adapt.course);
                 }, this));
@@ -179,7 +180,8 @@ define([
                                     Adapt.once('pageView:ready', function() {
                                         // Allow navigation.
                                         Adapt.router.set('_canNavigate', true, { pluginName: 'adapt' });
-                                    });
+                                        this.handleNavigationFocus();
+                                    }.bind(this));
                                     Adapt.trigger('router:page', currentModel);
                                     this.$wrapper.append(new PageView({ model: currentModel }).$el);
                                 }, this));
@@ -189,7 +191,8 @@ define([
                                     Adapt.once('menuView:ready', function() {
                                         // Allow navigation.
                                         Adapt.router.set('_canNavigate', true, { pluginName: 'adapt' });
-                                    });
+                                        this.handleNavigationFocus();
+                                    }.bind(this));
                                     Adapt.trigger('router:menu', currentModel);
                                 }, this));
                             }
@@ -369,6 +372,13 @@ define([
             Adapt.once('pageView:ready menuView:ready', function() {
                 document.title = documentTitle;
             });
+        },
+
+        handleNavigationFocus: function() {
+            if (!Adapt.router.get("_shouldNavigateReFocus")) return;
+            // Body will be forced to accept focus to start the
+            // screen reader reading the page.
+            $("body").focusNoScroll();
         }
     });
 


### PR DESCRIPTION
#2233 
Added behaviour to allow the body to become focused once adapt navigates.
This causes screen readers to notify the user of changed page content.

List of outstanding PRs: https://github.com/adaptlearning/adapt_framework/issues/2206.