### PR TITLE
Convert port string to number

### DIFF
--- a/grunt/config/connect.js
+++ b/grunt/config/connect.js
@@ -1,6 +1,6 @@
 module.exports = function(grunt, options) {
 
-  var port = grunt.option('port') || 9001;
+  var port = parseInt(grunt.option('port')) || 9001;
   var host = grunt.option('host') || 'localhost';
 
   return {


### PR DESCRIPTION
Reference: https://github.com/gruntjs/grunt-contrib-connect/issues/254.

Resolves #2954.