### PR TITLE
Fix _disableAnimationFor (framework 3)

### DIFF
--- a/src/core/schema/config.model.schema
+++ b/src/core/schema/config.model.schema
@@ -318,7 +318,8 @@
     },
     "_disableAnimationFor": {
       "type": "array",
-      "required": false,
+      "default": [],
+      "title": "Disable animation for",
       "isSetting": true,
       "inputType": "List",
       "help": "Allows you to disable some animations (e.g. the drawer close animation) on platform(s) where they are not performing well, using CSS selectors to target the relevant platform(s) via the classes on the HTML element."


### PR DESCRIPTION
Apologies, missed a tiny but crucial amend, [already merged into framework 4](https://github.com/adaptlearning/adapt_framework/commit/0e8bed46c38624cb2dc70e70e76f42536427e44d#diff-0909d803337ea772187699d7c7729838), that fixes the authoring tool's _Configuration settings_ page.

Part of #2306.