### PR TITLE
issue/2812-1 Disabled submit button by default, facilitate instruction error

### DIFF
--- a/src/core/js/models/itemsQuestionModel.js
+++ b/src/core/js/models/itemsQuestionModel.js
@@ -30,6 +30,8 @@ define([
     init() {
       super.init();
       this.set('_isRadio', this.isSingleSelect());
+      this.listenTo(this.getChildren(), 'change:_isActive', this.checkCanSubmit);
+      this.checkCanSubmit();
     }
 
     /**

--- a/src/core/js/models/questionModel.js
+++ b/src/core/js/models/questionModel.js
@@ -19,6 +19,7 @@ define([
         _canShowModelAnswer: true,
         _canShowFeedback: true,
         _canShowMarking: true,
+        _canSubmit: true,
         _isSubmitted: false,
         _questionWeight: Adapt.config.get('_questionWeight'),
         _items: []
@@ -46,6 +47,7 @@ define([
     init() {
       this.setupDefaultSettings();
       this.listenToOnce(Adapt, 'adapt:initialize', this.onAdaptInitialize);
+      this.setLocking('_canSubmit', true);
     }
 
     // Calls default methods to setup on questions
@@ -111,6 +113,10 @@ define([
     // Use to check if the user is allowed to submit the question
     // Maybe the user has to select an item?
     canSubmit() {}
+
+    checkCanSubmit() {
+      this.set('_canSubmit', this.canSubmit(), { pluginName: 'adapt' });
+    }
 
     // Used to update the amount of attempts the user has left
     updateAttempts() {

--- a/src/core/js/views/buttonsView.js
+++ b/src/core/js/views/buttonsView.js
@@ -19,9 +19,12 @@ define([
     initialize: function(options) {
       this.parent = options.parent;
       this.listenTo(Adapt.parentView, 'postRemove', this.remove);
-      this.listenTo(this.model, 'change:_buttonState', this.onButtonStateChanged);
-      this.listenTo(this.model, 'change:feedbackMessage', this.onFeedbackMessageChanged);
-      this.listenTo(this.model, 'change:_attemptsLeft', this.onAttemptsChanged);
+      this.listenTo(this.model, {
+        'change:_buttonState': this.onButtonStateChanged,
+        'change:feedbackMessage': this.onFeedbackMessageChanged,
+        'change:_attemptsLeft': this.onAttemptsChanged,
+        'change:_canSubmit': this.onCanSubmitChange
+      });
       this.render();
     },
 
@@ -77,6 +80,10 @@ define([
       }
     },
 
+    onCanSubmitChange: function() {
+      this.onButtonStateChanged(this.model, this.model.get('_buttonState'));
+    },
+
     onButtonStateChanged: function(model, changedAttribute) {
 
       this.updateAttemptsCount();
@@ -97,7 +104,7 @@ define([
 
         // Enable the button, make accessible and update aria labels and text
 
-        Adapt.a11y.toggleAccessibleEnabled($buttonsAction, true);
+        Adapt.a11y.toggleAccessibleEnabled($buttonsAction, this.model.get('_canSubmit'));
         $buttonsAction.html(buttonText).attr('aria-label', ariaLabel);
 
         // Make model answer button inaccessible (but still enabled) for visual users due to

--- a/src/core/js/views/questionView.js
+++ b/src/core/js/views/questionView.js
@@ -215,7 +215,6 @@ define([
       this.onSubmitted();
     }
 
-    // Adds a validation error class when the canSubmit returns false
     showInstructionError() {
       Adapt.trigger('questionView:showInstructionError', this);
     }

--- a/src/core/js/views/questionView.js
+++ b/src/core/js/views/questionView.js
@@ -217,8 +217,7 @@ define([
 
     // Adds a validation error class when the canSubmit returns false
     showInstructionError() {
-      this.$('.component__instruction-inner').addClass('validation-error');
-      Adapt.a11y.focusFirst(this.$el, { defer: true });
+      Adapt.trigger('questionView:showInstructionError', this);
     }
 
     // Blank method for question to fill out when the question cannot be submitted


### PR DESCRIPTION
#2812 

#### Added
* `questionView:showInstructionError` event to allow for instruction error popups
* `_canSubmit` with locking to allow extension to lock `_canSubmit` to true

#### Removed
* Old instruction error behaviour

Use extension [adapt-contrib-instructionError](https://github.com/adaptlearning/adapt-contrib-instructionError) as discussed for warnings on invalid submissions.

Requires prs in matching and textinput to disable submit button in both cases [matching#125](https://github.com/adaptlearning/adapt-contrib-matching/pull/125), [textinput#101](https://github.com/adaptlearning/adapt-contrib-textInput/pull/101)

