### PR TITLE
accessibility issue/2304 role="heading" isReadable

### DIFF
--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -28,7 +28,7 @@ define([
             "focusableElementsAccessible": ":not(a,button,input,select,textarea)[tabindex]",
             "hideableElements": ".a11y-hideable",
             "ariaLabelElements": "div[aria-label], span[aria-label]",
-            "readableElements": "[aria-label],[aria-labelledby],[alt]"
+            "readableElements": "[role=heading],[aria-label],[aria-labelledby],[alt]"
         };
 
     // JQUERY INJECTED ELEMENTS


### PR DESCRIPTION
#2304 
* Forces focus from trickle button to land directly on the heading rather than on the heading children. This solves the misreading in JAWS