### PR TITLE
Resolves #2247, adds a shim to preserve adapt_manifest identifier

### DIFF
--- a/grunt/config/replace.js
+++ b/grunt/config/replace.js
@@ -62,7 +62,13 @@ module.exports = function (grunt, options) {
           grunt.log.writeln('WARNING: xAPI activityID has not been set');
         }
       }
-      
+
+      // Shim to preserve the 'adapt_manifest' identifier.
+      if (configJson.hasOwnProperty('_spoor')) {
+        configJson._spoor._advancedSettings = configJson._spoor._advancedSettings || {};
+        configJson._spoor._advancedSettings._manifestIdentifier = spoor._advancedSettings._manifestIdentifier || 'adapt_manifest';
+      }
+
       // Combine the course and config JSON so both can be passed to replace.  
       return {
         'course': filterNullValues(courseJson),


### PR DESCRIPTION
This commit supports a corresponding change in Spoor by providing backwards
compatibility for JSONs which may be missing the 'manifiest_identifier' attribute.