### PR TITLE
issue/2415: Fix ItemsComponentModel inheritance chain

### DIFF
--- a/src/core/js/models/itemsQuestionModel.js
+++ b/src/core/js/models/itemsQuestionModel.js
@@ -4,7 +4,10 @@ define([
     'core/js/models/itemsComponentModel'
 ], function(Adapt, QuestionModel, ItemsComponentModel) {
 
-    var BlendedModel = QuestionModel.extend(ItemsComponentModel.prototype);
+    var ItemsComponentModelFunctions = _.extendOwn({}, ItemsComponentModel.prototype);
+    delete ItemsComponentModelFunctions.constructor;
+    var BlendedModel = QuestionModel.extend(ItemsComponentModelFunctions);
+    
     var ItemsQuestionModel = BlendedModel.extend({
 
         init: function() {


### PR DESCRIPTION
#2415 
* Stopped `QuestionModel.extend` from modifying `ItemsComponentModel.prototype.constructor` which was causing `QuestionModel` to appear in the inheritance chain of `ItemsComponentModel`. The process of blending `QuestionModel` and `ItemsComponentModel` now takes only the own properties from `ItemsComponentModel.prototype`, minus the `constructor` function and brings them into a blended class first.
(The `constructor` function is assigned by Backbone as an enumerable property as part of the `.extend` process.)