### PR TITLE
issue/2928 Fixes navigateToElement, deprecates scrollTo

### DIFF
--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -140,9 +140,9 @@ define([
     }
 
     /**
-     * Allows a selector to be passed in and Adapt will navigate to this element. Resolves
+     * Allows a selector or id to be passed in and Adapt will navigate to this element. Resolves
      * asynchronously when the element has been navigated to.
-     * @param {string} selector CSS selector of the Adapt element you want to navigate to e.g. `".co-05"`
+     * @param {string} selector CSS selector or id of the Adapt element you want to navigate to e.g. `".co-05"` or `"co-05"`
      * @param {Object} [settings] The settings for the `$.scrollTo` function (See https://github.com/flesler/jquery.scrollTo#settings).
      * @param {Object} [settings.replace=false] Set to `true` if you want to update the URL without creating an entry in the browser's history.
      */

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -350,8 +350,56 @@ define([
      * @param {Object} [settings.replace=false] Set to `true` if you want to update the URL without creating an entry in the browser's history.
      */
     async navigateToElement(selector, settings = {}) {
-      Adapt.log.deprecated('Adapt.navigateToElement and Adapt.router.navigateToElement, use Adapt.scrollTo instead.');
-      return Adapt.scrolling.scrollTo(selector, settings);
+      const currentModelId = selector.replace(/\./g, '').split(' ')[0];
+      const currentModel = Adapt.findById(currentModelId);
+
+      if (currentModel && (!currentModel.get('_isRendered') || !currentModel.get('_isReady'))) {
+        await this.navigateToContentObject(currentModelId);
+        await Adapt.parentView.renderTo(currentModelId);
+      }
+
+      // Get the current location - this is set in the router
+      const location = (Adapt.location._contentType) ?
+        Adapt.location._contentType : Adapt.location._currentLocation;
+      // Trigger initial scrollTo event
+      Adapt.trigger(`${location}:scrollTo`, selector);
+      // Setup duration variable passed upon argumentsß
+      const disableScrollToAnimation = Adapt.config.has('_disableAnimation') ? Adapt.config.get('_disableAnimation') : false;
+      if (disableScrollToAnimation) {
+        settings.duration = 0;
+      } else if (!settings.duration) {
+        settings.duration = $.scrollTo.defaults.duration;
+      }
+
+      let offsetTop = 0;
+      if (Adapt.scrolling.isLegacyScrolling) {
+        offsetTop = -$('.nav').outerHeight();
+        // prevent scroll issue when component description aria-label coincident with top of component
+        if ($(selector).hasClass('component')) {
+          offsetTop -= $(selector).find('.aria-label').height() || 0;
+        }
+      }
+
+      if (!settings.offset) settings.offset = { top: offsetTop, left: 0 };
+      if (settings.offset.top === undefined) settings.offset.top = offsetTop;
+      if (settings.offset.left === undefined) settings.offset.left = 0;
+
+      if (settings.offset.left === 0) settings.axis = 'y';
+
+      if (Adapt.get('_canScroll') !== false) {
+        // Trigger scrollTo plugin
+        $.scrollTo(selector, settings);
+      }
+
+      // Trigger an event after animation
+      // 300 milliseconds added to make sure queue has finished
+      await new Promise(resolve => {
+        _.delay(() => {
+          Adapt.a11y.focusNext(selector);
+          Adapt.trigger(`${location}:scrolledTo`, selector);
+          resolve();
+        }, settings.duration + 300);
+      });
     }
 
     get(...args) {

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -322,10 +322,10 @@ define([
     }
 
     /**
-     * Allows a selector to be passed in and Adapt will navigate to this element. Resolves
+     * Allows a selector or id to be passed in and Adapt will navigate to this element. Resolves
      * asynchronously when the element has been navigated to.
      * Backend for Adapt.navigateToElement
-     * @param {string} selector CSS selector of the Adapt element you want to navigate to e.g. `".co-05"`
+     * @param {string} selector CSS selector or id of the Adapt element you want to navigate to e.g. `".co-05"` or `"co-05"`
      * @param {Object} [settings] The settings for the `$.scrollTo` function (See https://github.com/flesler/jquery.scrollTo#settings).
      * @param {Object} [settings.replace=false] Set to `true` if you want to update the URL without creating an entry in the browser's history.
      */

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -361,7 +361,7 @@ define([
         Adapt.location._contentType : Adapt.location._currentLocation;
       // Trigger initial scrollTo event
       Adapt.trigger(`${location}:scrollTo`, selector);
-      // Setup duration variable passed upon argumentsß
+      // Setup duration variable
       const disableScrollToAnimation = Adapt.config.has('_disableAnimation') ? Adapt.config.get('_disableAnimation') : false;
       if (disableScrollToAnimation) {
         settings.duration = 0;

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -342,10 +342,10 @@ define([
           this.isScrolling = true;
           this.navigate(`#/id/${currentModelId}`, { trigger: true, replace: shouldReplace });
           this.model.set('_shouldNavigateFocus', false, { pluginName: 'adapt' });
-          await new Promise(resolve => Adapt.once('contentObjectView:preRender', () => {
+          await new Promise(resolve => Adapt.once('contentObjectView:ready', _.debounce(() => {
             this.model.set('_shouldNavigateFocus', true, { pluginName: 'adapt' });
             resolve();
-          }));
+          }, 1)));
           this.isScrolling = false;
         }
         await Adapt.parentView.renderTo(currentModelId);

--- a/src/core/js/scrolling.js
+++ b/src/core/js/scrolling.js
@@ -110,56 +110,8 @@ define([
      * @param {Object} [settings.replace=false] Set to `true` if you want to update the URL without creating an entry in the browser's history.
      */
     async scrollTo(selector, settings = {}) {
-      const currentModelId = selector.replace(/\./g, '').split(' ')[0];
-      const currentModel = Adapt.findById(currentModelId);
-
-      if (currentModel && (!currentModel.get('_isRendered') || !currentModel.get('_isReady'))) {
-        await Adapt.router.navigateToContentObject(currentModelId);
-        await Adapt.parentView.renderTo(currentModelId);
-      }
-
-      // Get the current location - this is set in the router
-      const location = (Adapt.location._contentType) ?
-        Adapt.location._contentType : Adapt.location._currentLocation;
-      // Trigger initial scrollTo event
-      Adapt.trigger(`${location}:scrollTo`, selector);
-      // Setup duration variable passed upon argumentsß
-      const disableScrollToAnimation = Adapt.config.has('_disableAnimation') ? Adapt.config.get('_disableAnimation') : false;
-      if (disableScrollToAnimation) {
-        settings.duration = 0;
-      } else if (!settings.duration) {
-        settings.duration = $.scrollTo.defaults.duration;
-      }
-
-      let offsetTop = 0;
-      if (Adapt.scrolling.isLegacyScrolling) {
-        offsetTop = -$('.nav').outerHeight();
-        // prevent scroll issue when component description aria-label coincident with top of component
-        if ($(selector).hasClass('component')) {
-          offsetTop -= $(selector).find('.aria-label').height() || 0;
-        }
-      }
-
-      if (!settings.offset) settings.offset = { top: offsetTop, left: 0 };
-      if (settings.offset.top === undefined) settings.offset.top = offsetTop;
-      if (settings.offset.left === undefined) settings.offset.left = 0;
-
-      if (settings.offset.left === 0) settings.axis = 'y';
-
-      if (Adapt.get('_canScroll') !== false) {
-        // Trigger scrollTo plugin
-        $.scrollTo(selector, settings);
-      }
-
-      // Trigger an event after animation
-      // 300 milliseconds added to make sure queue has finished
-      await new Promise(resolve => {
-        _.delay(() => {
-          Adapt.a11y.focusNext(selector);
-          Adapt.trigger(`${location}:scrolledTo`, selector);
-          resolve();
-        }, settings.duration + 300);
-      });
+      Adapt.log.deprecated('Adapt.scrollTo and Adapt.scrolling.scrollTo, use Adapt.navigateToElement instead.');
+      return Adapt.router.navigateToElement(selector, settings);
     }
 
   }

--- a/src/core/js/scrolling.js
+++ b/src/core/js/scrolling.js
@@ -1,7 +1,6 @@
 define([
-  'core/js/adapt',
-  'core/js/models/contentObjectModel'
-], function(Adapt, ContentObjectModel) {
+  'core/js/adapt'
+], function(Adapt) {
 
   class Scrolling extends Backbone.Controller {
 

--- a/src/core/js/scrolling.js
+++ b/src/core/js/scrolling.js
@@ -1,6 +1,7 @@
 define([
-  'core/js/adapt'
-], function(Adapt) {
+  'core/js/adapt',
+  'core/js/models/contentObjectModel'
+], function(Adapt, ContentObjectModel) {
 
   class Scrolling extends Backbone.Controller {
 
@@ -109,12 +110,11 @@ define([
      * @param {Object} [settings.replace=false] Set to `true` if you want to update the URL without creating an entry in the browser's history.
      */
     async scrollTo(selector, settings = {}) {
-
-      const currentModelId = selector.replace(/\./g, '');
+      const currentModelId = selector.replace(/\./g, '').split(' ')[0];
       const currentModel = Adapt.findById(currentModelId);
-      if (!currentModel) return;
 
-      if (!currentModel.get('_isRendered') || !currentModel.get('_isReady')) {
+      if (currentModel && (!currentModel.get('_isRendered') || !currentModel.get('_isReady'))) {
+        await Adapt.router.navigateToContentObject(currentModelId);
         await Adapt.parentView.renderTo(currentModelId);
       }
 


### PR DESCRIPTION
#2928 

### Added
* Sub-contentobject urls are now compatible with the browser back and next buttons, `#/id/c-80`, `#/id/c-35`, `#/id/c-25` etc

### Fixes
* `Adapt.navigateToElement` with any selector `.c-25 .component__instruction`, the first part is assumed to be the `id`
* `Adapt.navigateToElement` will now handle being passed an `id` or a selector

### Deprecated
* `Adapt.scrollTo` and `Adapt.scrolling.scrollTo` and incorporated the scrolling behaviour properly into `Adapt.router.navigateToElement`