### PR TITLE
config.json: change _isFocusOutlineKeyboardOnlyEnabled to true

### DIFF
--- a/src/course/config.json
+++ b/src/course/config.json
@@ -21,7 +21,7 @@
             "_notify": 1
         },
         "_options": {
-            "_isFocusOutlineKeyboardOnlyEnabled": false,
+            "_isFocusOutlineKeyboardOnlyEnabled": true,
             "_isFocusOutlineDisabled": false,
             "_isFocusAssignmentEnabled": true,
             "_isFocusOnClickEnabled": true,


### PR DESCRIPTION
to match the default value in a11y.js (see #2530)