### PR TITLE
issue/2886 preventScroll fix now excludes firefox

### DIFF
--- a/src/core/js/a11y.js
+++ b/src/core/js/a11y.js
@@ -617,8 +617,8 @@ define([
             // Drop focus errors as only happens when the element
             // isn't attached to the DOM.
           }
-          if (Adapt.device.browser === 'internet explorer') {
-            // ie 11 doesn't support preventScroll but this breaks firefox 79.0
+          if (Adapt.device.browser !== 'firefox') {
+            // ie 11 and safari doesn't support preventScroll but this breaks firefox 79.0
             window.scrollTo(null, y);
           }
         } else {

--- a/src/core/js/a11y.js
+++ b/src/core/js/a11y.js
@@ -617,7 +617,10 @@ define([
             // Drop focus errors as only happens when the element
             // isn't attached to the DOM.
           }
-          window.scrollTo(null, y);
+          if (Adapt.device.browser === 'internet explorer') {
+            // ie 11 doesn't support preventScroll but this breaks firefox 79.0
+            window.scrollTo(null, y);
+          }
         } else {
           $element[0].focus();
         }

--- a/src/core/js/a11y.js
+++ b/src/core/js/a11y.js
@@ -618,11 +618,11 @@ define([
             // isn't attached to the DOM.
           }
           switch (Adapt.device.browser) {
-          case 'internet explorer':
-          case 'microsoft edge':
-          case 'safari':
-            // return to previous scroll position due to no support for preventScroll
-            window.scrollTo(null, y);
+            case 'internet explorer':
+            case 'microsoft edge':
+            case 'safari':
+              // return to previous scroll position due to no support for preventScroll
+              window.scrollTo(null, y);
           }
         } else {
           $element[0].focus();

--- a/src/core/js/a11y.js
+++ b/src/core/js/a11y.js
@@ -617,8 +617,11 @@ define([
             // Drop focus errors as only happens when the element
             // isn't attached to the DOM.
           }
-          if (Adapt.device.browser !== 'firefox') {
-            // ie 11 and safari do not support preventScroll but this fix breaks firefox 79.0
+          switch (Adapt.device.browser) {
+          case 'internet explorer':
+          case 'microsoft edge':
+          case 'safari':
+            // return to previous scroll position due to no support for preventScroll
             window.scrollTo(null, y);
           }
         } else {

--- a/src/core/js/a11y.js
+++ b/src/core/js/a11y.js
@@ -618,7 +618,7 @@ define([
             // isn't attached to the DOM.
           }
           if (Adapt.device.browser !== 'firefox') {
-            // ie 11 and safari doesn't support preventScroll but this breaks firefox 79.0
+            // ie 11 and safari do not support preventScroll but this fix breaks firefox 79.0
             window.scrollTo(null, y);
           }
         } else {


### PR DESCRIPTION
#2886 

Firefox misreports `$(window).scrollTop()` frequently, returning 0 in unusual circumstances. The `preventScroll` fix for `Element.focus` - for browsers which don't support the `preventScroll` option, ie11 and safari at the time of writing - is necessary but should not be applied to Firefox where it often causes the scroll to bounce back to 0.

### Changed
* Stopped `preventScroll` fix applying in Firefox


References:
Browser compatibility - https://developer.mozilla.org/en-US/docs/Web/API/HTMLOrForeignElement/focus#Browser_compatibility
Safari support ticket for preventDefault - https://bugs.webkit.org/show_bug.cgi?id=178583

Notes:
Have yet to identify why Firefox misreports the `$(window).scrollTop()`, it reads fine in the debugger console or watch window. The bug seems to appear at frequency in Firefox and then disappears again. The `scrollTop` overrides from `Adapt.scrolling` were not applied, so this is either a jQuery or Firefox bug.