### PR TITLE
Resolves #2386, switches listeners out for 'configModel:dataLoaded'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased][unreleased]
 
+## [3.5.1] - 2019-03-19
+### Fixed
+- Language Picker breaks tracking.js module completion criteria ([#2386](https://github.com/adaptlearning/adapt_framework/issues/2386))
+
 ## [3.5.0] - 2019-01-30
 ### Added
 - Support for changing the identifier in SCORM imsmanifest.xml ([#2247](https://github.com/adaptlearning/adapt_framework/issues/2247))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt_framework",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Adapt Learning output framework",
   "repository": {
     "type": "git",

--- a/src/core/js/logging.js
+++ b/src/core/js/logging.js
@@ -13,11 +13,11 @@ define([
         
         initialize: function() {
 
-            Adapt.once('configModel:loadCourseData', this.onLoadCourseData.bind(this));
+            Adapt.once('configModel:dataLoaded', this.onLoadConfigData.bind(this));
 
         },
         
-        onLoadCourseData: function() {
+        onLoadConfigData: function() {
 
             this.loadConfig();
 

--- a/src/core/js/tracking.js
+++ b/src/core/js/tracking.js
@@ -13,7 +13,7 @@ define([
         _assessmentState: null,
 
         initialize: function() {
-            Adapt.once('configModel:loadCourseData', this.loadConfig.bind(this));
+            Adapt.once('configModel:dataLoaded', this.loadConfig.bind(this));
             Adapt.on('app:dataReady', this.setupEventListeners.bind(this));
         },
 


### PR DESCRIPTION
The tracking, logging and scrolling modules were only checking the Adapt.config object so once it's loaded they are ok to continue.