### PR TITLE
Added template + partial render events and a fix for lazyloading images

### DIFF
--- a/src/core/js/app.js
+++ b/src/core/js/app.js
@@ -1,5 +1,7 @@
 require([
   'core/js/adapt',
+  'core/js/templates',
+  'core/js/fixes',
   'core/js/accessibility',
   'core/js/data',
   'core/js/offlineStorage',

--- a/src/core/js/fixes.js
+++ b/src/core/js/fixes.js
@@ -1,3 +1,3 @@
 define([
   './fixes/img.lazyload'
-], function() {})
+], function() {});

--- a/src/core/js/fixes.js
+++ b/src/core/js/fixes.js
@@ -1,0 +1,3 @@
+define([
+  './fixes/img.lazyload'
+], function() {})

--- a/src/core/js/fixes/img.lazyload.js
+++ b/src/core/js/fixes/img.lazyload.js
@@ -11,19 +11,21 @@ define([
    * Add a loading="eager" attribute to all template and partial img tags where
    * the loading attribute is missing.
    */
+  const findImgTag = /<img([^>]*)>/gi;
+  const hasLoadingAttr = / loading=/gi;
   Adapt.on('template:postRender partial:postRender', function(event) {
-    const imgs = event.value.match(/<img([^>]*)>/gi);
+    const imgs = event.value.match(findImgTag);
     if (!imgs) {
       // No img tags found
       return;
     }
     event.value = imgs.reduce((value, img) => {
-      // Check if the img tag already has a loading attribute
-      if (/ loading=/gi.test(img)) {
+      // Check if the img tag has a loading attribute
+      if (hasLoadingAttr.test(img)) {
         return value;
       }
       // Add loading="eager" by default
-      return value.replace(img, img.replace(/<img([^>]*)>/gi, '<img loading="eager"$1>'));
+      return value.replace(img, img.replace(findImgTag, '<img loading="eager"$1>'));
     }, event.value);
   });
 

--- a/src/core/js/fixes/img.lazyload.js
+++ b/src/core/js/fixes/img.lazyload.js
@@ -21,13 +21,11 @@ define([
     const findImgTag = /<img([^>]*)>/gi;
     const hasLoadingAttr = / loading=/gi;
     Adapt.on('template:postRender partial:postRender', function(event) {
-      const imgs = event.value.match(findImgTag);
-      if (!imgs) {
-        // No img tags found
+      const imgTagsFound = event.value.match(findImgTag);
+      if (!imgTagsFound) {
         return;
       }
-      event.value = imgs.reduce((value, img) => {
-        // Check if the img tag has a loading attribute
+      event.value = imgTagsFound.reduce((value, img) => {
         if (hasLoadingAttr.test(img)) {
           return value;
         }

--- a/src/core/js/fixes/img.lazyload.js
+++ b/src/core/js/fixes/img.lazyload.js
@@ -1,0 +1,30 @@
+define([
+  'core/js/adapt',
+  '../templates'
+], function(Adapt) {
+
+  /**
+   * 27 April 2020 https://github.com/adaptlearning/adapt_framework/issues/2734
+   * Chrome on Android 10 defers load events on images when lite mode is enabled
+   * and as part of a data saving technique.
+   *
+   * Add a loading="eager" attribute to all template and partial img tags where
+   * the loading attribute is missing.
+   */
+  Adapt.on('template:postRender partial:postRender', function(event) {
+    const imgs = event.value.match(/<img([^>]*)>/gi);
+    if (!imgs) {
+      // No img tags found
+      return;
+    }
+    event.value = imgs.reduce((value, img) => {
+      // Check if the img tag already has a loading attribute
+      if (/ loading=/gi.test(img)) {
+        return value;
+      }
+      // Add loading="eager" by default
+      return value.replace(img, img.replace(/<img([^>]*)>/gi, '<img loading="eager"$1>'));
+    }, event.value);
+  });
+
+});

--- a/src/core/js/fixes/img.lazyload.js
+++ b/src/core/js/fixes/img.lazyload.js
@@ -5,28 +5,36 @@ define([
 
   /**
    * 27 April 2020 https://github.com/adaptlearning/adapt_framework/issues/2734
-   * Chrome on Android 10 defers load events on images when lite mode is enabled
+   * Chrome on Android defers load events on images when lite mode is enabled
    * and as part of a data saving technique.
    *
    * Add a loading="eager" attribute to all template and partial img tags where
    * the loading attribute is missing.
    */
-  const findImgTag = /<img([^>]*)>/gi;
-  const hasLoadingAttr = / loading=/gi;
-  Adapt.on('template:postRender partial:postRender', function(event) {
-    const imgs = event.value.match(findImgTag);
-    if (!imgs) {
-      // No img tags found
-      return;
-    }
-    event.value = imgs.reduce((value, img) => {
-      // Check if the img tag has a loading attribute
-      if (hasLoadingAttr.test(img)) {
-        return value;
-      }
-      // Add loading="eager" by default
-      return value.replace(img, img.replace(findImgTag, '<img loading="eager"$1>'));
-    }, event.value);
+  Adapt.on('app:dataReady', function() {
+    const config = Adapt.config.get('_fixes');
+    if (config && config._imgLazyLoad === false) return;
+    applyImgLoadingFix();
   });
+
+  function applyImgLoadingFix() {
+    const findImgTag = /<img([^>]*)>/gi;
+    const hasLoadingAttr = / loading=/gi;
+    Adapt.on('template:postRender partial:postRender', function(event) {
+      const imgs = event.value.match(findImgTag);
+      if (!imgs) {
+        // No img tags found
+        return;
+      }
+      event.value = imgs.reduce((value, img) => {
+        // Check if the img tag has a loading attribute
+        if (hasLoadingAttr.test(img)) {
+          return value;
+        }
+        // Add loading="eager" by default
+        return value.replace(img, img.replace(findImgTag, '<img loading="eager"$1>'));
+      }, event.value);
+    });
+  }
 
 });

--- a/src/core/js/templateRenderEvent.js
+++ b/src/core/js/templateRenderEvent.js
@@ -1,0 +1,30 @@
+define(function() {
+
+  class TemplateRenderEvent extends Backbone.Controller {
+
+    /**
+     * Template render event
+     * @param {string} type Event type
+     * @param {string} name Template name
+     * @param {string} mode "template" / "partial"
+     * @param {string} value Rendered template string
+     * @param {[*]} args Arguments passed to template for render
+     */
+    initialize(type, name, mode, value, args) {
+      /** @type {string} Event type */
+      this.type = type;
+      /** @type {string} Template name */
+      this.name = name;
+      /** @type {string} "template" / "partial" */
+      this.mode = mode;
+      /** @type {string} Rendered template string */
+      this.value = value;
+      /** @type {[*]} Arguments passed to template for render */
+      this.args = args;
+    }
+
+  }
+
+  return TemplateRenderEvent;
+
+});

--- a/src/core/js/templates.js
+++ b/src/core/js/templates.js
@@ -20,13 +20,20 @@ define([
     });
   }
 
-  handlebarsInject(function(originalFunction, name, mode, ...args) {
-    let event = new TemplateRenderEvent(`${mode}:preRender`, name, mode, null, args);
-    Adapt.trigger(event.type, event);
-    let value = originalFunction.apply(this, event.args);
-    event = new TemplateRenderEvent(`${mode}:postRender`, name, mode, value, args);
-    Adapt.trigger(event.type, event);
-    return event.value;
+  handlebarsInject(function(template, name, mode, ...args) {
+    // Send preRender event to allow modification of args
+    const preRenderEvent = new TemplateRenderEvent(`${mode}:preRender`, name, mode, null, args);
+    Adapt.trigger(preRenderEvent.type, preRenderEvent);
+
+    // Execute template
+    const value = template(...preRenderEvent.args);
+
+    // Send postRender event to allow modification of rendered template
+    const postRenderEvent = new TemplateRenderEvent(`${mode}:postRender`, name, mode, value, preRenderEvent.args);
+    Adapt.trigger(postRenderEvent.type, postRenderEvent);
+
+    // Return rendered, modified template
+    return postRenderEvent.value;
   });
 
 });

--- a/src/core/js/templates.js
+++ b/src/core/js/templates.js
@@ -8,19 +8,19 @@ define([
    * Adds template and partial, preRender and postRender events to Adapt
    */
 
-  function handlebarsInject(cb) {
-    const duckPunch = function(object, name, mode, cb) {
+  function onRender(cb) {
+    const intercept = (object, name, mode, cb) => {
       return object[name] = cb.bind(object, object[name], name, mode);
     };
     Object.keys(Handlebars.templates).forEach(name => {
-      duckPunch(Handlebars.templates, name, 'template', cb);
+      intercept(Handlebars.templates, name, 'template', cb);
     });
     Object.keys(Handlebars.partials).forEach(name => {
-      duckPunch(Handlebars.partials, name, 'partial', cb);
+      intercept(Handlebars.partials, name, 'partial', cb);
     });
   }
 
-  handlebarsInject(function(template, name, mode, ...args) {
+  onRender((template, name, mode, ...args) => {
     // Send preRender event to allow modification of args
     const preRenderEvent = new TemplateRenderEvent(`${mode}:preRender`, name, mode, null, args);
     Adapt.trigger(preRenderEvent.type, preRenderEvent);

--- a/src/core/js/templates.js
+++ b/src/core/js/templates.js
@@ -10,7 +10,7 @@ define([
 
   function onRender(cb) {
     const intercept = (object, name, mode, cb) => {
-      return object[name] = cb.bind(object, object[name], name, mode);
+      return (object[name] = cb.bind(object, object[name], name, mode));
     };
     Object.keys(Handlebars.templates).forEach(name => {
       intercept(Handlebars.templates, name, 'template', cb);

--- a/src/core/js/templates.js
+++ b/src/core/js/templates.js
@@ -1,0 +1,32 @@
+define([
+  'core/js/adapt',
+  'handlebars',
+  './templateRenderEvent'
+], function(Adapt, Handlebars, TemplateRenderEvent) {
+
+  /**
+   * Adds template and partial, preRender and postRender events to Adapt
+   */
+
+  function handlebarsInject(cb) {
+    const duckPunch = function(object, name, mode, cb) {
+      return object[name] = cb.bind(object, object[name], name, mode);
+    };
+    Object.keys(Handlebars.templates).forEach(name => {
+      duckPunch(Handlebars.templates, name, 'template', cb);
+    });
+    Object.keys(Handlebars.partials).forEach(name => {
+      duckPunch(Handlebars.partials, name, 'partial', cb);
+    });
+  }
+
+  handlebarsInject(function(originalFunction, name, mode, ...args) {
+    let event = new TemplateRenderEvent(`${mode}:preRender`, name, mode, null, args);
+    Adapt.trigger(event.type, event);
+    let value = originalFunction.apply(this, event.args);
+    event = new TemplateRenderEvent(`${mode}:postRender`, name, mode, value, args);
+    Adapt.trigger(event.type, event);
+    return event.value;
+  });
+
+});

--- a/src/core/js/views/navigationView.js
+++ b/src/core/js/views/navigationView.js
@@ -36,8 +36,8 @@ define([
     render() {
       var template = Handlebars.templates[this.constructor.template];
       this.$el.html(template({
-          _globals: Adapt.course.get('_globals'),
-          _accessibility: Adapt.config.get('_accessibility')
+        _globals: Adapt.course.get('_globals'),
+        _accessibility: Adapt.config.get('_accessibility')
       })).insertBefore('#app');
 
       _.defer(() => {

--- a/src/core/libraries/imageReady.js
+++ b/src/core/libraries/imageReady.js
@@ -96,6 +96,7 @@
 
         // stripCSSQuotes
         var url = matches[1].replace(/[\"\']/g, "");
+        $image.attr('loading', 'eager');
         $image.attr("src", url);
         $images = $images.add($image);
 

--- a/src/core/libraries/imageReady.js
+++ b/src/core/libraries/imageReady.js
@@ -8,6 +8,7 @@
 
     var img = $img[0];
     var hasNoSrc = !$img.attr("src");
+    var isLazyLoading = ($img.attr('loading') === 'lazy');
     var isMarkedComplete = img.complete;
     var hasCorrectReadyState = img.readyState === 4;
 
@@ -18,7 +19,7 @@
 
     var hasValidHeight = has$Height && hasNaturalHeight;
 
-    return hasNoSrc || isMarkedComplete || hasCorrectReadyState || hasValidHeight;
+    return hasNoSrc || isLazyLoading || isMarkedComplete || hasCorrectReadyState || hasValidHeight;
 
   }
 

--- a/src/core/schema/config.model.schema
+++ b/src/core/schema/config.model.schema
@@ -176,6 +176,17 @@
         }
       }
     },
+    "_fixes": {
+      "type": "object",
+      "default": {},
+      "title": "Fixes Extended Options",
+      "inputType": {
+        "type": "CodeEditor",
+        "mode": "json"
+      },
+      "validators": [],
+      "help": "Optional object that can be used to customize the application of fixes"
+    },
     "screenSize": {
       "type": "object",
       "title": "Screen Size",

--- a/src/core/schema/config.model.schema
+++ b/src/core/schema/config.model.schema
@@ -178,7 +178,9 @@
     },
     "_fixes": {
       "type": "object",
-      "default": {},
+      "default": {
+        "_imgLazyLoad": true
+      },
       "title": "Fixes Extended Options",
       "inputType": {
         "type": "CodeEditor",

--- a/src/course/config.json
+++ b/src/course/config.json
@@ -37,6 +37,9 @@
             "_warnFirstOnly": true
         }
     },
+    "_fixes": {
+        "_imgLazyLoad": true
+    },
     "_drawer": {
         "_showEasing": "easeOutQuart",
         "_hideEasing": "easeInQuart",


### PR DESCRIPTION
#2734

All template and partial `img` tags will now have the `loading="eager"` added by default unless the tag already contains a `loading` attribute. `imageready` will now ignore `loading="lazy"` `img` tags.
 
#### Added
* Introduced `template:preRender`, `template:postRender`, `partial:preRender` and `partial:postRender` events to Adapt
* Sub folder `core/js/fixes` for essential fixes
* `img.lazyload` fix, to inject `loading="eager"` attribute into `img` tags if `loading` attribute is missing
* Added `_fixes` object to config.json
* Added `_fixes._imgLazyLoad: true` to config.json to control image lazy load fix, defaults to true

#### Changed
* `imageready` `background-image` loader to ensure the `loading="eager"` attribute is applied
* `imageready` skips loading checks on explicitly `loading="lazy"` images