### PR TITLE
accessibility: fixes 2232 2231 Cause click events to focus

### DIFF
--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -487,15 +487,13 @@ define([
     // PRIVATE EVENT HANDLERS
         function onClick(event) {
             var $element = $(event.target);
-            if ($element.parents(domSelectors.globalTabIndexElements).length) return;
-            if ($element.is(domSelectors.globalTabIndexElements)) return;
-            $element.attr({
-                'tabindex': '-1',
-                'data-a11y-force-focus': true
-            });
-            $element.focus();
+            var $stack = $().add($element).add($element.parents());
+            var $focusable = $stack.filter(domSelectors.globalTabIndexElements);
+            if (!$focusable.length) return;
+            // Force focus for screen reader enter / space press
+            $focusable[0].focus();
         }
-
+    
         function onFocus(event) {
             var options = $.a11y.options;
             var state = $.a11y.state;
@@ -570,15 +568,18 @@ define([
 
         function a11y_setupFocusControlListeners() {
             var options = $.a11y.options;
-            $("body")
-                .off("click", '*', onClick)
-                .off("focus", '*', onFocus)
-                .off("blur", '*', onBlur);
+            var $body = $('body');
+            $body
+                .off('focus', '*', onFocus)
+                .off('blur', '*', onBlur);
 
-            $("body")
-                .on("click", '*', onClick)
-                .on("focus", '*', onFocus)
-                .on("blur", '*', onBlur);
+            $body
+                .on('focus', '*', onFocus)
+                .on('blur', '*', onBlur);
+
+            // "Capture" event attachement for click
+            $body[0].removeEventListener('click', onClick);
+            $body[0].addEventListener('click', onClick, true);
         }
 
         function a11y_setupFocusGuard() {

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -578,7 +578,7 @@ define([
                 .on('focus', onFocus)
                 .on("blur", onBlur);
 
-            // "Capture" event attachement for click
+            // "Capture" event attachment for click
             $body[0].removeEventListener('click', onClick);
             $body[0].addEventListener('click', onClick, true);
         }

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -495,7 +495,7 @@ define([
             if (options.isDebug) console.log("clicked", $focusable[0]);
             $focusable[0].focus();
         }
-    
+
         function onFocus(event) {
             var options = $.a11y.options;
             var state = $.a11y.state;

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -486,11 +486,13 @@ define([
 
     // PRIVATE EVENT HANDLERS
         function onClick(event) {
+            var options = $.a11y.options;
             var $element = $(event.target);
             var $stack = $().add($element).add($element.parents());
             var $focusable = $stack.filter(domSelectors.globalTabIndexElements);
             if (!$focusable.length) return;
             // Force focus for screen reader enter / space press
+            if (options.isDebug) console.log("clicked", $focusable[0]);
             $focusable[0].focus();
         }
     
@@ -506,11 +508,6 @@ define([
             if (options.isDebug) console.log("focus", $element[0]);
 
             state.$activeElement = $(event.target);
-
-            if (state.$activeElement.is(domSelectors.nativeTabElements)) {
-                //Capture that the user has interacted with a native form element
-                $.a11y.userInteracted = true;
-            }
         }
 
         function onBlur(event) {
@@ -518,7 +515,7 @@ define([
             var $element = $(element);
 
             if ($element.is('[data-a11y-force-focus]')) {
-                $element.removeAttr('tabindex');
+                $element.removeAttr('tabindex data-a11y-force-focus');
             }
         }
 
@@ -571,11 +568,15 @@ define([
             var $body = $('body');
             $body
                 .off('focus', '*', onFocus)
-                .off('blur', '*', onBlur);
+                .off('blur', '*', onBlur)
+                .off('focus', onFocus)
+                .off("blur", onBlur);
 
             $body
                 .on('focus', '*', onFocus)
-                .on('blur', '*', onBlur);
+                .on('blur', '*', onBlur)
+                .on('focus', onFocus)
+                .on("blur", onBlur);
 
             // "Capture" event attachement for click
             $body[0].removeEventListener('click', onClick);


### PR DESCRIPTION
#2231 
Force click events on focusable elements to assign focus. Useful for screen readers to maintain placement on returning from popups.

#2232 
Stop click causing focus on non-focusable elements.

List of outstanding PRs: https://github.com/adaptlearning/adapt_framework/issues/2206.