### PR TITLE
default course: assessment trickle button label improvements

### DIFF
--- a/src/course/en/articles.json
+++ b/src/course/en/articles.json
@@ -51,7 +51,11 @@
             "_attempts": "infinite"
         },
         "_trickle": {
-            "_isEnabled": true
+            "_isEnabled": true,
+            "_button": {
+                "_isEnabled": true,
+                "startText": "Continue"
+            }
         }
     },
     {

--- a/src/course/en/blocks.json
+++ b/src/course/en/blocks.json
@@ -218,9 +218,7 @@
             "_isEnabled": true,
             "_button": {
                 "_isEnabled": true,
-                "text": "Continue",
-                "startText": "Continue",
-                "finalText": "Continue"
+                "text": "Show results"
             }
         },
         "_trackingId": 18


### PR DESCRIPTION
first trickle button now reads 'Continue' (instead of 'Begin'); last one now reads 'Show results'.

fixes #2803 