### PR TITLE
issue/#2398 - Incorrect Unknown lesson status when completing assessment first

### DIFF
--- a/src/core/js/tracking.js
+++ b/src/core/js/tracking.js
@@ -71,14 +71,17 @@ define([
 
             // Assessment completed required.
             if (this._config._requireAssessmentCompleted) {
-                if (!this._assessmentState) {
+                if (!this._assessmentState && !Adapt.offlineStorage.get("assessment")) {
                     // INCOMPLETE: assessment is not complete.
                     return completionData;
                 }
 
                 // PASSED/FAILED: assessment completed.
-                completionData.status = this._assessmentState.isPass ? COMPLETION_STATE.PASSED : COMPLETION_STATE.FAILED;
-                completionData.assessment = this._assessmentState;
+                completionData.status =
+					(this._assessmentState && this._assessmentState.isPass) ||
+					Adapt.offlineStorage.get("_isAssessmentPassed")
+                    ? COMPLETION_STATE.PASSED : COMPLETION_STATE.FAILED
+				completionData.assessment = this._assessmentState || null
 
                 return completionData;
             }

--- a/src/core/js/tracking.js
+++ b/src/core/js/tracking.js
@@ -71,7 +71,7 @@ define([
 
             // Assessment completed required.
             if (this._config._requireAssessmentCompleted) {
-                if (!this._assessmentState && !Adapt.offlineStorage.get("assessment")) {
+                if (!this._assessmentState && !Adapt.offlineStorage.get('assessment')) {
                     // INCOMPLETE: assessment is not complete.
                     return completionData;
                 }
@@ -79,7 +79,7 @@ define([
                 // PASSED/FAILED: assessment completed.
                 completionData.status =
 					(this._assessmentState && this._assessmentState.isPass) ||
-					Adapt.offlineStorage.get("_isAssessmentPassed")
+					Adapt.offlineStorage.get('_isAssessmentPassed')
                     ? COMPLETION_STATE.PASSED : COMPLETION_STATE.FAILED
 				completionData.assessment = this._assessmentState || null
 


### PR DESCRIPTION
 If a course has an assessment and course content tracked as part of the completion criteria, in instances where the assessment is completed first, the session closed and then resumed, when the rest of the course content is completed the lesson status is incorrectly showing as "Unknown".