### PR TITLE
Updated inview selector

### DIFF
--- a/src/core/js/views/componentView.js
+++ b/src/core/js/views/componentView.js
@@ -42,7 +42,7 @@ define([
      * for an example. Defaults to `view.setCompletionStatus` if not specified.
      */
     setupInviewCompletion: function(inviewElementSelector, callback) {
-      this.$inviewElement = this.$(inviewElementSelector || '.component-inner');
+      this.$inviewElement = this.$(inviewElementSelector || '.component__inner');
       this.inviewCallback = (callback || this.setCompletionStatus);
 
       this.$inviewElement.on('inview.componentView', this.onInview.bind(this));

--- a/src/core/js/views/componentView.js
+++ b/src/core/js/views/componentView.js
@@ -36,7 +36,7 @@ define([
     /**
      * Allows components that want to use inview for completion to set that up
      * @param {string} [inviewElementSelector] Allows to you to specify (via a selector) which DOM element to use for inview.
-     * Defaults to `'.component-inner'` if not supplied.
+     * Defaults to `'.component__inner'` if not supplied.
      * @param {function} [callback] Allows you to specify what function is called when the component has been viewed, should
      * you want to perform additional checks before setting the component to completed - see adapt-contrib-assessmentResults
      * for an example. Defaults to `view.setCompletionStatus` if not specified.


### PR DESCRIPTION
Fixes https://github.com/adaptlearning/adapt_framework/issues/2595

Updated selector to match v5 naming convention in `setupInviewCompletion` function for when a plugin uses the default.