### PR TITLE
issue/2843 Fixed submit disabled on reset click

### DIFF
--- a/src/core/js/models/questionModel.js
+++ b/src/core/js/models/questionModel.js
@@ -57,12 +57,12 @@ define([
 
     init() {
       this.setupDefaultSettings();
+      this.setLocking('_canSubmit', true);
       if (Adapt.get('_isStarted')) {
         this.onAdaptInitialize();
         return;
       }
       this.listenToOnce(Adapt, 'adapt:initialize', this.onAdaptInitialize);
-      this.setLocking('_canSubmit', true);
     }
 
     // Calls default methods to setup on questions

--- a/src/core/js/scrolling.js
+++ b/src/core/js/scrolling.js
@@ -56,7 +56,8 @@ define([
         const $app = Adapt.scrolling.$app;
         const $element = this;
         const elementOffset = selectorOffset.call($element);
-        const isCorrectedContainer = $element.parents().add($element).filter('html,body,#app').length;
+        const isCorrectedContainer = $element.is('html', 'body', '#app') ||
+          $element.parents().is('#app');
         if (!isCorrectedContainer) {
           // Do not adjust the offset measurement as not in $app container and isn't html or body
           return elementOffset;

--- a/src/core/js/scrolling.js
+++ b/src/core/js/scrolling.js
@@ -56,8 +56,7 @@ define([
         const $app = Adapt.scrolling.$app;
         const $element = this;
         const elementOffset = selectorOffset.call($element);
-        const isCorrectedContainer = $element.is('html', 'body', '#app') ||
-          $element.parents().is('#app');
+        const isCorrectedContainer = $element.parents().add($element).filter('html,body,#app').length;
         if (!isCorrectedContainer) {
           // Do not adjust the offset measurement as not in $app container and isn't html or body
           return elementOffset;

--- a/src/core/js/views/questionView.js
+++ b/src/core/js/views/questionView.js
@@ -66,12 +66,12 @@ define([
     checkIfResetOnRevisit() {
 
       let isResetOnRevisit = this.model.get('_isResetOnRevisit');
-      
+
       // Convert AAT "false" string to boolean
-      isResetOnRevisit = (isResetOnRevisit === "false") ? 
+      isResetOnRevisit = (isResetOnRevisit === "false") ?
         false :
         isResetOnRevisit;
-      
+
       // If reset is enabled set defaults
       // Call blank method for question to handle
       if (isResetOnRevisit) {
@@ -279,11 +279,13 @@ define([
     onResetClicked() {
       this.setQuestionAsReset();
 
-      this._runModelCompatibleFunction('updateButtons');
-
       this._runModelCompatibleFunction('resetUserAnswer');
 
       this.resetQuestion();
+
+      this.model.checkCanSubmit();
+
+      this._runModelCompatibleFunction('updateButtons');
 
       // onResetClicked is called as part of the checkIfResetOnRevisit
       // function and as a button click. if the view is already rendered,


### PR DESCRIPTION
#2812 

### Fixed
* Multiple attempt resets now check `canSubmit`
* Bad merge order for cloned model `_canSubmit` locking



original [issue](https://github.com/adaptlearning/adapt-contrib-matching/pull/125#pullrequestreview-454012732)