### PR TITLE
Resolves #2480, adds a guard on '_items' property

### DIFF
--- a/src/core/js/models/itemsComponentModel.js
+++ b/src/core/js/models/itemsComponentModel.js
@@ -21,7 +21,7 @@ define([
         },
 
         setUpItems: function() {
-            var items = this.get('_items') || [];
+            var items = this.get('_items') || []; // see https://github.com/adaptlearning/adapt_framework/issues/2480
             items.forEach(function(item, index) {
                 item._index = index;
             });

--- a/src/core/js/models/itemsComponentModel.js
+++ b/src/core/js/models/itemsComponentModel.js
@@ -21,7 +21,7 @@ define([
         },
 
         setUpItems: function() {
-            var items = this.get('_items');
+            var items = this.get('_items') || [];
             items.forEach(function(item, index) {
                 item._index = index;
             });


### PR DESCRIPTION
If '_items' was not set this would throw an error which would prevent the content from loading.