### PR TITLE
issue/2845 Presentation component save+restore

### DIFF
--- a/src/core/js/models/componentModel.js
+++ b/src/core/js/models/componentModel.js
@@ -63,15 +63,15 @@ define([
 
     /**
      * Restore the user's answer from the _userAnswer property.
-     * The _userAnswer value must be in the form of an array containing
-     * arrays of numbers, booleans or arrays only.
+     * The _userAnswer value must be in the form of arrays containing
+     * numbers, booleans or arrays only.
      */
     restoreUserAnswers() {}
 
     /**
      * Store the user's answer in the _userAnswer property.
-     * The _userAnswer value must be in the form of an array containing
-     * arrays of numbers, booleans or arrays only.
+     * The _userAnswer value must be in the form of arrays containing
+     * numbers, booleans or arrays only.
      */
     storeUserAnswer() {}
 

--- a/src/core/js/models/componentModel.js
+++ b/src/core/js/models/componentModel.js
@@ -63,15 +63,15 @@ define([
 
     /**
      * Restore the user's answer from the _userAnswer property.
-     * The _userAnswer value must be in the form of arrays containing
-     * numbers, booleans or arrays only.
+     * The _userAnswer value must be in the form of an array containing
+     * arrays of numbers, booleans or arrays only.
      */
     restoreUserAnswers() {}
 
     /**
      * Store the user's answer in the _userAnswer property.
-     * The _userAnswer value must be in the form of arrays containing
-     * numbers, booleans or arrays only.
+     * The _userAnswer value must be in the form of an array containing
+     * arrays of numbers, booleans or arrays only.
      */
     storeUserAnswer() {}
 

--- a/src/core/js/models/componentModel.js
+++ b/src/core/js/models/componentModel.js
@@ -61,8 +61,18 @@ define([
       this.restoreUserAnswers();
     }
 
+    /**
+     * Restore the user's answer from the _userAnswer property.
+     * The _userAnswer value must be in the form of arrays containing
+     * numbers, booleans or arrays only.
+     */
     restoreUserAnswers() {}
 
+    /**
+     * Store the user's answer in the _userAnswer property.
+     * The _userAnswer value must be in the form of arrays containing
+     * numbers, booleans or arrays only.
+     */
     storeUserAnswer() {}
 
     resetUserAnswer() {

--- a/src/core/js/models/componentModel.js
+++ b/src/core/js/models/componentModel.js
@@ -25,24 +25,145 @@ define([
 
     defaults() {
       return AdaptModel.resultExtend('defaults', {
-        _isA11yComponentDescriptionEnabled: true
+        _isA11yComponentDescriptionEnabled: true,
+        _userAnswer: null,
+        _attemptStates: null,
       });
     }
 
     trackable() {
       return AdaptModel.resultExtend('trackable', [
-        '_userAnswer'
+        '_userAnswer',
+        '_attemptStates'
       ]);
     }
 
     trackableType() {
       return AdaptModel.resultExtend('trackableType', [
+        Array,
         Array
       ]);
     }
 
     get hasManagedChildren() {
       return false;
+    }
+
+    init() {
+      if (Adapt.get('_isStarted')) {
+        this.onAdaptInitialize();
+        return;
+      }
+      this.listenToOnce(Adapt, 'adapt:initialize', this.onAdaptInitialize);
+    }
+
+    onAdaptInitialize() {
+      this.restoreUserAnswers();
+    }
+
+    restoreUserAnswers() {}
+
+    storeUserAnswer() {}
+
+    resetUserAnswer() {
+      this.set('_userAnswer', null);
+    }
+
+    reset(type, force) {
+      if (!this.get('_canReset') && !force) return;
+      this.resetUserAnswer();
+      super.reset(type, force);
+    }
+
+    /**
+     * Returns the current attempt state raw data or the raw data from the supplied attempt state object.
+     * @param {Object} [object] JSON object representing the component state. Defaults to current JSON.
+     * @returns {Array}
+     */
+    getAttemptState(object = this.toJSON()) {
+      const trackables = this.trackable();
+      const types = this.trackableType();
+      trackables.find((name, index) => {
+        // Exclude _attemptStates as it's trackable but isn't needed here
+        if (name !== '_attemptStates') return;
+        trackables.splice(index, 1);
+        types.splice(index, 1);
+        return true;
+      });
+      const values = trackables.map(n => object[n]);
+      const booleans = values.filter((v, i) => types[i] === Boolean).map(Boolean);
+      const numbers = values.filter((v, i) => types[i] === Number).map(v => Number(v) || 0);
+      const arrays = values.filter((v, i) => types[i] === Array);
+      return [
+        numbers,
+        booleans,
+        arrays
+      ];
+    }
+
+    /**
+     * Returns an attempt object representing the current state or a formatted version of the raw state object supplied.
+     * @param {Array} [state] JSON object representing the component state, defaults to current state returned from getAttemptState().
+     * @returns {Object}
+     */
+    getAttemptObject(state = this.getAttemptState()) {
+      const trackables = this.trackable();
+      const types = this.trackableType();
+      trackables.find((name, index) => {
+        // Exclude _attemptStates as it's trackable but isn't needed here
+        if (name !== '_attemptStates') return;
+        trackables.splice(index, 1);
+        types.splice(index, 1);
+        return true;
+      });
+      const numbers = (state[0] || []).slice(0);
+      const booleans = (state[1] || []).slice(0);
+      const arrays = (state[2] || []).slice(0);
+      const object = {};
+      trackables.forEach((n, i) => {
+        if (n === '_id') return;
+        switch (types[i]) {
+          case Number:
+            object[n] = numbers.shift();
+            break;
+          case Boolean:
+            object[n] = booleans.shift();
+            break;
+          case Array:
+            object[n] = arrays.shift();
+            break;
+        }
+      });
+      return object;
+    }
+
+    /**
+     * Sets the current attempt state from the supplied attempt state object.
+     * @param {Object} object JSON object representing the component state.
+     * @param {boolean} silent Stops change events from triggering
+     */
+    setAttemptObject(object, silent = true) {
+      this.set(object, { silent });
+    }
+
+    /**
+     * Adds the current attempt state object or the supplied state object to the attempts store.
+     * @param {Object} [object] JSON object representing the component state. Defaults to current JSON.
+     */
+    addAttemptObject(object = this.getAttemptObject()) {
+      const attemptStates = this.get('_attemptStates') || [];
+      const state = this.getAttemptState(object);
+      attemptStates.push(state);
+      this.set('_attemptStates', attemptStates);
+    }
+
+    /**
+     * Returns an array of the previous state objects. The most recent state is last in the list.
+     * @returns {Array}
+     */
+    getAttemptObjects() {
+      const states = this.get('_attemptStates') || [];
+      return states.map(state => this.getAttemptObject(state));
     }
 
   }

--- a/src/core/js/models/itemsComponentModel.js
+++ b/src/core/js/models/itemsComponentModel.js
@@ -18,6 +18,17 @@ define([
         'all': this.onAll,
         'change:_isVisited': this.checkCompletionStatus
       });
+      super.init();
+    }
+
+    restoreUserAnswers() {
+      const userAnswer = this.get('_userAnswer');
+      if (!userAnswer) return;
+      this.getChildren().forEach((child, index) => child.set('_isVisited', userAnswer[index]));
+    }
+
+    storeUserAnswer() {
+      this.set('_userAnswer', this.getChildren().map(child => child.get('_isVisited')));
     }
 
     /**
@@ -56,6 +67,7 @@ define([
     }
 
     checkCompletionStatus() {
+      this.storeUserAnswer();
       if (!this.areAllItemsCompleted()) return;
       this.setCompletionStatus();
     }

--- a/src/core/js/models/itemsComponentModel.js
+++ b/src/core/js/models/itemsComponentModel.js
@@ -22,13 +22,14 @@ define([
     }
 
     restoreUserAnswers() {
-      const userAnswer = this.get('_userAnswer');
-      if (!userAnswer) return;
-      this.getChildren().forEach((child, index) => child.set('_isVisited', userAnswer[index]));
+      const booleanArray = this.get('_userAnswer');
+      if (!booleanArray) return;
+      this.getChildren().forEach((child, index) => child.set('_isVisited', booleanArray[index]));
     }
 
     storeUserAnswer() {
-      this.set('_userAnswer', this.getChildren().map(child => child.get('_isVisited')));
+      const booleanArray = this.getChildren().map(child => child.get('_isVisited'));
+      this.set('_userAnswer', booleanArray);
     }
 
     /**

--- a/src/core/js/models/questionModel.js
+++ b/src/core/js/models/questionModel.js
@@ -32,8 +32,7 @@ define([
         '_isSubmitted',
         '_score',
         '_isCorrect',
-        '_attemptsLeft',
-        '_attemptStates'
+        '_attemptsLeft'
       ]);
     }
 
@@ -42,8 +41,7 @@ define([
         Boolean,
         Number,
         Boolean,
-        Number,
-        Array
+        Number
       ]);
     }
 
@@ -110,18 +108,6 @@ define([
     }
 
     /// ///
-    // Selection restoration process
-    /// /
-
-    // Used to add post-load changes to the model
-    onAdaptInitialize() {
-      this.restoreUserAnswers();
-    }
-
-    // Used to restore the user answers
-    restoreUserAnswers() {}
-
-    /// ///
     // Submit process
     /// /
 
@@ -148,10 +134,6 @@ define([
         _isSubmitted: true
       });
     }
-
-    // This is important for returning or showing the users answer
-    // This should preserve the state of the users answers
-    storeUserAnswer() {}
 
     // Sets _isCorrect:true/false based upon isCorrect method below
     markQuestion() {
@@ -308,9 +290,6 @@ define([
       });
     }
 
-    // Used by the question view to reset the stored user answer
-    resetUserAnswer() {}
-
     refresh() {
       this.trigger('question:refresh');
     }
@@ -356,97 +335,6 @@ define([
       }
 
       return this.get('_isInteractionComplete');
-    }
-
-    /**
-     * Returns the current attempt state raw data or the raw data from the supplied attempt state object.
-     * @param {Object} [object] JSON object representing the component state. Defaults to current JSON.
-     * @returns {Array}
-     */
-    getAttemptState(object = this.toJSON()) {
-      const trackables = this.trackable();
-      const types = this.trackableType();
-      trackables.find((name, index) => {
-        // Exclude _attemptStates as it's trackable but isn't needed here
-        if (name !== '_attemptStates') return;
-        trackables.splice(index, 1);
-        types.splice(index, 1);
-        return true;
-      });
-      const values = trackables.map(n => object[n]);
-      const booleans = values.filter((v, i) => types[i] === Boolean).map(Boolean);
-      const numbers = values.filter((v, i) => types[i] === Number).map(v => Number(v) || 0);
-      const arrays = values.filter((v, i) => types[i] === Array);
-      return [
-        numbers,
-        booleans,
-        arrays
-      ];
-    }
-
-    /**
-     * Returns an attempt object representing the current state or a formatted version of the raw state object supplied.
-     * @param {Array} [state] JSON object representing the component state, defaults to current state returned from getAttemptState().
-     * @returns {Object}
-     */
-    getAttemptObject(state = this.getAttemptState()) {
-      const trackables = this.trackable();
-      const types = this.trackableType();
-      trackables.find((name, index) => {
-        // Exclude _attemptStates as it's trackable but isn't needed here
-        if (name !== '_attemptStates') return;
-        trackables.splice(index, 1);
-        types.splice(index, 1);
-        return true;
-      });
-      const numbers = (state[0] || []).slice(0);
-      const booleans = (state[1] || []).slice(0);
-      const arrays = (state[2] || []).slice(0);
-      const object = {};
-      trackables.forEach((n, i) => {
-        if (n === '_id') return;
-        switch (types[i]) {
-          case Number:
-            object[n] = numbers.shift();
-            break;
-          case Boolean:
-            object[n] = booleans.shift();
-            break;
-          case Array:
-            object[n] = arrays.shift();
-            break;
-        }
-      });
-      return object;
-    }
-
-    /**
-     * Sets the current attempt state from the supplied attempt state object.
-     * @param {Object} object JSON object representing the component state.
-     * @param {boolean} silent Stops change events from triggering
-     */
-    setAttemptObject(object, silent = true) {
-      this.set(object, { silent });
-    }
-
-    /**
-     * Adds the current attempt state object or the supplied state object to the attempts store.
-     * @param {Object} [object] JSON object representing the component state. Defaults to current JSON.
-     */
-    addAttemptObject(object = this.getAttemptObject()) {
-      const attemptStates = this.get('_attemptStates') || [];
-      const state = this.getAttemptState(object);
-      attemptStates.push(state);
-      this.set('_attemptStates', attemptStates);
-    }
-
-    /**
-     * Returns an array of the previous state objects. The most recent state is last in the list.
-     * @returns {Array}
-     */
-    getAttemptObjects() {
-      const states = this.get('_attemptStates') || [];
-      return states.map(state => this.getAttemptObject(state));
     }
 
   }

--- a/src/core/js/models/questionModel.js
+++ b/src/core/js/models/questionModel.js
@@ -56,6 +56,7 @@ define([
     init() {
       this.setupDefaultSettings();
       this.setLocking('_canSubmit', true);
+      super.init();
     }
 
     // Calls default methods to setup on questions

--- a/src/core/js/models/questionModel.js
+++ b/src/core/js/models/questionModel.js
@@ -55,11 +55,6 @@ define([
 
     init() {
       this.setupDefaultSettings();
-      if (Adapt.get('_isStarted')) {
-        this.onAdaptInitialize();
-        return;
-      }
-      this.listenToOnce(Adapt, 'adapt:initialize', this.onAdaptInitialize);
       this.setLocking('_canSubmit', true);
     }
 


### PR DESCRIPTION
#2845 
Presentation components hotgraphic and accordion will keep visited states (narrative will also but there is no visible representation of visited states in narrative).

This should all carry on working as before except some crucial `QuestionModel` only behaviour is now also accessible to `ComponentModel` and by extension `ItemsComponentModel`. 

### Changed
* Moved` _attemptStates` API from `QuestionModel` to `ComponentModel`
* Moved `_userAnswer` API from `QuestionModel` to `ComponentModel`

### Added
* `ItemsComponentModel` save and restore behaviour
* `ComponentModel._userAnswer` reset behaviour

Test with spoor [pr#197](https://github.com/adaptlearning/adapt-contrib-spoor/pull/197) or using spoor branch [issue/2805](https://github.com/adaptlearning/adapt-contrib-spoor/tree/issue/2805)
Use scorm_test_harness.html to check save/restore