### PR TITLE
issue/2663 revert needed library removal

### DIFF
--- a/grunt/helpers.js
+++ b/grunt/helpers.js
@@ -1,6 +1,8 @@
 var _ = require('underscore');
 var fs = require('fs');
 var path = require('path');
+// extends grunt.file.expand with { order: cb(filePaths) }
+require('grunt-file-order');
 
 module.exports = function(grunt) {
 


### PR DESCRIPTION
#2663 
* reverted the removal of the `grunt-file-order` library