### PR TITLE
correct accidental use of ES6 'Shorthand method definition'

### DIFF
--- a/src/core/js/a11y.js
+++ b/src/core/js/a11y.js
@@ -740,7 +740,7 @@ define([
          * @param {Object} $focusElement Set a new element to focus on.
          * @returns {Object} Returns previously set focus element.
          */
-        setPopupCloseTo($focusElement) {
+        setPopupCloseTo: function($focusElement) {
             return this._popup.setCloseTo($focusElement);
         }
 


### PR DESCRIPTION
by adding `function` keyword

fixes #2570 