### PR TITLE
Resolves #2247, adds a shim to support custom manifest 'identifier'

### DIFF
--- a/grunt/config/replace.js
+++ b/grunt/config/replace.js
@@ -70,7 +70,9 @@ module.exports = function (grunt, options) {
             configJson._spoor._advancedSettings._manifestIdentifier = 'adapt_scorm';
           }
         } else {
-          configJson._spoor._advancedSettings._manifestIdentifier = 'adapt_scorm';
+          configJson._spoor._advancedSettings = { 
+            _manifestIdentifier: 'adapt_scorm'
+          };
         }
       }
 

--- a/grunt/config/replace.js
+++ b/grunt/config/replace.js
@@ -65,15 +65,8 @@ module.exports = function (grunt, options) {
 
       // Shim to preserve the 'adapt_scorm' identifier.
       if (configJson.hasOwnProperty('_spoor')) {
-        if (configJson._spoor._advancedSettings) {
-          if (!configJson._spoor._advancedSettings._manifestIdentifier) {
-            configJson._spoor._advancedSettings._manifestIdentifier = 'adapt_scorm';
-          }
-        } else {
-          configJson._spoor._advancedSettings = { 
-            _manifestIdentifier: 'adapt_scorm'
-          };
-        }
+        configJson._spoor._advancedSettings = configJson._spoor._advancedSettings || {};
+        configJson._spoor._advancedSettings._manifestIdentifier = spoor._advancedSettings._manifestIdentifier || 'adapt_scorm';
       }
 
       // Combine the course and config JSON so both can be passed to replace.  

--- a/grunt/config/replace.js
+++ b/grunt/config/replace.js
@@ -62,7 +62,18 @@ module.exports = function (grunt, options) {
           grunt.log.writeln('WARNING: xAPI activityID has not been set');
         }
       }
-      
+
+      // Shim to preserve the 'adapt_scorm' identifier.
+      if (configJson.hasOwnProperty('_spoor')) {
+        if (comfigJson._spoor._advancedSettings) {
+          if (!comfigJson._spoor._advancedSettings._manifestIdentifier) {
+            comfigJson._spoor._advancedSettings._manifestIdentifier = 'adapt_scorm';
+          }
+        } else {
+          comfigJson._spoor._advancedSettings._manifestIdentifier = 'adapt_scorm';
+        }
+      }
+
       // Combine the course and config JSON so both can be passed to replace.  
       return {
         'course': filterNullValues(courseJson),

--- a/grunt/config/replace.js
+++ b/grunt/config/replace.js
@@ -65,12 +65,12 @@ module.exports = function (grunt, options) {
 
       // Shim to preserve the 'adapt_scorm' identifier.
       if (configJson.hasOwnProperty('_spoor')) {
-        if (comfigJson._spoor._advancedSettings) {
-          if (!comfigJson._spoor._advancedSettings._manifestIdentifier) {
-            comfigJson._spoor._advancedSettings._manifestIdentifier = 'adapt_scorm';
+        if (configJson._spoor._advancedSettings) {
+          if (!configJson._spoor._advancedSettings._manifestIdentifier) {
+            configJson._spoor._advancedSettings._manifestIdentifier = 'adapt_scorm';
           }
         } else {
-          comfigJson._spoor._advancedSettings._manifestIdentifier = 'adapt_scorm';
+          configJson._spoor._advancedSettings._manifestIdentifier = 'adapt_scorm';
         }
       }
 


### PR DESCRIPTION
This ensures 'adapt_scorm' will be used as a default if the corresponding property is missing.