### PR TITLE
issue/2853 Fixed csv delimiter detection on translate import

### DIFF
--- a/grunt/helpers/Translate.js
+++ b/grunt/helpers/Translate.js
@@ -41,7 +41,7 @@ class Translate {
     masterLang = 'en',
     targetLang = null,
     format = 'csv',
-    csvDelimiter = ',',
+    csvDelimiter = null,
     shouldReplaceExisting = false,
     jsonext = 'json',
     sourcePath = '',
@@ -186,7 +186,7 @@ class Translate {
 
     const csvOptions = {
       quotedString: true,
-      delimiter: this.csvDelimiter
+      delimiter: this.csvDelimiter || ','
     };
 
     const fileNames = Object.keys(outputGroupedByFile);
@@ -294,13 +294,20 @@ class Translate {
             this.log(`Encoding not detected used utf-8 ${filename}`);
           }
           let csvDelimiter = this.csvDelimiter;
-          const firstLineMatches = fileContent.match(/.+\/"{0,1}.{1}/);
-          if (firstLineMatches && firstLineMatches.length) {
-            const detectedDelimiter = firstLineMatches[0].slice(-1);
-            if (detectedDelimiter !== this.csvDelimiter) {
-              this.log(`Delimiter detected as ${detectedDelimiter} in ${filename}`);
-              csvDelimiter = detectedDelimiter;
+          if (!csvDelimiter) {
+            const firstLineMatches = fileContent.match(/[,;\t| ]{1}/);
+            if (firstLineMatches && firstLineMatches.length) {
+              const detectedDelimiter = firstLineMatches[0].slice(-1);
+              if (detectedDelimiter !== this.csvDelimiter) {
+                this.log(`Delimiter detected as ${detectedDelimiter} in ${filename}`);
+                csvDelimiter = detectedDelimiter;
+              }
             }
+          }
+          if (!csvDelimiter) {
+            const err = new Error(`Could not detect csv delimiter ${targetLanguage.path}`);
+            err.number = 10014;
+            throw err;
           }
           const options = {
             delimiter: csvDelimiter

--- a/grunt/helpers/Translate.js
+++ b/grunt/helpers/Translate.js
@@ -295,7 +295,7 @@ class Translate {
           }
           let csvDelimiter = this.csvDelimiter;
           if (!csvDelimiter) {
-            const firstLineMatches = fileContent.match(/[,;\t| ]{1}/);
+            const firstLineMatches = fileContent.match(/^[^,;\t| \n\r]+\/"{0,1}[,;\t| ]{1}/);
             if (firstLineMatches && firstLineMatches.length) {
               const detectedDelimiter = firstLineMatches[0].slice(-1);
               if (detectedDelimiter !== this.csvDelimiter) {

--- a/grunt/tasks/translate.js
+++ b/grunt/tasks/translate.js
@@ -13,7 +13,7 @@ module.exports = function(grunt) {
       masterLang: grunt.option('masterLang') || 'en',
       targetLang: grunt.option('targetLang') || null,
       format: grunt.option('format') || 'csv',
-      csvDelimiter: grunt.option('csvDelimiter') || ',',
+      csvDelimiter: grunt.option('csvDelimiter') || null,
       shouldReplaceExisting: grunt.option('replace') || false,
       languagePath: grunt.option('languagedir') || 'languagefiles',
       isTest: grunt.option('test') || false,
@@ -38,6 +38,9 @@ module.exports = function(grunt) {
               break;
             case 10003: // Import destination folder already exists.
               grunt.log.error(err + `\nTo replace the content in this folder, please add a --replace flag to the grunt task.`);
+              break;
+            case 10014: // Import destination folder already exists.
+              grunt.log.error(err + `\nTo specify a delimiter, please add a --csvDelimiter=',' flag to the grunt task. Only , ; | tab and space are supported.`);
               break;
             default:
               grunt.log.error(err);

--- a/grunt/tasks/translate.js
+++ b/grunt/tasks/translate.js
@@ -39,7 +39,7 @@ module.exports = function(grunt) {
             case 10003: // Import destination folder already exists.
               grunt.log.error(err + `\nTo replace the content in this folder, please add a --replace flag to the grunt task.`);
               break;
-            case 10014: // Import destination folder already exists.
+            case 10014: // Could not detect delimiter
               grunt.log.error(err + `\nTo specify a delimiter, please add a --csvDelimiter=',' flag to the grunt task. Only , ; | tab and space are supported.`);
               break;
             default:


### PR DESCRIPTION
#2853 
`translate:import` delimiter detection was broken when the first value to import contained slashes (html usually).
```csv
"articles/a-05/title/","<div>a-05</div>"
"articles/a-10/title/","a-10"
"articles/a-15/title/","a-15"
"articles/a-15/_trickle/_button/startText/","Continue"
"articles/a-20/title/","a-20"
```
### Changed
* Now detects delimiters only when none is specified at the command line `--csvDelimiter=','`
* Now only supports the detection of the delimiters , ; | tab and space
* Will now error if csv delimiter isn't specified and cannot be detected

### Notes
* Still exports with comma as the default delimiter

[Regexp](https://github.com/adaptlearning/adapt_framework/pull/2857/files#diff-f99b28ae92e4435fff8d5fd848f99463R298) test: [/^[^,;\t| \n\r]+\/"{0,1}[,;\t| ]{1}/](https://regex101.com/r/o8exUQ/1)