### PR TITLE
issue/2339: Fixed helper expecting missing object

### DIFF
--- a/src/core/js/helpers.js
+++ b/src/core/js/helpers.js
@@ -186,7 +186,7 @@ define([
          */
         component_description: function(override, context) {
             if (!this._isA11yComponentDescriptionEnabled) return;
-            if (!this._globals._components['_'+this._component]) return;
+            if (!this._globals._components || !this._globals._components['_'+this._component]) return;
             var hasOverride = (arguments.length > 1);
             var description;
             if (hasOverride) {


### PR DESCRIPTION
#2339 
* When no component globals are included the container object isn't created. This happens when only using a text/graphic component in a course.