### PR TITLE
Added fix for firefox outline container misalignment

### DIFF
--- a/src/core/less/core/global.less
+++ b/src/core/less/core/global.less
@@ -1,0 +1,14 @@
+// Fix for Firefox outline container height misalignment
+// https://github.com/adaptlearning/adapt_framework/issues/2912
+// --------------------------------------------------
+.menu,
+.menu-item,
+.page,
+.article,
+.block,
+.component {
+  &__title-inner {
+    display: inline;
+    vertical-align: middle;
+  }
+}


### PR DESCRIPTION
Related issue https://github.com/adaptlearning/adapt_framework/issues/2912

* Add fix for Firefox container height misalignment
* Moved *-title-inner CSS from Vanilla theme to Core