### PR TITLE
issue/2625 Fix for ie11 svg

### DIFF
--- a/src/core/libraries/imageReady.js
+++ b/src/core/libraries/imageReady.js
@@ -38,7 +38,7 @@
       for (var i = 0, len = tags.length; i < len; i++) {
 
         el = tags[i];
-
+        if (!el.currentStyle) continue;
         var hasNoValue = (el.currentStyle[scriptName] == 'none');
         if (hasNoValue) continue;
 


### PR DESCRIPTION
#2625 
* Prevented issue where no 'currentStyle' property exists on SVGs