### PR TITLE
Resolves #2439, adds a timeout to Adapt.wait

### DIFF
--- a/src/core/js/wait.js
+++ b/src/core/js/wait.js
@@ -3,11 +3,13 @@ define(function() {
      var Wait = Backbone.Controller.extend({
 
         initialize: function() {
-            _.bindAll(this, "begin", "end");
+            _.bindAll(this, 'begin', 'end');
         },
 
         _waitCount: 0,
         _callbackHandle: null,
+        _timeoutHandlerId: null,
+        _timeoutInSeconds: 7,
 
         /**
          * Returns true if there are items in the waiting count.
@@ -19,6 +21,35 @@ define(function() {
         },
 
         /**
+         * Starts or re-starts a timer to ensure that pending calls to end()
+         * are actually executed after a timeout period.
+         */
+        startTimer: function() {
+            this.stopTimer();
+
+            this._timeoutHandlerId = setInterval(function() {
+              // Flush Adapt.wait due to timeout
+              while (this._waitCount > 0) {
+                // Trigger an end() for anything waiting.
+                this.end();
+              }
+  
+              if (this._waitCount === 0) {
+                this.stopTimer();
+              }
+            }.bind(this), this._timeoutInSeconds * 1000)
+        },
+
+        /**
+         * Clears the timer.
+         */
+        stopTimer: function() {
+            if (this._timeoutHandlerId) {
+              clearInterval(this._timeoutHandlerId);
+            }
+        },
+
+        /**
          * Add one item to the waiting count.
          * 
          * @return {Object}
@@ -26,7 +57,7 @@ define(function() {
         begin: function() {
 
             if (!this.isWaiting()) {
-                this.trigger("wait");
+                this.trigger('wait');
             }
 
             this._waitCount++;
@@ -64,7 +95,7 @@ define(function() {
             this._callbackHandle = setTimeout(function() {
 
                 this._callbackHandle = null;
-                this.trigger("ready");
+                this.trigger('ready');
 
             }.bind(this), 0);
 
@@ -81,7 +112,7 @@ define(function() {
         queue: function(callback) {
 
             this.begin();
-            this.once("ready", callback);
+            this.once('ready', callback);
             this.end();
 
             return this;
@@ -98,7 +129,7 @@ define(function() {
 
             this.begin();
             _.defer(function() {
-                callback(this.end);
+                _.once(callback(this.end));
             }.bind(this));
 
             return this;

--- a/src/core/js/wait.js
+++ b/src/core/js/wait.js
@@ -28,15 +28,15 @@ define(function() {
             this.stopTimer();
 
             this._timeoutHandlerId = setInterval(function() {
-              // Flush Adapt.wait due to timeout
-              while (this._waitCount > 0) {
-                // Trigger an end() for anything waiting.
-                this.end();
-              }
+                // Flush Adapt.wait due to timeout
+                while (this._waitCount > 0) {
+                    // Trigger an end() for anything waiting.
+                    this.end();
+                }
   
-              if (this._waitCount === 0) {
-                this.stopTimer();
-              }
+                if (this._waitCount === 0) {
+                    this.stopTimer();
+                }
             }.bind(this), this._timeoutInSeconds * 1000)
         },
 
@@ -45,7 +45,7 @@ define(function() {
          */
         stopTimer: function() {
             if (this._timeoutHandlerId) {
-              clearInterval(this._timeoutHandlerId);
+                clearInterval(this._timeoutHandlerId);
             }
         },
 
@@ -67,6 +67,8 @@ define(function() {
                 this._callbackHandle = null;
             }
 
+            this.startTimer();
+
             return this;
 
         },
@@ -83,6 +85,10 @@ define(function() {
             }
 
             this._waitCount--;
+
+            if (this._waitCount === 0) {
+                this.stopTimer();
+            }
 
             if (this.isWaiting()) {
                 return this;
@@ -129,7 +135,7 @@ define(function() {
 
             this.begin();
             _.defer(function() {
-                _.once(callback(this.end));
+                callback(_.once(this.end));
             }.bind(this));
 
             return this;


### PR DESCRIPTION
To prevent an unhandled expection or a call to begin() not having a corresponding end() from blocking rendering of the Adapt content, a 7-second timeout is now added on every begin.  If the time has elapsed since the last begin() the outstanding calls to Adapt.wait.end() will be triggered.

Also added a _.once() call to the for() callback and replaced double quote marks in strings with single quotes.