### PR TITLE
issue/2851 Fixed DrawerView passing Backbone view to Adapt.a11y.focusFirst

### DIFF
--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -35,7 +35,7 @@ define([
         'navigation:toggleDrawer': this.toggleDrawer,
         'drawer:triggerCustomView': this.openCustomView,
         'drawer:closeDrawer': this.onCloseDrawer,
-        'remove': this.onCloseDrawer,
+        'remove': this.onRemove,
         'drawer:remove': this.remove
       });
 
@@ -108,6 +108,10 @@ define([
 
     onCloseDrawer: function($toElement) {
       this.hideDrawer($toElement);
+    },
+
+    onRemove: function() {
+      this.hideDrawer();
     },
 
     toggleDrawer: function() {


### PR DESCRIPTION
See #2851 

### Fixed
* Added handler for external remove events fired when the drawer is open (originating from url changes, custom extensions etc)