### PR TITLE
issue/2901 Fix to prevent error in contentObjectView.renderTo

### DIFF
--- a/src/core/js/scrolling.js
+++ b/src/core/js/scrolling.js
@@ -114,7 +114,7 @@ define([
       const currentModel = Adapt.findById(currentModelId);
       if (!currentModel) return;
 
-      if (!currentModel.get('_isRendered') || !currentModel.get('_isRendered')) {
+      if (!currentModel.get('_isRendered') || !currentModel.get('_isReady')) {
         await Adapt.parentView.renderTo(currentModelId);
       }
 

--- a/src/core/js/views/contentObjectView.js
+++ b/src/core/js/views/contentObjectView.js
@@ -95,6 +95,8 @@ define([
      * @param {string} id
      */
     async renderTo(id) {
+      const isRenderToSelf = (id === this.model.get('_id'));
+      if (isRenderToSelf) return;
       let models = this.model.getAllDescendantModels(true).filter(model => model.get('_isAvailable'));
       const index = models.findIndex(model => model.get('_id') === id);
       if (index === -1) {


### PR DESCRIPTION
#2901 

### Fixed
* Defensive code to prevent `contentObjectView.renderTo(id)` from attempting to render to itself
* Typo in `Adapt.scrollTo`