### PR TITLE
fixes #2997 CommonJS and nested requires

### DIFF
--- a/grunt/tasks/javascript.js
+++ b/grunt/tasks/javascript.js
@@ -295,6 +295,7 @@ module.exports = function(grunt) {
               {
                 amdToES6Modules: true,
                 amdDefineES6Modules: true,
+                ignoreNestedRequires: true,
                 defineFunctionName: '__AMD',
                 defineModuleId: (moduleId) => moduleId.replace(convertSlashes, '/').replace(basePath, '').replace('.js', ''),
                 excludes: []

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "@types/backbone": "^1.4.1",
         "@types/jquery": "^3.3.31",
         "async": "^3.1.1",
-        "babel-plugin-transform-amd-to-es6": "^0.3.0",
+        "babel-plugin-transform-amd-to-es6": "^0.4.0",
         "chalk": "^2.4.1",
         "columnify": "^1.5.4",
         "csv": "^5.0.0",


### PR DESCRIPTION
### Changed
* Updated [babel-plugin-transform-amd-to-es6](https://github.com/cgkineo/babel-plugin-transform-amd-to-es6) to the latest version ([relevant amend](https://github.com/cgkineo/babel-plugin-transform-amd-to-es6/commit/9bb4bde94fc73041781ca3e423c47fb2445be64f))
* Added configuration option to ignore nested requires