### PR TITLE
Resolves #2386, switches listeners out for 'configModel:dataLoaded'

### DIFF
--- a/src/core/js/logging.js
+++ b/src/core/js/logging.js
@@ -13,11 +13,11 @@ define([
         
         initialize: function() {
 
-            Adapt.once('configModel:loadCourseData', this.onLoadCourseData.bind(this));
+            Adapt.once('configModel:dataLoaded', this.onLoadConfigData.bind(this));
 
         },
         
-        onLoadCourseData: function() {
+        onLoadConfigData: function() {
 
             this.loadConfig();
 

--- a/src/core/js/scrolling.js
+++ b/src/core/js/scrolling.js
@@ -10,7 +10,7 @@ define([
 
         initialize: function() {
             this._checkApp();
-            Adapt.once('configModel:loadCourseData', this._loadConfig.bind(this));
+            Adapt.once('configModel:dataLoaded', this._loadConfig.bind(this));
         },
 
         _checkApp: function() {

--- a/src/core/js/tracking.js
+++ b/src/core/js/tracking.js
@@ -13,7 +13,7 @@ define([
         _assessmentState: null,
 
         initialize: function() {
-            Adapt.once('configModel:loadCourseData', this.loadConfig.bind(this));
+            Adapt.once('configModel:dataLoaded', this.loadConfig.bind(this));
             Adapt.on('app:dataReady', this.setupEventListeners.bind(this));
         },
 


### PR DESCRIPTION
The tracking, logging and scrolling modules were only checking the Adapt.config object so once it's loaded they are ok to continue.