### PR TITLE
Add ability to insert variables into HTML files

### DIFF
--- a/grunt/config/replace.js
+++ b/grunt/config/replace.js
@@ -89,7 +89,10 @@ module.exports = function (grunt, options) {
         {
           expand: true,
           flatten: true,
-          src: [path.join(options.outputdir, '*.xml')],
+          src: [
+            path.join(options.outputdir, '*.xml'),
+            path.join(options.outputdir, '*.html')
+          ],
           dest: options.outputdir
         }
       ]


### PR DESCRIPTION
In our theme, we want to add some course data into meta tags, etc, in a custom `required/index.html` file. 

Currently, in `required`, the XML files are processed so you can do things like this from https://github.com/adaptlearning/adapt-contrib-spoor/blob/master/required/imsmanifest.xml#L9

```
 <langstring xml:lang="x-none"><![CDATA[@@course.title]]></langstring>
```

if we add `*.html` to the grunt replace job as well as `*.xml`, we should be able to do the same thing in index.html, meaning that themes can then automatically pull in data from the course. For instance:

```
 <title><![CDATA[@@course.title]]></title>
```

This is my first venture into the internals of the Adapt framework, so if there is a way I should be testing these jobs, or otherwise improving my PR, please tell me!