### PR TITLE
Removed _isTextProcessorEnabled

### DIFF
--- a/src/core/schema/config.model.schema
+++ b/src/core/schema/config.model.schema
@@ -76,14 +76,6 @@
           "validators": [],
           "title": "Enabled?"
         },
-        "_isTextProcessorEnabled": {
-          "type": "boolean",
-          "default": false,
-          "inputType": "Checkbox",
-          "validators": [],
-          "title": "Enable text reader support?",
-          "help": "Adds focusing to assist text reader software"
-        },
         "_isSkipNavigationEnabled": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
Resolves https://github.com/adaptlearning/adapt_framework/issues/2952

* Removes `_isTextProcessorEnabled` property from config.model.schema