### PR TITLE
pass all three arguments when calling removeEventListener

### DIFF
--- a/src/core/js/libraries/jquery.a11y.js
+++ b/src/core/js/libraries/jquery.a11y.js
@@ -550,9 +550,7 @@ define([
     // PRIVATE $.a11y FUNCTIONS
         function a11y_setupScrollListeners() {
             window.addEventListener("wheel", nativePreventScroll, { passive: false });
-            window.addEventListener("mousewheel", nativePreventScroll, { passive: false });
             document.addEventListener("wheel", nativePreventScroll, { passive: false });
-            document.addEventListener("mousewheel", nativePreventScroll, { passive: false });
             $(window).on("touchstart", onScrollStartCapture); // mobile
             window.addEventListener("touchmove", nativePreventScroll, { passive: false }); // mobile
             $(window).on("touchend", onScrollEndCapture); // mobile
@@ -560,10 +558,8 @@ define([
         }
 
         function a11y_removeScrollListeners() {
-            window.removeEventListener("wheel", nativePreventScroll);
-            window.removeEventListener("mousewheel", nativePreventScroll);
-            document.removeEventListener("wheel", nativePreventScroll);
-            document.removeEventListener("mousewheel", nativePreventScroll);
+            window.removeEventListener("wheel", nativePreventScroll, { passive: false });// shouldn't need to supply 3rd arg when removing, but IE11 won't remove the event listener if you don't - see https://github.com/adaptlearning/adapt_framework/issues/2466
+            document.removeEventListener("wheel", nativePreventScroll, { passive: false });
             $(window).off("touchstart", onScrollStartCapture); // mobile
             window.removeEventListener("touchmove", nativePreventScroll); // mobile
             $(window).off("touchend", onScrollEndCapture); // mobile


### PR DESCRIPTION
else IE11 won't actually remove it - fixes #2466

also remove 'mousewheel' as it's deprecated and all browsers now have support for 'wheel'