### PR TITLE
better media component config for captions, a11y

### DIFF
--- a/src/course/en/components.json
+++ b/src/course/en/components.json
@@ -219,6 +219,13 @@
                 }
             ]
         },
+        "_playerOptions": {
+            "alwaysShowControls": true,
+            "toggleCaptionsButtonWhenOnlyOne": true,
+            "iPadUseNativeControls": true,
+            "iPhoneUseNativeControls": true,
+            "AndroidUseNativeControls": true
+        },
         "_transcript": {
             "_inlineTranscript": true,
             "_externalTranscript": false,


### PR DESCRIPTION
enable `toggleCaptionsButtonWhenOnlyOne` as the most typical use-case is only to have one captions language
use native controls on tablet/smartphone to prevent double-display of captions/controls (#2477)
better for a11y to have controls always on-screen