### PR TITLE
issue/2812 Improved question canSubmit: false behaviour

### DIFF
--- a/src/core/js/models/itemsQuestionModel.js
+++ b/src/core/js/models/itemsQuestionModel.js
@@ -30,9 +30,7 @@ define([
     init() {
       super.init();
       this.set('_isRadio', this.isSingleSelect());
-      this.listenTo(this.getChildren(), {
-       'change:_isActive': this.checkCanSubmit
-      });
+      this.listenTo(this.getChildren(), 'change:_isActive': this.checkCanSubmit);
       this.checkCanSubmit();
     }
 

--- a/src/core/js/models/itemsQuestionModel.js
+++ b/src/core/js/models/itemsQuestionModel.js
@@ -30,7 +30,7 @@ define([
     init() {
       super.init();
       this.set('_isRadio', this.isSingleSelect());
-      this.listenTo(this.getChildren(), 'change:_isActive': this.checkCanSubmit);
+      this.listenTo(this.getChildren(), 'change:_isActive', this.checkCanSubmit);
       this.checkCanSubmit();
     }
 

--- a/src/core/js/models/itemsQuestionModel.js
+++ b/src/core/js/models/itemsQuestionModel.js
@@ -30,6 +30,10 @@ define([
     init() {
       super.init();
       this.set('_isRadio', this.isSingleSelect());
+      this.listenTo(this.getChildren(), {
+       'change:_isActive': this.checkCanSubmit
+      });
+      this.checkCanSubmit();
     }
 
     /**

--- a/src/core/js/models/questionModel.js
+++ b/src/core/js/models/questionModel.js
@@ -19,6 +19,7 @@ define([
         _canShowModelAnswer: true,
         _canShowFeedback: true,
         _canShowMarking: true,
+        _canSubmit: true,
         _isSubmitted: false,
         _questionWeight: Adapt.config.get('_questionWeight'),
         _items: []
@@ -111,6 +112,10 @@ define([
     // Use to check if the user is allowed to submit the question
     // Maybe the user has to select an item?
     canSubmit() {}
+
+    checkCanSubmit() {
+      this.set('_canSubmit', this.canSubmit());
+    }
 
     // Used to update the amount of attempts the user has left
     updateAttempts() {

--- a/src/core/js/views/buttonsView.js
+++ b/src/core/js/views/buttonsView.js
@@ -19,9 +19,13 @@ define([
     initialize: function(options) {
       this.parent = options.parent;
       this.listenTo(Adapt.parentView, 'postRemove', this.remove);
-      this.listenTo(this.model, 'change:_buttonState', this.onButtonStateChanged);
-      this.listenTo(this.model, 'change:feedbackMessage', this.onFeedbackMessageChanged);
-      this.listenTo(this.model, 'change:_attemptsLeft', this.onAttemptsChanged);
+      this.listenTo(this.model, {
+        'change:_buttonState': this.onButtonStateChanged,
+        'change:feedbackMessage': this.onFeedbackMessageChanged,
+        'change:_attemptsLeft': this.onAttemptsChanged,
+        'change:_canSubmit': this.onCanSubmitChange
+      });
+      this.model.checkCanSubmit();
       this.render();
     },
 
@@ -77,6 +81,10 @@ define([
       }
     },
 
+    onCanSubmitChange: function() {
+      this.onButtonStateChanged(this.model, this.model.get('_buttonState'));
+    },
+
     onButtonStateChanged: function(model, changedAttribute) {
 
       this.updateAttemptsCount();
@@ -97,7 +105,7 @@ define([
 
         // Enable the button, make accessible and update aria labels and text
 
-        Adapt.a11y.toggleAccessibleEnabled($buttonsAction, true);
+        Adapt.a11y.toggleAccessibleEnabled($buttonsAction, this.model.get('_canSubmit'));
         $buttonsAction.html(buttonText).attr('aria-label', ariaLabel);
 
         // Make model answer button inaccessible (but still enabled) for visual users due to

--- a/src/core/js/views/buttonsView.js
+++ b/src/core/js/views/buttonsView.js
@@ -103,8 +103,10 @@ define([
         var buttonText = this.model.get('_buttons')['_' + propertyName].buttonText;
 
         // Enable the button, make accessible and update aria labels and text
+        const incompleteWarningConfig = Adapt.course.get('_buttons')._incompleteWarning;
+        const hasIncompleteWarning = incompleteWarningConfig && incompleteWarningConfig._isEnabled;
 
-        Adapt.a11y.toggleAccessibleEnabled($buttonsAction, this.model.get('_canSubmit'));
+        Adapt.a11y.toggleAccessibleEnabled($buttonsAction, hasIncompleteWarning ? true : this.model.get('_canSubmit'));
         $buttonsAction.html(buttonText).attr('aria-label', ariaLabel);
 
         // Make model answer button inaccessible (but still enabled) for visual users due to

--- a/src/core/js/views/buttonsView.js
+++ b/src/core/js/views/buttonsView.js
@@ -25,7 +25,7 @@ define([
         'change:_attemptsLeft': this.onAttemptsChanged,
         'change:_canSubmit': this.onCanSubmitChange
       });
-      this.model.checkCanSubmit();
+      //this.model.checkCanSubmit();
       this.render();
     },
 

--- a/src/core/js/views/buttonsView.js
+++ b/src/core/js/views/buttonsView.js
@@ -25,7 +25,6 @@ define([
         'change:_attemptsLeft': this.onAttemptsChanged,
         'change:_canSubmit': this.onCanSubmitChange
       });
-      //this.model.checkCanSubmit();
       this.render();
     },
 

--- a/src/core/js/views/questionView.js
+++ b/src/core/js/views/questionView.js
@@ -217,6 +217,17 @@ define([
 
     // Adds a validation error class when the canSubmit returns false
     showInstructionError() {
+      const incompleteWarningConfig = Adapt.course.get('_buttons')._incompleteWarning;
+      const hasIncompleteWarning = incompleteWarningConfig && incompleteWarningConfig._isEnabled;
+      if (hasIncompleteWarning) {
+        const data = this.model.toJSON();
+        const notifyObject = Object.assign({}, incompleteWarningConfig, {
+          title: Handlebars.compile(incompleteWarningConfig.title)(data),
+          body: Handlebars.compile(incompleteWarningConfig.body)(data)
+        });
+        Adapt.notify.popup(notifyObject);
+        return;
+      }
       this.$('.component__instruction-inner').addClass('validation-error');
       Adapt.a11y.focusFirst(this.$el, { defer: true });
     }

--- a/src/course/en/course.json
+++ b/src/course/en/course.json
@@ -29,6 +29,11 @@
             "buttonText": "Show feedback",
             "ariaLabel": "Show feedback"
         },
+        "_incompleteWarning": {
+          "_isEnabled": false,
+          "title": "Instructions",
+          "body": "{{#if instruction}}{{instruction}}{{else}}Please complete the question and then click Submit.{{/if}}"
+        },
         "remainingAttemptsText": "attempts remaining",
         "remainingAttemptText": "final attempt",
         "disabledAriaLabel": "This button is disabled at the moment"


### PR DESCRIPTION
#2812 

This pr adds an optional incomplete question notification when no options are selected and the submit button is click that is disabled by default. It also modifies the submit button so that when the incomplete question notification is disabled, the submit button is instead disabled until the instructions have been satisfied.

### Added
* `_canSubmit` property to question model, default `true`
* `checkCanSubmit()` function to question model to set `_canSubmit` based upon value of `canSubmit()` from the question component
* `ButtonsView` listens to `_canSubmit` changes and updates the button state accordingly
* `ItemsQuestionModel` runs `checkCanSubmit` on the model when the active items change
* Optional "Incomplete Warning" notify configured from the `course.json`
```json
{
  "_buttons": {
    "_incompleteWarning": {
      "_isEnabled": false,
      "title": "Instructions",
      "body": "{{#if instruction}}{{instruction}}{{else}}Please complete the question and then click Submit.{{/if}}"
    }
  }
}
```

Notes:
* Might need a switch to revert the disabled submit button to original behaviour.
* Will only work on `ItemsQuestionModel` components (mcq and gmcq) out of the box, so matching and textinput - which have their own models - will need to run `checkCanSubmit()` on `init` and after selection. PRs referenced below.