### PR TITLE
issue/2649 added change:_isActive event bubbling

### DIFF
--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -33,7 +33,8 @@ define([
 
     bubblingEvents: [
       'change:_isComplete',
-      'change:_isInteractionComplete'
+      'change:_isInteractionComplete',
+      'change:_isActive'
     ],
 
     initialize: function () {

--- a/src/core/js/models/itemsComponentModel.js
+++ b/src/core/js/models/itemsComponentModel.js
@@ -16,6 +16,7 @@ define([
       this.setUpItems();
 
       this.listenTo(this.get('_children'), {
+        'all': this.onAll,
         'change:_isVisited': this.checkCompletionStatus
       });
     },


### PR DESCRIPTION
#2649
* Added `change_isActive` event bubbling from `ItemsComponentModels`
Allows:
```js
Adapt.course.on("bubble:change:_isActive", function(event) {
  // event.type == "change:_isActive
  // event.target == originating model
  // event.value === boolean
  // event.deepPath === array of models traversed
});
```