### PR TITLE
issue/2645 Added manifest creation and loading

### DIFF
--- a/grunt/config/babel.js
+++ b/grunt/config/babel.js
@@ -1,22 +1,50 @@
 module.exports = {
-  options: {
-    sourceMap: true,
-    inputSourceMap: true,
-    sourceType: 'script',
-    minified: true,
-    comments: false,
-    presets: [
-      [
-        '@babel/preset-env',
-        {
-          "targets": {
-            "ie": "11"
+  compile: {
+    options: {
+      inputSourceMap: false,
+      minified: true,
+      comments: false,
+      presets: [
+        [
+          '@babel/preset-env',
+          {
+            "targets": {
+              "ie": "11"
+            }
           }
-        }
+        ]
       ]
-    ]
+    },
+    files: [{
+      "expand": true,
+      "cwd": "<%= tempdir %>",
+      "src": [
+        "adapt.min.js"
+      ],
+      "dest": "<%= outputdir %>adapt/js/",
+      "ext": ".min.js"
+    }]
   },
-  dist: {
+  dev: {
+    options: {
+      sourceMap: true,
+      inputSourceMap: true,
+      sourceType: 'script',
+      retainLines: true,
+      minified: false,
+      compact: false,
+      comments: true,
+      presets: [
+        [
+          '@babel/preset-env',
+          {
+            "targets": {
+              "ie": "11"
+            }
+          }
+        ]
+      ]
+    },
     files: [{
       "expand": true,
       "cwd": "<%= tempdir %>",

--- a/grunt/config/babel.js
+++ b/grunt/config/babel.js
@@ -2,6 +2,7 @@ module.exports = {
   compile: {
     options: {
       inputSourceMap: false,
+      sourceType: 'script',
       minified: true,
       comments: false,
       presets: [

--- a/grunt/config/watch.js
+++ b/grunt/config/watch.js
@@ -17,8 +17,8 @@ module.exports = {
     tasks: ['handlebars', 'javascript:dev']
   },
   courseJson: {
-    files: ['<%= sourcedir %>course/**/*.<%= jsonext %>'],
-    tasks: ['jsonlint', 'check-json', 'newer:copy:courseJson', 'schema-defaults']
+    files: ['<%= sourcedir %>course/**/*.<%= jsonext %>', '<%= outputdir %>course/*/language_data_manifest.js'],
+    tasks: ['language-data-manifests', 'jsonlint', 'check-json', 'newer:copy:courseJson', 'schema-defaults']
   },
   courseAssets: {
     files: ['<%= sourcedir %>course/<%=languages%>/*', '!<%= sourcedir %>course/<%=languages%>/*.<%= jsonext %>'],

--- a/grunt/tasks/build.js
+++ b/grunt/tasks/build.js
@@ -9,6 +9,7 @@ module.exports = function(grunt) {
     'build-config',
     'copy',
     'schema-defaults',
+    'language-data-manifests',
     'handlebars',
     'tracking-insert',
     'javascript:compile',

--- a/grunt/tasks/build.js
+++ b/grunt/tasks/build.js
@@ -13,7 +13,7 @@ module.exports = function(grunt) {
     'handlebars',
     'tracking-insert',
     'javascript:compile',
-    'babel',
+    'babel:compile',
     'clean:dist',
     'less:compile',
     'replace',

--- a/grunt/tasks/dev.js
+++ b/grunt/tasks/dev.js
@@ -8,6 +8,7 @@ module.exports = function(grunt) {
     'build-config',
     'copy',
     'schema-defaults',
+    'language-data-manifests',
     'handlebars',
     'tracking-insert',
     'javascript:dev',

--- a/grunt/tasks/dev.js
+++ b/grunt/tasks/dev.js
@@ -12,7 +12,7 @@ module.exports = function(grunt) {
     'handlebars',
     'tracking-insert',
     'javascript:dev',
-    'babel',
+    'babel:dev',
     'less:dev',
     'replace',
     'scripts:adaptpostbuild',

--- a/grunt/tasks/diff.js
+++ b/grunt/tasks/diff.js
@@ -12,7 +12,7 @@ module.exports = function(grunt) {
     'newer:handlebars:compile',
     'tracking-insert',
     'newer:javascript:dev',
-    'babel',
+    'babel:dev',
     'newer:less:dev',
     'replace',
     'scripts:adaptpostbuild',

--- a/grunt/tasks/diff.js
+++ b/grunt/tasks/diff.js
@@ -8,6 +8,7 @@ module.exports = function(grunt) {
     'build-config',
     'copy',
     'schema-defaults',
+    'language-data-manifests',
     'newer:handlebars:compile',
     'tracking-insert',
     'newer:javascript:dev',

--- a/grunt/tasks/language-data-manifests.js
+++ b/grunt/tasks/language-data-manifests.js
@@ -1,0 +1,7 @@
+module.exports = function(grunt) {
+  const Helpers = require('../helpers')(grunt);
+  grunt.registerTask('language-data-manifests', 'Creates a manifest for each set of language data files', function() {
+    const languages = Helpers.getFramework({ useOutputData: true }).getData().languages;
+    languages.forEach(language => language.saveManifest());
+  });
+};

--- a/grunt/tasks/server-build.js
+++ b/grunt/tasks/server-build.js
@@ -9,6 +9,7 @@ module.exports = function(grunt) {
       '_log-vars',
       'build-config',
       'copy',
+      'language-data-manifests',
       'less:' + requireMode,
       'handlebars',
       'javascript:' + requireMode,

--- a/grunt/tasks/server-build.js
+++ b/grunt/tasks/server-build.js
@@ -13,7 +13,7 @@ module.exports = function(grunt) {
       'less:' + requireMode,
       'handlebars',
       'javascript:' + requireMode,
-      'babel',
+      'babel:' + requireMode,
       'replace',
       'scripts:adaptpostbuild',
       'clean:temp'

--- a/src/core/js/collections/adaptCollection.js
+++ b/src/core/js/collections/adaptCollection.js
@@ -5,13 +5,7 @@ define([
   class AdaptCollection extends Backbone.Collection {
 
     initialize(models, options) {
-      this.url = options.url;
       this.once('reset', this.loadedData, this);
-      if (!this.url) return;
-      this.fetch({
-        reset: true,
-        error: () => console.error('ERROR: unable to load file ' + this.url)
-      });
     }
 
     loadedData() {

--- a/src/core/js/collections/adaptSubsetCollection.js
+++ b/src/core/js/collections/adaptSubsetCollection.js
@@ -1,0 +1,23 @@
+define([
+  'core/js/adapt',
+  './adaptCollection'
+], function(Adapt, AdaptCollection) {
+
+  class AdaptSubsetCollection extends AdaptCollection {
+
+    initialize(models, options) {
+      super.initialize(models, options);
+      this.parent = options.parent;
+      this.listenTo(this.parent, 'reset', this.loadSubset);
+    }
+
+    loadSubset() {
+      this.set(this.parent.filter(model => model instanceof this.model));
+      this._byAdaptID = this.groupBy('_id');
+    }
+
+  }
+
+  return AdaptSubsetCollection;
+
+});

--- a/src/core/js/models/buildModel.js
+++ b/src/core/js/models/buildModel.js
@@ -37,6 +37,6 @@ define([
 
   }
 
-  return (Adapt.build = new BuildModel(null, { url: 'adapt/js/build.min.js', reset: true }));
+  return BuildModel;
 
 });

--- a/src/core/js/models/courseModel.js
+++ b/src/core/js/models/courseModel.js
@@ -23,22 +23,20 @@ define([
       return 'course';
     }
 
-    initialize(attrs, options) {
-      super.initialize(arguments);
+    initialize(...args) {
       Adapt.trigger('courseModel:dataLoading');
-      this.url = options.url;
-      this.on('sync', this.loadedData, this);
-      if (!this.url) return;
-      this.fetch({
-        error: () => console.error(`ERROR: unable to load file ${this.url}`)
-      });
+      super.initialize(...args);
+      this.loadedData();
     }
 
     loadedData() {
+      Adapt.course = this;
       Adapt.trigger('courseModel:dataLoaded');
     }
 
   }
+
+  Adapt.register('course', { model: CourseModel });
 
   return CourseModel;
 

--- a/src/core/js/mpabc.js
+++ b/src/core/js/mpabc.js
@@ -19,8 +19,8 @@ define([
     initialize() {
       // Example of how to cause the data loader to wait for another module to setup
       this.listenTo(Data, {
-        'loading': this.waitForDataLoaded,
-        'loaded': this.onDataLoaded
+        loading: this.waitForDataLoaded,
+        loaded: this.onDataLoaded
       });
       this.setupDeprecatedSubsetCollections();
     }
@@ -41,40 +41,32 @@ define([
       let blocks = new AdaptSubsetCollection(null, { parent: Data, model: BlockModel });
       let components = new AdaptSubsetCollection(null, { parent: Data, model: ComponentModel });
       Object.defineProperty(Adapt, 'contentObjects', {
-        get: function() {
+        get: () => {
           Adapt.log.deprecated('Adapt.contentObjects, please use Adapt.data instead');
           return contentObjects;
         },
-        set: function(value) {
-          contentObjects = value;
-        }
+        set: value => contentObjects = value
       });
       Object.defineProperty(Adapt, 'articles', {
-        get: function() {
+        get: () => {
           Adapt.log.deprecated('Adapt.articles, please use Adapt.data instead');
           return articles;
         },
-        set: function(value) {
-          articles = value;
-        }
+        set: value => articles = value
       });
       Object.defineProperty(Adapt, 'blocks', {
-        get: function() {
+        get: () => {
           Adapt.log.deprecated('Adapt.blocks, please use Adapt.data instead');
           return blocks;
         },
-        set: function(value) {
-          blocks = value;
-        }
+        set: value => blocks = value
       });
       Object.defineProperty(Adapt, 'components', {
-        get: function() {
+        get: () => {
           Adapt.log.deprecated('Adapt.components, please use Adapt.data instead');
           return components;
         },
-        set: function(value) {
-          components = value;
-        }
+        set: value => components = value
       });
     }
 

--- a/src/core/js/mpabc.js
+++ b/src/core/js/mpabc.js
@@ -1,9 +1,85 @@
 define([
+  'core/js/adapt',
+  'core/js/data',
+  'core/js/collections/adaptSubsetCollection',
+  'core/js/models/courseModel',
+  'core/js/models/contentObjectModel',
   'core/js/models/menuModel',
   'core/js/models/pageModel',
   'core/js/models/articleModel',
   'core/js/models/blockModel',
+  'core/js/models/componentModel',
   'core/js/views/pageView',
   'core/js/views/articleView',
   'core/js/views/blockView'
-], function(MenuModel, PageModel, ArticleModel, BlockModel, PageView, ArticleView, BlockView) {});
+], function(Adapt, Data, AdaptSubsetCollection, CourseModel, ContentObjectModel, MenuModel, PageModel, ArticleModel, BlockModel, ComponentModel, PageView, ArticleView, BlockView) {
+
+  class MPABC extends Backbone.Controller {
+
+    initialize() {
+      // Example of how to cause the data loader to wait for another module to setup
+      this.listenTo(Data, {
+        'loading': this.waitForDataLoaded,
+        'loaded': this.onDataLoaded
+      });
+      this.setupDeprecatedSubsetCollections();
+    }
+
+    waitForDataLoaded() {
+      // Tell the data loader to wait
+      Adapt.wait.begin();
+    }
+
+    onDataLoaded() {
+      // Tell the data loader that we have finished
+      Adapt.wait.end();
+    }
+
+    setupDeprecatedSubsetCollections() {
+      let contentObjects = new AdaptSubsetCollection(null, { parent: Data, model: ContentObjectModel });
+      let articles = new AdaptSubsetCollection(null, { parent: Data, model: ArticleModel });
+      let blocks = new AdaptSubsetCollection(null, { parent: Data, model: BlockModel });
+      let components = new AdaptSubsetCollection(null, { parent: Data, model: ComponentModel });
+      Object.defineProperty(Adapt, 'contentObjects', {
+        get: function() {
+          Adapt.log.deprecated('Adapt.contentObjects, please use Adapt.data instead');
+          return contentObjects;
+        },
+        set: function(value) {
+          contentObjects = value;
+        }
+      });
+      Object.defineProperty(Adapt, 'articles', {
+        get: function() {
+          Adapt.log.deprecated('Adapt.articles, please use Adapt.data instead');
+          return articles;
+        },
+        set: function(value) {
+          articles = value;
+        }
+      });
+      Object.defineProperty(Adapt, 'blocks', {
+        get: function() {
+          Adapt.log.deprecated('Adapt.blocks, please use Adapt.data instead');
+          return blocks;
+        },
+        set: function(value) {
+          blocks = value;
+        }
+      });
+      Object.defineProperty(Adapt, 'components', {
+        get: function() {
+          Adapt.log.deprecated('Adapt.components, please use Adapt.data instead');
+          return components;
+        },
+        set: function(value) {
+          components = value;
+        }
+      });
+    }
+
+  }
+
+  return (Adapt.mpabc = new MPABC());
+
+});


### PR DESCRIPTION
fixes #2645 

PR goes into #2714 then into #2713 then into #2711 then into master

* Adapt is now JSON filename agnostic in the language folder (`build.js` and `config.json` are still fixed filenames outside of the language folders). 
* Each file must contain an object or an array of objects with, at minimum a `{ "_type": "" }`, `{ "_component": "" }` or `{ "_model": "" }` attribute on each JSON file object as this denotes the corresponding model inside the framework.
* Each language folder must have a `{ "_type": "course" }` object.

#### Added
* grunt task `language-data-manifests`

#### Changed
* Reworked `src/core/js/data.js` to load manifest, files and become the collection for all models. It now has no references to the menu, page, article, block and component structure
* Moved menu, page, article, block and component controller parts from data into `src/core/js/mpabc.js` 
* `AdaptCollection` so that it is no longer a data loader, only a container.

#### Deprecated
* `Adapt.contentObjects`, `Adapt.articles`, `Adapt.blocks`, `Adapt.components` in favour of `Adapt.data`

#### Testing
Tested with languagePicker, works as normal.
`change` events trigger from `Adapt.data` and `Adapt.blocks`, `Adapt.components` etc as intended