### PR TITLE
accessibility: issue/2179 Remove focusguard from box flow

### DIFF
--- a/src/core/less/base.less
+++ b/src/core/less/base.less
@@ -273,7 +273,7 @@
 
     /*IPAD: Stop accessibility cursor focusing until end of page;*/
     .touchevents & {
-        position: relative !important;
+        position: absolute !important;
     }
 
     /*DESKTOP: stop focus making window jump to bottom of page;*/


### PR DESCRIPTION
#2179 
* Remove focusguard from document flow whilst retaining top position to remove the whitespace height but keep the element in position

List of outstanding PRs: https://github.com/adaptlearning/adapt_framework/issues/2206