### PR TITLE
Add new hotgraphic config to example course

### DIFF
--- a/src/course/en/components.json
+++ b/src/course/en/components.json
@@ -141,6 +141,8 @@
         "_setCompletionOn": "allItems",
         "_canCycleThroughPagination": false,
         "_hidePagination": false,
+        "_isNarrativeOnMobile": true,
+        "_useNumberedPins": false,
         "_useGraphicsAsPins": false,
         "title": "Hot Graphic",
         "displayTitle": "Hot Graphic",


### PR DESCRIPTION
Dependent on https://github.com/adaptlearning/adapt_framework/issues/2936

* Adds two new configuration options, `_isNarrativeOnMobile` and `_useNumberedPins`, to the Hotgraphic component in the example course.