### PR TITLE
fix bug in triggerDataReady

### DIFF
--- a/src/core/js/data.js
+++ b/src/core/js/data.js
@@ -164,9 +164,7 @@ define([
         Adapt.trigger('app:languageChanged', newLanguage);
         _.defer(() => {
           Adapt.startController.loadCourseData();
-          const hash = Adapt.startController.isEnabled() ?
-            '#/' :
-            Adapt.startController.getStartHash(true);
+          const hash = Adapt.startController.isEnabled() ? Adapt.startController.getStartHash(true) : '#/';
           Adapt.router.navigate(hash, { trigger: true, replace: true });
         });
       }


### PR DESCRIPTION
should only be calling `getStartHash` if start page is enabled, not the other way round

fixes #2907