### PR TITLE
issue/2903 Close the event life-cycle on requestChild no model

### DIFF
--- a/src/core/js/views/adaptView.js
+++ b/src/core/js/views/adaptView.js
@@ -224,6 +224,8 @@ define([
         Adapt.trigger('view:requestChild', event);
         if (!event.hasRequestChild) {
           // No new model was supplied
+          // Close the event so that the final state can be scrutinized
+          event.close();
           return;
         }
         // A new model has been supplied for the end of the list.


### PR DESCRIPTION
#2903 

#### Added
* `event` object life-cycle event `closed`