### PR TITLE
accessibility: issue/2080 Fixed bug, forced [disabled] focus loss to focus forward

### DIFF
--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -525,7 +525,7 @@ define([
             // due to the addition of a disabled class
             if ($element.is("[disabled]")) {
                 // Move focus to next readable element
-                defer($element.focusNext, $element, 1000);
+                $element.focusNext();
             }
         }
 

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -330,7 +330,7 @@ define([
                 $found = $sibling.findWalk(iterator);
                 if ($found && $found.length) return true;
             });
-            if ($found) return $found;
+            if ($found && $found.length) return $found;
 
             // move through parents towards the body element
             var $branch = this.add(this.parents()).toArray().reverse();
@@ -516,6 +516,16 @@ define([
 
             if ($element.is('[data-a11y-force-focus]')) {
                 $element.removeAttr('tabindex data-a11y-force-focus');
+            }
+
+            // From here, only check source elements
+            if (event.target !== event.currentTarget) return;
+
+            // Check if element losing focus is losing focus
+            // due to the addition of a disabled class
+            if ($element.is("[disabled]")) {
+                // Nove focus to next readable element
+                defer($element.focusNext, $element, 1000);
             }
         }
 

--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -524,7 +524,7 @@ define([
             // Check if element losing focus is losing focus
             // due to the addition of a disabled class
             if ($element.is("[disabled]")) {
-                // Nove focus to next readable element
+                // Move focus to next readable element
                 defer($element.focusNext, $element, 1000);
             }
         }


### PR DESCRIPTION
#2080 
* Fixed bug in findForward
* When an element loses focus due to the addition of the [disabled] attribute, it will now force a focus forward instead of falling backward.

List of outstanding PRs: https://github.com/adaptlearning/adapt_framework/issues/2206.