### PR TITLE
issue/2999 Converted to ES6 classes and modules and let/const

### DIFF
--- a/src/core/js/a11y.js
+++ b/src/core/js/a11y.js
@@ -1,23 +1,18 @@
-define([
-  'core/js/adapt',
-  './a11y/browserFocus',
-  './a11y/focusOptions',
-  './a11y/keyboardFocusOutline',
-  './a11y/log',
-  './a11y/scroll',
-  './a11y/wrapFocus',
-  './a11y/popup',
-  './a11y/deprecated'
-], function(Adapt, BrowserFocus, FocusOptions, KeyboardFocusOutline, Log, Scroll, WrapFocus, Popup) {
+import Adapt from 'core/js/adapt';
+import BrowserFocus from 'core/js/a11y/browserFocus';
+import FocusOptions from 'core/js/a11y/focusOptions';
+import KeyboardFocusOutline from 'core/js/a11y/keyboardFocusOutline';
+import Log from 'core/js/a11y/log';
+import Scroll from 'core/js/a11y/scroll';
+import WrapFocus from 'core/js/a11y/wrapFocus';
+import Popup from 'core/js/a11y/popup';
 
-  var A11y = Backbone.Controller.extend({
+import 'core/js/a11y/deprecated';
 
-    $html: $('html'),
-    _htmlCharRegex: /&.*;/g,
+class A11y extends Backbone.Controller {
 
-    config: null,
-    defaults: {
-
+  defaults() {
+    return {
       _isFocusOutlineKeyboardOnlyEnabled: true,
       /**
        * `_isFocusOutlineDisabled` ignores `_isEnabled` and can be used when all other
@@ -59,351 +54,387 @@ define([
        */
       _warnFirstOnly: true,
       _warn: true
+    };
+  }
 
-    },
+  initialize() {
+    this.$html = $('html');
+    this._htmlCharRegex = /&.*;/g;
+    this.config = null;
+    this._browserFocus = new BrowserFocus();
+    this._keyboardFocusOutline = new KeyboardFocusOutline();
+    this._wrapFocus = new WrapFocus();
+    this._popup = new Popup();
+    this._scroll = new Scroll();
+    this.log = new Log();
 
-    _browserFocus: new BrowserFocus(),
-    _keyboardFocusOutline: new KeyboardFocusOutline(),
-    _wrapFocus: new WrapFocus(),
-    _popup: new Popup(),
-    _scroll: new Scroll(),
+    this._removeLegacyElements();
+    this.listenToOnce(Adapt, {
+      'app:dataLoaded': this._onDataLoaded,
+      'navigationView:postRender': this._removeLegacyElements
+    }, this);
+    Adapt.on('device:changed', this._setupNoSelect);
+    this.listenTo(Adapt, {
+      'router:location': this._onNavigationStart,
+      'contentObjectView:ready router:plugin': this._onNavigationEnd
+    });
+  }
 
-    log: new Log(),
+  _onDataLoaded() {
+    this.config = Adapt.config.get('_accessibility');
+    this.config._isActive = false;
+    this.config._options = _.defaults(this.config._options || {}, this.defaults());
+    Adapt.offlineStorage.set('a11y', false);
+    this.$html.toggleClass('has-accessibility', this.isEnabled());
+    this._setupNoSelect();
+    this._addFocuserDiv();
+    if (this._isReady) {
+      return;
+    }
+    this._isReady = true;
+    Adapt.trigger('accessibility:ready');
+  }
 
-    initialize: function() {
-      this._removeLegacyElements();
-      this.listenToOnce(Adapt, {
-        'app:dataLoaded': this._onDataLoaded,
-        'navigationView:postRender': this._removeLegacyElements
-      }, this);
-      Adapt.on('device:changed', this._setupNoSelect);
-      this.listenTo(Adapt, {
-        'router:location': this._onNavigationStart,
-        'contentObjectView:ready router:plugin': this._onNavigationEnd
-      });
-    },
-
-    _onDataLoaded: function() {
-      this.config = Adapt.config.get('_accessibility');
-      this.config._isActive = false;
-      this.config._options = _.defaults(this.config._options || {}, this.defaults);
-      Adapt.offlineStorage.set('a11y', false);
-      this.$html.toggleClass('has-accessibility', this.isEnabled());
-      this._setupNoSelect();
-      this._addFocuserDiv();
-      if (this._isReady) {
-        return;
+  _setupNoSelect() {
+    if (!this.config || !this.config._disableTextSelectOnClasses) {
+      return;
+    }
+    var classes = this.config._disableTextSelectOnClasses.split(' ');
+    var isMatch = false;
+    for (var i = 0, item; (item = classes[i++]);) {
+      if (this.$html.is(item)) {
+        isMatch = true;
+        break;
       }
-      this._isReady = true;
-      Adapt.trigger('accessibility:ready');
-    },
+    }
+    this.$html.toggleClass('u-no-select', isMatch);
+  }
 
-    _setupNoSelect: function() {
-      if (!this.config || !this.config._disableTextSelectOnClasses) {
-        return;
-      }
-      var classes = this.config._disableTextSelectOnClasses.split(' ');
-      var isMatch = false;
-      for (var i = 0, item; (item = classes[i++]);) {
-        if (this.$html.is(item)) {
-          isMatch = true;
-          break;
-        }
-      }
-      this.$html.toggleClass('u-no-select', isMatch);
-    },
+  _addFocuserDiv() {
+    if ($('#a11y-focuser').length) {
+      return;
+    }
+    $('body').append($('<div id="a11y-focuser" class="a11y-ignore" tabindex="-1" role="presentation">&nbsp;</div>'));
+  }
 
-    _addFocuserDiv: function() {
-      if ($('#a11y-focuser').length) {
-        return;
-      }
-      $('body').append($('<div id="a11y-focuser" class="a11y-ignore" tabindex="-1" role="presentation">&nbsp;</div>'));
-    },
+  _removeLegacyElements() {
+    var $legacyElements = $('body').children('#accessibility-toggle, #accessibility-instructions');
+    var $navigationElements = $('.nav').find('#accessibility-toggle, #accessibility-instructions');
+    if (!$legacyElements.length && !$navigationElements.length) {
+      return;
+    }
+    Adapt.log.warn('REMOVED: #accessibility-toggle and #accessibility-instructions have been removed. Please remove them from all of your .html files.');
+    $legacyElements.remove();
+    $navigationElements.remove();
+  }
 
-    _removeLegacyElements: function() {
-      var $legacyElements = $('body').children('#accessibility-toggle, #accessibility-instructions');
-      var $navigationElements = $('.nav').find('#accessibility-toggle, #accessibility-instructions');
-      if (!$legacyElements.length && !$navigationElements.length) {
-        return;
-      }
-      Adapt.log.warn('REMOVED: #accessibility-toggle and #accessibility-instructions have been removed. Please remove them from all of your .html files.');
-      $legacyElements.remove();
-      $navigationElements.remove();
-    },
+  _onNavigationStart() {
+    if (!this.isEnabled()) {
+      return;
+    }
+    // Stop document reading
+    _.defer(function() {
+      Adapt.a11y.toggleHidden('.contentobject', true);
+    });
+  }
 
-    _onNavigationStart: function() {
-      if (!this.isEnabled()) {
-        return;
-      }
-      // Stop document reading
-      _.defer(function() {
-        Adapt.a11y.toggleHidden('.contentobject', true);
-      });
-    },
+  _onNavigationEnd(view) {
+    // Prevent sub-menu items provoking behaviour
+    if ((view && view.model && view.model.get('_id') !== Adapt.location._currentId) || !this.isEnabled()) {
+      return;
+    }
+    // Allow document to be read
+    Adapt.a11y.toggleHidden('.contentobject', false);
+  }
 
-    _onNavigationEnd: function(view) {
-      // Prevent sub-menu items provoking behaviour
-      if ((view && view.model && view.model.get('_id') !== Adapt.location._currentId) || !this.isEnabled()) {
-        return;
-      }
-      // Allow document to be read
-      Adapt.a11y.toggleHidden('.contentobject', false);
-    },
+  isActive() {
+    this.log.removed('Accessibility is now always active when enabled. Please unify your user experiences.');
+    return false;
+  }
 
-    isActive: function() {
-      this.log.removed('Accessibility is now always active when enabled. Please unify your user experiences.');
-      return false;
-    },
+  isEnabled() {
+    return this.config && this.config._isEnabled;
+  }
 
-    isEnabled: function() {
-      return this.config && this.config._isEnabled;
-    },
-
-    /**
-     * Adds or removes `aria-hidden` attribute to elements.
-     *
-     * @param {Object|string|Array} $elements
-     * @param {boolean} [isHidden=true]
-     * @returns {Object} Returns `Adapt.a11y`
-     */
-    toggleHidden: function($elements, isHidden) {
-      $elements = $($elements);
-      var config = Adapt.a11y.config;
-      if (!config._isEnabled || !config._options._isAriaHiddenManagementEnabled) {
-        return this;
-      }
-      isHidden = isHidden === undefined ? true : isHidden;
-      if (isHidden === true) {
-        $elements.attr('aria-hidden', true);
-      } else {
-        $elements.removeAttr('aria-hidden');
-      }
+  /**
+   * Adds or removes `aria-hidden` attribute to elements.
+   *
+   * @param {Object|string|Array} $elements
+   * @param {boolean} [isHidden=true]
+   * @returns {Object} Returns `Adapt.a11y`
+   */
+  toggleHidden($elements, isHidden) {
+    $elements = $($elements);
+    var config = Adapt.a11y.config;
+    if (!config._isEnabled || !config._options._isAriaHiddenManagementEnabled) {
       return this;
-    },
+    }
+    isHidden = isHidden === undefined ? true : isHidden;
+    if (isHidden === true) {
+      $elements.attr('aria-hidden', true);
+    } else {
+      $elements.removeAttr('aria-hidden');
+    }
+    return this;
+  }
 
-    /**
-     * Adds or removes `aria-hidden` and `disabled` attributes and `disabled`
-     * classes to elements.
-     *
-     * @param {Object|string|Array} $elements
-     * @param {boolean} [isHidden=true]
-     * @returns {Object} Returns `Adapt.a11y`
-     */
-    toggleAccessibleEnabled: function($elements, isAccessibleEnabled) {
-      this.toggleAccessible($elements, isAccessibleEnabled);
-      this.toggleEnabled($elements, isAccessibleEnabled);
+  /**
+   * Adds or removes `aria-hidden` and `disabled` attributes and `disabled`
+   * classes to elements.
+   *
+   * @param {Object|string|Array} $elements
+   * @param {boolean} [isHidden=true]
+   * @returns {Object} Returns `Adapt.a11y`
+   */
+  toggleAccessibleEnabled($elements, isAccessibleEnabled) {
+    this.toggleAccessible($elements, isAccessibleEnabled);
+    this.toggleEnabled($elements, isAccessibleEnabled);
+    return this;
+  }
+
+  /**
+   * Adds or removes `aria-hidden` attribute and disables `tabindex` on elements.
+   *
+   * @param {Object|string|Array} $elements
+   * @param {boolean} [isReadable=true]
+   * @returns {Object} Returns `Adapt.a11y`
+   */
+  toggleAccessible($elements, isReadable) {
+    $elements = $($elements);
+    var config = Adapt.a11y.config;
+    if (!config._isEnabled || !config._options._isAriaHiddenManagementEnabled || $elements.length === 0) {
       return this;
-    },
+    }
+    isReadable = isReadable === undefined ? true : isReadable;
+    if (!isReadable) {
+      $elements.attr({
+        tabindex: '-1',
+        'aria-hidden': 'true'
+      }).addClass('aria-hidden');
+    } else {
+      $elements.removeAttr('aria-hidden tabindex').removeClass('aria-hidden');
+      $elements.parents(config._options._ariaHiddenExcludes).removeAttr('aria-hidden').removeClass('aria-hidden');
+    }
+    return this;
+  }
 
-    /**
-     * Adds or removes `aria-hidden` attribute and disables `tabindex` on elements.
-     *
-     * @param {Object|string|Array} $elements
-     * @param {boolean} [isReadable=true]
-     * @returns {Object} Returns `Adapt.a11y`
-     */
-    toggleAccessible: function($elements, isReadable) {
-      $elements = $($elements);
-      var config = Adapt.a11y.config;
-      if (!config._isEnabled || !config._options._isAriaHiddenManagementEnabled || $elements.length === 0) {
-        return this;
-      }
-      isReadable = isReadable === undefined ? true : isReadable;
-      if (!isReadable) {
-        $elements.attr({
-          tabindex: '-1',
-          'aria-hidden': 'true'
-        }).addClass('aria-hidden');
-      } else {
-        $elements.removeAttr('aria-hidden tabindex').removeClass('aria-hidden');
-        $elements.parents(config._options._ariaHiddenExcludes).removeAttr('aria-hidden').removeClass('aria-hidden');
-      }
+  /**
+   * Adds or removes `disabled` attribute and `disabled` class.
+   *
+   * @param {Object|string|Array} $elements
+   * @param {boolean} [isEnabled=true]
+   * @returns {Object} Returns `Adapt.a11y`
+   */
+  toggleEnabled($elements, isEnabled) {
+    $elements = $($elements);
+    if ($elements.length === 0) {
       return this;
-    },
+    }
+    isEnabled = isEnabled === undefined ? true : isEnabled;
+    if (!isEnabled) {
+      $elements.attr({
+        tabindex: '-1',
+        'aria-disabled': 'true'
+      }).addClass('is-disabled');
+    } else {
+      $elements.removeAttr('aria-disabled tabindex').removeClass('is-disabled');
+    }
+    return this;
+  }
 
-    /**
-     * Adds or removes `disabled` attribute and `disabled` class.
-     *
-     * @param {Object|string|Array} $elements
-     * @param {boolean} [isEnabled=true]
-     * @returns {Object} Returns `Adapt.a11y`
-     */
-    toggleEnabled: function($elements, isEnabled) {
-      $elements = $($elements);
-      if ($elements.length === 0) {
-        return this;
-      }
-      isEnabled = isEnabled === undefined ? true : isEnabled;
-      if (!isEnabled) {
-        $elements.attr({
-          tabindex: '-1',
-          'aria-disabled': 'true'
-        }).addClass('is-disabled');
-      } else {
-        $elements.removeAttr('aria-disabled tabindex').removeClass('is-disabled');
-      }
-      return this;
-    },
+  /**
+   * Find the first tabbable element after the specified element.
+   *
+   * @param {Object|string|Array} $element
+   * @returns {Object}
+   */
+  findFirstTabbable($element) {
+    $element = $($element).first();
+    return this._findFirstForward($element, this.isTabbable);
+  }
 
-    /**
-     * Find the first tabbable element after the specified element.
-     *
-     * @param {Object|string|Array} $element
-     * @returns {Object}
-     */
-    findFirstTabbable: function($element) {
-      $element = $($element).first();
-      return this._findFirstForward($element, this.isTabbable);
-    },
+  /**
+   * Find the first readable element after the specified element.
+   *
+   * @param {Object|string|Array} $element
+   * @returns {Object}
+   */
+  findFirstReadable($element) {
+    $element = $($element).first();
+    return this._findFirstForward($element, this.isReadable);
+  }
 
-    /**
-     * Find the first readable element after the specified element.
-     *
-     * @param {Object|string|Array} $element
-     * @returns {Object}
-     */
-    findFirstReadable: function($element) {
-      $element = $($element).first();
-      return this._findFirstForward($element, this.isReadable);
-    },
+  /**
+   * Find all tabbable elements in the specified element.
+   *
+   * @param {Object|string|Array} $element
+   * @returns {Object}
+   */
+  findTabbable($element) {
+    var config = Adapt.a11y.config;
+    return $($element).find(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes);
+  }
 
-    /**
-     * Find all tabbable elements in the specified element.
-     *
-     * @param {Object|string|Array} $element
-     * @returns {Object}
-     */
-    findTabbable: function($element) {
-      var config = Adapt.a11y.config;
-      return $($element).find(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes);
-    },
+  /**
+   * Find all readable elements in the specified element.
+   *
+   * @param {Object|string|Array} $element
+   */
+  findReadable($element) {
+    return $($element).find('*').filter(function(index, element) {
+      return this.isReadable(element);
+    }.bind(this));
+  }
 
-    /**
-     * Find all readable elements in the specified element.
-     *
-     * @param {Object|string|Array} $element
-     */
-    findReadable: function($element) {
-      return $($element).find('*').filter(function(index, element) {
-        return this.isReadable(element);
-      }.bind(this));
-    },
+  /**
+   * Check if the element is natively or explicitly tabbable.
+   *
+   * @param {Object|string|Array} $element
+   * @returns {boolean|undefined}
+   */
+  isTabbable($element) {
+    var config = Adapt.a11y.config;
+    var value = $($element).is(config._options._tabbableElements).is(config._options._tabbableElementsExcludes);
+    if (!value) {
+      return undefined; // Allow _findForward to descend
+    }
+    return value;
+  }
 
-    /**
-     * Check if the element is natively or explicitly tabbable.
-     *
-     * @param {Object|string|Array} $element
-     * @returns {boolean|undefined}
-     */
-    isTabbable: function($element) {
-      var config = Adapt.a11y.config;
-      var value = $($element).is(config._options._tabbableElements).is(config._options._tabbableElementsExcludes);
-      if (!value) {
-        return undefined; // Allow _findForward to descend
-      }
-      return value;
-    },
+  /**
+   * Check if the first item is readable by a screen reader.
+   *
+   * @param {Object|string|Array} $element
+   * @param {boolean} [checkParents=true] Check if parents are inaccessible.
+   * @returns {boolean}
+   */
+  isReadable($element, checkParents) {
+    var config = Adapt.a11y.config;
+    $element = $($element).first();
+    checkParents = checkParents === undefined;
 
-    /**
-     * Check if the first item is readable by a screen reader.
-     *
-     * @param {Object|string|Array} $element
-     * @param {boolean} [checkParents=true] Check if parents are inaccessible.
-     * @returns {boolean}
-     */
-    isReadable: function($element, checkParents) {
-      var config = Adapt.a11y.config;
-      $element = $($element).first();
-      checkParents = checkParents === undefined;
+    var $branch = checkParents
+      ? $element.add($element.parents())
+      : $element;
 
-      var $branch = checkParents
-        ? $element.add($element.parents())
-        : $element;
-
-      var isNotVisible = _.find($branch.toArray(), function(item) {
-        var $item = $(item);
-        // make sure item is not explicitly invisible
-        var isNotVisible = $item.css('display') === 'none' ||
-          $item.css('visibility') === 'hidden' ||
-          $item.attr('aria-hidden') === 'true';
-        if (isNotVisible) {
-          return true;
-        }
-      });
+    var isNotVisible = _.find($branch.toArray(), function(item) {
+      var $item = $(item);
+      // make sure item is not explicitly invisible
+      var isNotVisible = $item.css('display') === 'none' ||
+        $item.css('visibility') === 'hidden' ||
+        $item.attr('aria-hidden') === 'true';
       if (isNotVisible) {
+        return true;
+      }
+    });
+    if (isNotVisible) {
+      return false;
+    }
+
+    // check that the component is natively tabbable or
+    // will be knowingly read by a screen reader
+    var hasNativeFocusOrIsScreenReadable = $element.is(config._options._focusableElements) ||
+      $element.is(config._options._readableElements);
+    if (hasNativeFocusOrIsScreenReadable) {
+      return true;
+    }
+    var childNodes = $element[0].childNodes;
+    for (var c = 0, cl = childNodes.length; c < cl; c++) {
+      var childNode = childNodes[c];
+      var isTextNode = (childNode.nodeType === 3);
+      if (!isTextNode) {
+        continue;
+      }
+      var isOnlyWhiteSpace = /^\s*$/.test(childNode.nodeValue);
+      if (isOnlyWhiteSpace) {
+        continue;
+      }
+      return true;
+    }
+    return undefined; // Allows _findForward to decend.
+  }
+
+  /**
+   * Find forward in the DOM, descending and ascending to move forward
+   * as appropriate.
+   *
+   * If the selector is a function it should returns true, false or undefined.
+   * Returning true matches the item and returns it. Returning false means do
+   * not match or descend into this item, returning undefined means do not match,
+   * but descend into this item.
+   *
+   * @param {Object|string|Array} $element
+   * @param {string|function|undefined} selector
+   * @returns {Object} Returns found descendant.
+   */
+  _findFirstForward($element, selector) {
+    $element = $($element).first();
+
+    // make sure iterator is correct, use boolean or selector comparison
+    // appropriately
+    var iterator;
+    switch (typeof selector) {
+      case 'string':
+        // make selector iterator
+        iterator = function($tag) {
+          return $tag.is(selector) || undefined;
+        };
+        break;
+      case 'function':
+        iterator = selector;
+        break;
+      case 'undefined':
+        // find first next element
+        iterator = Boolean;
+    }
+
+    if ($element.length === 0) {
+      return $element.not('*');
+    }
+
+    // check children by walking the tree
+    var $found = this._findFirstForwardDescendant($element, iterator);
+    if ($found && $found.length) {
+      return $found;
+    }
+
+    // check subsequent siblings
+    var $nextSiblings = $element.nextAll().toArray();
+    _.find($nextSiblings, function(sibling) {
+      var $sibling = $(sibling);
+      var value = iterator($sibling);
+
+      // skip this sibling if explicitly instructed
+      if (value === false) {
+        return;
+      }
+
+      if (value) {
+        // sibling matched
+        $found = $sibling;
+        return true;
+      }
+
+      // check parent sibling children by walking the tree
+      $found = this._findFirstForwardDescendant($sibling, iterator);
+      if ($found && $found.length) return true;
+    }.bind(this));
+    if ($found && $found.length) {
+      return $found;
+    }
+
+    // move through parents towards the body element
+    var $branch = $element.add($element.parents()).toArray().reverse();
+    _.find($branch, function(parent) {
+      var $parent = $(parent);
+      if (iterator($parent) === false) {
+        // skip this parent if explicitly instructed
         return false;
       }
 
-      // check that the component is natively tabbable or
-      // will be knowingly read by a screen reader
-      var hasNativeFocusOrIsScreenReadable = $element.is(config._options._focusableElements) ||
-        $element.is(config._options._readableElements);
-      if (hasNativeFocusOrIsScreenReadable) {
-        return true;
-      }
-      var childNodes = $element[0].childNodes;
-      for (var c = 0, cl = childNodes.length; c < cl; c++) {
-        var childNode = childNodes[c];
-        var isTextNode = (childNode.nodeType === 3);
-        if (!isTextNode) {
-          continue;
-        }
-        var isOnlyWhiteSpace = /^\s*$/.test(childNode.nodeValue);
-        if (isOnlyWhiteSpace) {
-          continue;
-        }
-        return true;
-      }
-      return undefined; // Allows _findForward to decend.
-    },
-
-    /**
-     * Find forward in the DOM, descending and ascending to move forward
-     * as appropriate.
-     *
-     * If the selector is a function it should returns true, false or undefined.
-     * Returning true matches the item and returns it. Returning false means do
-     * not match or descend into this item, returning undefined means do not match,
-     * but descend into this item.
-     *
-     * @param {Object|string|Array} $element
-     * @param {string|function|undefined} selector
-     * @returns {Object} Returns found descendant.
-     */
-    _findFirstForward: function($element, selector) {
-      $element = $($element).first();
-
-      // make sure iterator is correct, use boolean or selector comparison
-      // appropriately
-      var iterator;
-      switch (typeof selector) {
-        case 'string':
-          // make selector iterator
-          iterator = function($tag) {
-            return $tag.is(selector) || undefined;
-          };
-          break;
-        case 'function':
-          iterator = selector;
-          break;
-        case 'undefined':
-          // find first next element
-          iterator = Boolean;
-      }
-
-      if ($element.length === 0) {
-        return $element.not('*');
-      }
-
-      // check children by walking the tree
-      var $found = this._findFirstForwardDescendant($element, iterator);
-      if ($found && $found.length) {
-        return $found;
-      }
-
-      // check subsequent siblings
-      var $nextSiblings = $element.nextAll().toArray();
-      _.find($nextSiblings, function(sibling) {
+      // move through parents nextAll siblings
+      var $siblings = $parent.nextAll().toArray();
+      return _.find($siblings, function(sibling) {
         var $sibling = $(sibling);
         var value = iterator($sibling);
 
@@ -420,339 +451,303 @@ define([
 
         // check parent sibling children by walking the tree
         $found = this._findFirstForwardDescendant($sibling, iterator);
-        if ($found && $found.length) return true;
+        if ($found && $found.length) {
+          return true;
+        }
       }.bind(this));
-      if ($found && $found.length) {
-        return $found;
+    }.bind(this));
+
+    if (!$found || !$found.length) {
+      return $element.not('*');
+    }
+    return $found;
+  }
+
+  /**
+   * Find descendant in a DOM tree, work from selected to branch-end, through allowed
+   * branch structures in hierarchy order
+   *
+   * If the selector is a function it should returns true, false or undefined.
+   * Returning true matches the item and returns it. Returning false means do
+   * not match or descend into this item, returning undefined means do not match,
+   * but descend into this item.
+   *
+   * @param {Object|string|Array} $element jQuery element to start from.
+   * @param {string|function|undefined} selector
+   * @returns {Object} Returns found descendant.
+   */
+  _findFirstForwardDescendant($element, selector) {
+    $element = $($element).first();
+
+    // make sure iterator is correct, use boolean or selector comparison
+    // appropriately
+    var iterator;
+    switch (typeof selector) {
+      case 'string':
+        // make selector iterator
+        iterator = function($tag) {
+          return $tag.is(selector) || undefined;
+        };
+        break;
+      case 'function':
+        iterator = selector;
+        break;
+      case 'undefined':
+        // find first next element
+        iterator = Boolean;
+    }
+
+    var $notFound = $element.not('*');
+    if ($element.length === 0) {
+      return $notFound;
+    }
+
+    // keep walked+passed children in a stack
+    var stack = [{
+      item: $element[0],
+      value: undefined
+    }];
+    var stackIndexPosition = 0;
+    var childIndexPosition = stackIndexPosition + 1;
+    do {
+
+      var stackEntry = stack[stackIndexPosition];
+      var $stackItem = $(stackEntry.item);
+
+      // check current item
+      switch (stackEntry.value) {
+        case true:
+          return $stackItem;
+        case false:
+          return $notFound;
       }
 
-      // move through parents towards the body element
-      var $branch = $element.add($element.parents()).toArray().reverse();
-      _.find($branch, function(parent) {
-        var $parent = $(parent);
-        if (iterator($parent) === false) {
-          // skip this parent if explicitly instructed
+      // get i stack children
+      var $children = $stackItem.children().toArray();
+      _.find($children, function(item) {
+        var $item = $(item);
+        var value = iterator($item);
+
+        // item explicitly not allowed, don't add to stack,
+        // skip children
+        if (value === false) {
           return false;
         }
 
-        // move through parents nextAll siblings
-        var $siblings = $parent.nextAll().toArray();
-        return _.find($siblings, function(sibling) {
-          var $sibling = $(sibling);
-          var value = iterator($sibling);
-
-          // skip this sibling if explicitly instructed
-          if (value === false) {
-            return;
-          }
-
-          if (value) {
-            // sibling matched
-            $found = $sibling;
-            return true;
-          }
-
-          // check parent sibling children by walking the tree
-          $found = this._findFirstForwardDescendant($sibling, iterator);
-          if ($found && $found.length) {
-            return true;
-          }
-        }.bind(this));
-      }.bind(this));
-
-      if (!$found || !$found.length) {
-        return $element.not('*');
-      }
-      return $found;
-    },
-
-    /**
-     * Find descendant in a DOM tree, work from selected to branch-end, through allowed
-     * branch structures in hierarchy order
-     *
-     * If the selector is a function it should returns true, false or undefined.
-     * Returning true matches the item and returns it. Returning false means do
-     * not match or descend into this item, returning undefined means do not match,
-     * but descend into this item.
-     *
-     * @param {Object|string|Array} $element jQuery element to start from.
-     * @param {string|function|undefined} selector
-     * @returns {Object} Returns found descendant.
-     */
-    _findFirstForwardDescendant: function($element, selector) {
-      $element = $($element).first();
-
-      // make sure iterator is correct, use boolean or selector comparison
-      // appropriately
-      var iterator;
-      switch (typeof selector) {
-        case 'string':
-          // make selector iterator
-          iterator = function($tag) {
-            return $tag.is(selector) || undefined;
-          };
-          break;
-        case 'function':
-          iterator = selector;
-          break;
-        case 'undefined':
-          // find first next element
-          iterator = Boolean;
-      }
-
-      var $notFound = $element.not('*');
-      if ($element.length === 0) {
-        return $notFound;
-      }
-
-      // keep walked+passed children in a stack
-      var stack = [{
-        item: $element[0],
-        value: undefined
-      }];
-      var stackIndexPosition = 0;
-      var childIndexPosition = stackIndexPosition + 1;
-      do {
-
-        var stackEntry = stack[stackIndexPosition];
-        var $stackItem = $(stackEntry.item);
-
-        // check current item
-        switch (stackEntry.value) {
-          case true:
-            return $stackItem;
-          case false:
-            return $notFound;
-        }
-
-        // get i stack children
-        var $children = $stackItem.children().toArray();
-        _.find($children, function(item) {
-          var $item = $(item);
-          var value = iterator($item);
-
-          // item explicitly not allowed, don't add to stack,
-          // skip children
-          if (value === false) {
-            return false;
-          }
-
-          // item passed or readable, add to stack before any parent
-          // siblings
-          stack.splice(childIndexPosition++, 0, {
-            item: item,
-            value: value
-          });
+        // item passed or readable, add to stack before any parent
+        // siblings
+        stack.splice(childIndexPosition++, 0, {
+          item: item,
+          value: value
         });
+      });
 
-        // move to next stack item
-        stackIndexPosition++;
-        // keep place to inject children
-        childIndexPosition = stackIndexPosition + 1;
-      } while (stackIndexPosition < stack.length);
+      // move to next stack item
+      stackIndexPosition++;
+      // keep place to inject children
+      childIndexPosition = stackIndexPosition + 1;
+    } while (stackIndexPosition < stack.length);
 
-      return $notFound;
-    },
+    return $notFound;
+  }
 
-    /**
-     * Assign focus to the next readable element.
-     *
-     * @param {Object|string|Array} $element
-     * @param {FocusOptions} options
-     * @returns {Object} Returns `Adapt.a11y`
-     */
-    focusNext: function($element, options) {
-      options = new FocusOptions(options);
-      $element = $($element).first();
-      $element = Adapt.a11y.findFirstReadable($element);
-      this.focus($element, options);
-      return this;
-    },
+  /**
+   * Assign focus to the next readable element.
+   *
+   * @param {Object|string|Array} $element
+   * @param {FocusOptions} options
+   * @returns {Object} Returns `Adapt.a11y`
+   */
+  focusNext($element, options) {
+    options = new FocusOptions(options);
+    $element = $($element).first();
+    $element = Adapt.a11y.findFirstReadable($element);
+    this.focus($element, options);
+    return this;
+  }
 
-    /**
-     * Assign focus to either the specified element if it is readable or the
-     * next readable element.
-     *
-     * @param {Object|string|Array} $element
-     * @param {FocusOptions} options
-     * @returns {Object} Returns `Adapt.a11y`
-     */
-    focusFirst: function($element, options) {
-      options = new FocusOptions(options);
-      $element = $($element).first();
-      if (Adapt.a11y.isReadable($element)) {
-        this.focus($element, options);
-        return $element;
-      }
-      $element = Adapt.a11y.findFirstReadable($element);
+  /**
+   * Assign focus to either the specified element if it is readable or the
+   * next readable element.
+   *
+   * @param {Object|string|Array} $element
+   * @param {FocusOptions} options
+   * @returns {Object} Returns `Adapt.a11y`
+   */
+  focusFirst($element, options) {
+    options = new FocusOptions(options);
+    $element = $($element).first();
+    if (Adapt.a11y.isReadable($element)) {
       this.focus($element, options);
       return $element;
-    },
-
-    /**
-     * Force focus to the specified element with/without a defer or scroll.
-     *
-     * @param {Object|string|Array} $element
-     * @param {FocusOptions} options
-     * @returns {Object} Returns `Adapt.a11y`
-     */
-    focus: function($element, options) {
-      options = new FocusOptions(options);
-      $element = $($element).first();
-      var config = Adapt.a11y.config;
-      if (!config._isEnabled || !config._options._isFocusAssignmentEnabled || $element.length === 0) {
-        return this;
-      }
-      function perform() {
-        if (options.preventScroll) {
-          var y = $(window).scrollTop();
-          try {
-            if ($element.attr('tabindex') === undefined) {
-              $element.attr({
-                'tabindex': '-1',
-                'data-a11y-force-focus': 'true'
-              });
-            }
-            $element[0].focus({
-              preventScroll: true
-            });
-          } catch (e) {
-            // Drop focus errors as only happens when the element
-            // isn't attached to the DOM.
-          }
-          switch (Adapt.device.browser) {
-            case 'internet explorer':
-            case 'microsoft edge':
-            case 'safari':
-              // return to previous scroll position due to no support for preventScroll
-              window.scrollTo(null, y);
-          }
-        } else {
-          $element[0].focus();
-        }
-      }
-      if (options.defer) {
-        _.defer(function() {
-          perform();
-        });
-      } else {
-        perform();
-      }
-      return this;
-    },
-
-    /**
-     * Used to convert html to text aria-labels.
-     *
-     * @param {string} htmls Any html strings.
-     * @returns {string} Returns text without markup or html encoded characters.
-     */
-    normalize: function(htmls) {
-      var values = Array.prototype.slice.call(arguments, 0);
-      values = values.filter(Boolean);
-      values = values.filter(_.isString);
-      htmls = values.join(' ');
-      var text = $('<div>' + htmls + '</div>').text();
-      // Remove all html encoded characters, such as &apos;
-      return text.replace(this._htmlCharRegex, '');
-    },
-
-    /**
-     * Removes all html tags except stylistic elements.
-     * Useful for producing uninterrupted text for screen readers from
-     * any html.
-     *
-     * @param  {string} htmls Any html strings.
-     * @return {string} Returns html string without markup which would cause screen reader to pause.
-     */
-    removeBreaks: function(htmls) {
-      var values = Array.prototype.slice.call(arguments, 0);
-      values = values.filter(Boolean);
-      values = values.filter(_.isString);
-      htmls = values.join(' ');
-      var $div = $('<div>' + htmls + '</div>');
-      var stack = [ $div[0] ];
-      var stackIndex = 0;
-      var outputs = [];
-      do {
-        if (stack[stackIndex].childNodes.length) {
-          var nodes = stack[stackIndex].childNodes;
-          var usable = _.filter(nodes, function(node) {
-            var isTextNode = (node.nodeType === 3);
-            if (isTextNode) {
-              return true;
-            }
-            var isStyleElement = $(node).is(Adapt.a11y.config._options._wrapStyleElements);
-            if (isStyleElement) {
-              return true;
-            }
-            return false;
-          });
-          outputs.push.apply(outputs, usable);
-          stack.push.apply(stack, nodes);
-        }
-        stackIndex++;
-      } while (stackIndex < stack.length);
-      var rtnText = '';
-      outputs.forEach(function(item) {
-        rtnText += item.outerHTML || item.textContent;
-      });
-      return rtnText;
-    },
-
-    /**
-     * @param {Object|string|Array} $elements
-     * @returns {Object} Returns `Adapt.a11y`
-     */
-    scrollEnable: function($elements) {
-      this._scroll.enable($elements);
-      return this;
-    },
-
-    /**
-     * @param {Object|string|Array} $elements
-     * @returns {Object} Returns `Adapt.a11y`
-     */
-    scrollDisable: function($elements) {
-      this._scroll.disable($elements);
-      return this;
-    },
-
-    /**
-     * To apply accessibilty handling to a tag, isolating the user.
-     *
-     * @param {Object} $popupElement Element encapsulating the popup.
-     * @returns {Object} Returns `Adapt.a11y`
-     */
-    popupOpened: function($popupElement) {
-      this._popup.opened($popupElement);
-      return this;
-    },
-
-    /**
-     * Remove the isolation applied with a call to `popupOpened`.
-     *
-     * @param {Object} [$focusElement] Element to move focus to.
-     * @returns {Object} Returns `Adapt.a11y`
-     */
-    popupClosed: function($focusElement) {
-      this._popup.closed($focusElement);
-      return this;
-    },
-
-    /**
-     * When a popup is open, this function makes it possible to swap the element
-     * that should receive focus on popup close.
-     *
-     * @param {Object} $focusElement Set a new element to focus on.
-     * @returns {Object} Returns previously set focus element.
-     */
-    setPopupCloseTo: function($focusElement) {
-      return this._popup.setCloseTo($focusElement);
     }
+    $element = Adapt.a11y.findFirstReadable($element);
+    this.focus($element, options);
+    return $element;
+  }
 
-  });
+  /**
+   * Force focus to the specified element with/without a defer or scroll.
+   *
+   * @param {Object|string|Array} $element
+   * @param {FocusOptions} options
+   * @returns {Object} Returns `Adapt.a11y`
+   */
+  focus($element, options) {
+    options = new FocusOptions(options);
+    $element = $($element).first();
+    var config = Adapt.a11y.config;
+    if (!config._isEnabled || !config._options._isFocusAssignmentEnabled || $element.length === 0) {
+      return this;
+    }
+    function perform() {
+      if (options.preventScroll) {
+        var y = $(window).scrollTop();
+        try {
+          if ($element.attr('tabindex') === undefined) {
+            $element.attr({
+              'tabindex': '-1',
+              'data-a11y-force-focus': 'true'
+            });
+          }
+          $element[0].focus({
+            preventScroll: true
+          });
+        } catch (e) {
+          // Drop focus errors as only happens when the element
+          // isn't attached to the DOM.
+        }
+        switch (Adapt.device.browser) {
+          case 'internet explorer':
+          case 'microsoft edge':
+          case 'safari':
+            // return to previous scroll position due to no support for preventScroll
+            window.scrollTo(null, y);
+        }
+      } else {
+        $element[0].focus();
+      }
+    }
+    if (options.defer) {
+      _.defer(function() {
+        perform();
+      });
+    } else {
+      perform();
+    }
+    return this;
+  }
 
-  return (Adapt.a11y = new A11y());
+  /**
+   * Used to convert html to text aria-labels.
+   *
+   * @param {string} htmls Any html strings.
+   * @returns {string} Returns text without markup or html encoded characters.
+   */
+  normalize(htmls) {
+    var values = Array.prototype.slice.call(arguments, 0);
+    values = values.filter(Boolean);
+    values = values.filter(_.isString);
+    htmls = values.join(' ');
+    var text = $('<div>' + htmls + '</div>').text();
+    // Remove all html encoded characters, such as &apos;
+    return text.replace(this._htmlCharRegex, '');
+  }
 
-});
+  /**
+   * Removes all html tags except stylistic elements.
+   * Useful for producing uninterrupted text for screen readers from
+   * any html.
+   *
+   * @param  {string} htmls Any html strings.
+   * @return {string} Returns html string without markup which would cause screen reader to pause.
+   */
+  removeBreaks(htmls) {
+    var values = Array.prototype.slice.call(arguments, 0);
+    values = values.filter(Boolean);
+    values = values.filter(_.isString);
+    htmls = values.join(' ');
+    var $div = $('<div>' + htmls + '</div>');
+    var stack = [ $div[0] ];
+    var stackIndex = 0;
+    var outputs = [];
+    do {
+      if (stack[stackIndex].childNodes.length) {
+        var nodes = stack[stackIndex].childNodes;
+        var usable = _.filter(nodes, function(node) {
+          var isTextNode = (node.nodeType === 3);
+          if (isTextNode) {
+            return true;
+          }
+          var isStyleElement = $(node).is(Adapt.a11y.config._options._wrapStyleElements);
+          if (isStyleElement) {
+            return true;
+          }
+          return false;
+        });
+        outputs.push.apply(outputs, usable);
+        stack.push.apply(stack, nodes);
+      }
+      stackIndex++;
+    } while (stackIndex < stack.length);
+    var rtnText = '';
+    outputs.forEach(function(item) {
+      rtnText += item.outerHTML || item.textContent;
+    });
+    return rtnText;
+  }
+
+  /**
+   * @param {Object|string|Array} $elements
+   * @returns {Object} Returns `Adapt.a11y`
+   */
+  scrollEnable($elements) {
+    this._scroll.enable($elements);
+    return this;
+  }
+
+  /**
+   * @param {Object|string|Array} $elements
+   * @returns {Object} Returns `Adapt.a11y`
+   */
+  scrollDisable($elements) {
+    this._scroll.disable($elements);
+    return this;
+  }
+
+  /**
+   * To apply accessibilty handling to a tag, isolating the user.
+   *
+   * @param {Object} $popupElement Element encapsulating the popup.
+   * @returns {Object} Returns `Adapt.a11y`
+   */
+  popupOpened($popupElement) {
+    this._popup.opened($popupElement);
+    return this;
+  }
+
+  /**
+   * Remove the isolation applied with a call to `popupOpened`.
+   *
+   * @param {Object} [$focusElement] Element to move focus to.
+   * @returns {Object} Returns `Adapt.a11y`
+   */
+  popupClosed($focusElement) {
+    this._popup.closed($focusElement);
+    return this;
+  }
+
+  /**
+   * When a popup is open, this function makes it possible to swap the element
+   * that should receive focus on popup close.
+   *
+   * @param {Object} $focusElement Set a new element to focus on.
+   * @returns {Object} Returns previously set focus element.
+   */
+  setPopupCloseTo($focusElement) {
+    return this._popup.setCloseTo($focusElement);
+  }
+
+}
+
+export default (Adapt.a11y = new A11y());

--- a/src/core/js/a11y.js
+++ b/src/core/js/a11y.js
@@ -58,6 +58,8 @@ class A11y extends Backbone.Controller {
   }
 
   initialize() {
+    this.isReadable = this.isReadable.bind(this);
+    this.isTabbable = this.isTabbable.bind(this);
     this.$html = $('html');
     this._htmlCharRegex = /&.*;/g;
     /** @type {Object} */

--- a/src/core/js/a11y.js
+++ b/src/core/js/a11y.js
@@ -99,9 +99,9 @@ class A11y extends Backbone.Controller {
     if (!this.config || !this.config._disableTextSelectOnClasses) {
       return;
     }
-    var classes = this.config._disableTextSelectOnClasses.split(' ');
-    var isMatch = false;
-    for (var i = 0, item; (item = classes[i++]);) {
+    const classes = this.config._disableTextSelectOnClasses.split(' ');
+    let isMatch = false;
+    for (let i = 0, item; (item = classes[i++]);) {
       if (this.$html.is(item)) {
         isMatch = true;
         break;
@@ -118,8 +118,8 @@ class A11y extends Backbone.Controller {
   }
 
   _removeLegacyElements() {
-    var $legacyElements = $('body').children('#accessibility-toggle, #accessibility-instructions');
-    var $navigationElements = $('.nav').find('#accessibility-toggle, #accessibility-instructions');
+    const $legacyElements = $('body').children('#accessibility-toggle, #accessibility-instructions');
+    const $navigationElements = $('.nav').find('#accessibility-toggle, #accessibility-instructions');
     if (!$legacyElements.length && !$navigationElements.length) {
       return;
     }
@@ -165,7 +165,7 @@ class A11y extends Backbone.Controller {
    */
   toggleHidden($elements, isHidden) {
     $elements = $($elements);
-    var config = Adapt.a11y.config;
+    const config = Adapt.a11y.config;
     if (!config._isEnabled || !config._options._isAriaHiddenManagementEnabled) {
       return this;
     }
@@ -201,7 +201,7 @@ class A11y extends Backbone.Controller {
    */
   toggleAccessible($elements, isReadable) {
     $elements = $($elements);
-    var config = Adapt.a11y.config;
+    const config = Adapt.a11y.config;
     if (!config._isEnabled || !config._options._isAriaHiddenManagementEnabled || $elements.length === 0) {
       return this;
     }
@@ -271,7 +271,7 @@ class A11y extends Backbone.Controller {
    * @returns {Object}
    */
   findTabbable($element) {
-    var config = Adapt.a11y.config;
+    const config = Adapt.a11y.config;
     return $($element).find(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes);
   }
 
@@ -293,8 +293,8 @@ class A11y extends Backbone.Controller {
    * @returns {boolean|undefined}
    */
   isTabbable($element) {
-    var config = Adapt.a11y.config;
-    var value = $($element).is(config._options._tabbableElements).is(config._options._tabbableElementsExcludes);
+    const config = Adapt.a11y.config;
+    const value = $($element).is(config._options._tabbableElements).is(config._options._tabbableElementsExcludes);
     if (!value) {
       return undefined; // Allow _findForward to descend
     }
@@ -309,18 +309,18 @@ class A11y extends Backbone.Controller {
    * @returns {boolean}
    */
   isReadable($element, checkParents) {
-    var config = Adapt.a11y.config;
+    const config = Adapt.a11y.config;
     $element = $($element).first();
     checkParents = checkParents === undefined;
 
-    var $branch = checkParents
+    const $branch = checkParents
       ? $element.add($element.parents())
       : $element;
 
-    var isNotVisible = _.find($branch.toArray(), function(item) {
-      var $item = $(item);
+    const isNotVisible = _.find($branch.toArray(), function(item) {
+      const $item = $(item);
       // make sure item is not explicitly invisible
-      var isNotVisible = $item.css('display') === 'none' ||
+      const isNotVisible = $item.css('display') === 'none' ||
         $item.css('visibility') === 'hidden' ||
         $item.attr('aria-hidden') === 'true';
       if (isNotVisible) {
@@ -333,19 +333,19 @@ class A11y extends Backbone.Controller {
 
     // check that the component is natively tabbable or
     // will be knowingly read by a screen reader
-    var hasNativeFocusOrIsScreenReadable = $element.is(config._options._focusableElements) ||
+    const hasNativeFocusOrIsScreenReadable = $element.is(config._options._focusableElements) ||
       $element.is(config._options._readableElements);
     if (hasNativeFocusOrIsScreenReadable) {
       return true;
     }
-    var childNodes = $element[0].childNodes;
-    for (var c = 0, cl = childNodes.length; c < cl; c++) {
-      var childNode = childNodes[c];
-      var isTextNode = (childNode.nodeType === 3);
+    const childNodes = $element[0].childNodes;
+    for (let c = 0, cl = childNodes.length; c < cl; c++) {
+      const childNode = childNodes[c];
+      const isTextNode = (childNode.nodeType === 3);
       if (!isTextNode) {
         continue;
       }
-      var isOnlyWhiteSpace = /^\s*$/.test(childNode.nodeValue);
+      const isOnlyWhiteSpace = /^\s*$/.test(childNode.nodeValue);
       if (isOnlyWhiteSpace) {
         continue;
       }
@@ -372,7 +372,7 @@ class A11y extends Backbone.Controller {
 
     // make sure iterator is correct, use boolean or selector comparison
     // appropriately
-    var iterator;
+    let iterator;
     switch (typeof selector) {
       case 'string':
         // make selector iterator
@@ -393,16 +393,16 @@ class A11y extends Backbone.Controller {
     }
 
     // check children by walking the tree
-    var $found = this._findFirstForwardDescendant($element, iterator);
+    let $found = this._findFirstForwardDescendant($element, iterator);
     if ($found && $found.length) {
       return $found;
     }
 
     // check subsequent siblings
-    var $nextSiblings = $element.nextAll().toArray();
+    const $nextSiblings = $element.nextAll().toArray();
     _.find($nextSiblings, function(sibling) {
-      var $sibling = $(sibling);
-      var value = iterator($sibling);
+      const $sibling = $(sibling);
+      const value = iterator($sibling);
 
       // skip this sibling if explicitly instructed
       if (value === false) {
@@ -424,19 +424,19 @@ class A11y extends Backbone.Controller {
     }
 
     // move through parents towards the body element
-    var $branch = $element.add($element.parents()).toArray().reverse();
+    const $branch = $element.add($element.parents()).toArray().reverse();
     _.find($branch, function(parent) {
-      var $parent = $(parent);
+      const $parent = $(parent);
       if (iterator($parent) === false) {
         // skip this parent if explicitly instructed
         return false;
       }
 
       // move through parents nextAll siblings
-      var $siblings = $parent.nextAll().toArray();
+      const $siblings = $parent.nextAll().toArray();
       return _.find($siblings, function(sibling) {
-        var $sibling = $(sibling);
-        var value = iterator($sibling);
+        const $sibling = $(sibling);
+        const value = iterator($sibling);
 
         // skip this sibling if explicitly instructed
         if (value === false) {
@@ -481,7 +481,7 @@ class A11y extends Backbone.Controller {
 
     // make sure iterator is correct, use boolean or selector comparison
     // appropriately
-    var iterator;
+    let iterator;
     switch (typeof selector) {
       case 'string':
         // make selector iterator
@@ -497,22 +497,22 @@ class A11y extends Backbone.Controller {
         iterator = Boolean;
     }
 
-    var $notFound = $element.not('*');
+    const $notFound = $element.not('*');
     if ($element.length === 0) {
       return $notFound;
     }
 
     // keep walked+passed children in a stack
-    var stack = [{
+    const stack = [{
       item: $element[0],
       value: undefined
     }];
-    var stackIndexPosition = 0;
-    var childIndexPosition = stackIndexPosition + 1;
+    let stackIndexPosition = 0;
+    let childIndexPosition = stackIndexPosition + 1;
     do {
 
-      var stackEntry = stack[stackIndexPosition];
-      var $stackItem = $(stackEntry.item);
+      const stackEntry = stack[stackIndexPosition];
+      const $stackItem = $(stackEntry.item);
 
       // check current item
       switch (stackEntry.value) {
@@ -523,10 +523,10 @@ class A11y extends Backbone.Controller {
       }
 
       // get i stack children
-      var $children = $stackItem.children().toArray();
+      const $children = $stackItem.children().toArray();
       _.find($children, function(item) {
-        var $item = $(item);
-        var value = iterator($item);
+        const $item = $(item);
+        const value = iterator($item);
 
         // item explicitly not allowed, don't add to stack,
         // skip children
@@ -596,13 +596,13 @@ class A11y extends Backbone.Controller {
   focus($element, options) {
     options = new FocusOptions(options);
     $element = $($element).first();
-    var config = Adapt.a11y.config;
+    const config = Adapt.a11y.config;
     if (!config._isEnabled || !config._options._isFocusAssignmentEnabled || $element.length === 0) {
       return this;
     }
     function perform() {
       if (options.preventScroll) {
-        var y = $(window).scrollTop();
+        const y = $(window).scrollTop();
         try {
           if ($element.attr('tabindex') === undefined) {
             $element.attr({
@@ -645,11 +645,11 @@ class A11y extends Backbone.Controller {
    * @returns {string} Returns text without markup or html encoded characters.
    */
   normalize(htmls) {
-    var values = Array.prototype.slice.call(arguments, 0);
+    let values = Array.prototype.slice.call(arguments, 0);
     values = values.filter(Boolean);
     values = values.filter(_.isString);
     htmls = values.join(' ');
-    var text = $('<div>' + htmls + '</div>').text();
+    const text = $('<div>' + htmls + '</div>').text();
     // Remove all html encoded characters, such as &apos;
     return text.replace(this._htmlCharRegex, '');
   }
@@ -663,23 +663,23 @@ class A11y extends Backbone.Controller {
    * @return {string} Returns html string without markup which would cause screen reader to pause.
    */
   removeBreaks(htmls) {
-    var values = Array.prototype.slice.call(arguments, 0);
+    let values = Array.prototype.slice.call(arguments, 0);
     values = values.filter(Boolean);
     values = values.filter(_.isString);
     htmls = values.join(' ');
-    var $div = $('<div>' + htmls + '</div>');
-    var stack = [ $div[0] ];
-    var stackIndex = 0;
-    var outputs = [];
+    const $div = $('<div>' + htmls + '</div>');
+    const stack = [ $div[0] ];
+    let stackIndex = 0;
+    const outputs = [];
     do {
       if (stack[stackIndex].childNodes.length) {
-        var nodes = stack[stackIndex].childNodes;
-        var usable = _.filter(nodes, function(node) {
-          var isTextNode = (node.nodeType === 3);
+        const nodes = stack[stackIndex].childNodes;
+        const usable = _.filter(nodes, function(node) {
+          const isTextNode = (node.nodeType === 3);
           if (isTextNode) {
             return true;
           }
-          var isStyleElement = $(node).is(Adapt.a11y.config._options._wrapStyleElements);
+          const isStyleElement = $(node).is(Adapt.a11y.config._options._wrapStyleElements);
           if (isStyleElement) {
             return true;
           }
@@ -690,7 +690,7 @@ class A11y extends Backbone.Controller {
       }
       stackIndex++;
     } while (stackIndex < stack.length);
-    var rtnText = '';
+    let rtnText = '';
     outputs.forEach(function(item) {
       rtnText += item.outerHTML || item.textContent;
     });

--- a/src/core/js/a11y/browserFocus.js
+++ b/src/core/js/a11y/browserFocus.js
@@ -31,11 +31,11 @@ export default class BrowserFocus extends Backbone.Controller {
    * @param {JQuery.Event} event
    */
   _onBlur(event) {
-    var config = Adapt.a11y.config;
+    const config = Adapt.a11y.config;
     if (!config._isEnabled || !config._options._isFocusNextOnDisabled) {
       return;
     }
-    var $element = $(event.target);
+    const $element = $(event.target);
     if ($element.is('[data-a11y-force-focus]')) {
       _.defer(function() {
         $element.removeAttr('tabindex data-a11y-force-focus');
@@ -62,14 +62,14 @@ export default class BrowserFocus extends Backbone.Controller {
    * @param {JQuery.Event} event
    */
   _onClick(event) {
-    var config = Adapt.a11y.config;
+    const config = Adapt.a11y.config;
     if (!config._isEnabled) {
       return;
     }
-    var $element = $(event.target);
+    const $element = $(event.target);
     if (config._options._isFocusOnClickEnabled) {
-      var $stack = $().add($element).add($element.parents());
-      var $focusable = $stack.filter(config._options._tabbableElements);
+      const $stack = $().add($element).add($element.parents());
+      const $focusable = $stack.filter(config._options._tabbableElements);
       if (!$focusable.length) {
         return;
       }

--- a/src/core/js/a11y/browserFocus.js
+++ b/src/core/js/a11y/browserFocus.js
@@ -7,7 +7,8 @@ import Adapt from 'core/js/adapt';
 export default class BrowserFocus extends Backbone.Controller {
 
   initialize() {
-    _.bindAll(this, '_onBlur', '_onClick');
+    this._onBlur = this._onBlur.bind(this);
+    this._onClick = this._onClick.bind(this);
     this.$body = $('body');
     this.listenTo(Adapt, {
       'accessibility:ready': this._attachEventListeners
@@ -37,9 +38,7 @@ export default class BrowserFocus extends Backbone.Controller {
     }
     const $element = $(event.target);
     if ($element.is('[data-a11y-force-focus]')) {
-      _.defer(function() {
-        $element.removeAttr('tabindex data-a11y-force-focus');
-      });
+      _.defer(() => $element.removeAttr('tabindex data-a11y-force-focus'));
     }
     // From here, only check source elements
     if (event.target !== event.currentTarget) {

--- a/src/core/js/a11y/browserFocus.js
+++ b/src/core/js/a11y/browserFocus.js
@@ -1,91 +1,85 @@
-define([
-  'core/js/adapt'
-], function(Adapt) {
+import Adapt from 'core/js/adapt';
+
+/**
+ * Browser modifications to focus handling.
+ * @class
+ */
+export default class BrowserFocus extends Backbone.Controller {
+
+  initialize() {
+    _.bindAll(this, '_onBlur', '_onClick');
+    this.$body = $('body');
+    this.listenTo(Adapt, {
+      'accessibility:ready': this._attachEventListeners
+    });
+  }
+
+  _attachEventListeners() {
+    this.$body
+      .on('blur', '*', this._onBlur)
+      .on('blur', this._onBlur);
+    // 'Capture' event attachment for click
+    this.$body[0].addEventListener('click', this._onClick, true);
+  }
 
   /**
-   * Browser modifications to focus handling.
-   * @class
+   * When any element in the document receives a blur event,
+   * check to see if it needs the `data-a11y-force-focus` attribute removing
+   * and check to see if it was blurred because a disabled attribute was added.
+   * If a disabled attribute was added, the focus will be moved forward.
+   *
+   * @param {JQuery.Event} event
    */
-  var BrowserFocus = Backbone.Controller.extend({
-
-    initialize: function() {
-      _.bindAll(this, '_onBlur', '_onClick');
-      this.$body = $('body');
-      this.listenTo(Adapt, {
-        'accessibility:ready': this._attachEventListeners
-      });
-    },
-
-    _attachEventListeners: function() {
-      this.$body
-        .on('blur', '*', this._onBlur)
-        .on('blur', this._onBlur);
-      // 'Capture' event attachment for click
-      this.$body[0].addEventListener('click', this._onClick, true);
-    },
-
-    /**
-     * When any element in the document receives a blur event,
-     * check to see if it needs the `data-a11y-force-focus` attribute removing
-     * and check to see if it was blurred because a disabled attribute was added.
-     * If a disabled attribute was added, the focus will be moved forward.
-     *
-     * @param {JQuery.Event} event
-     */
-    _onBlur: function(event) {
-      var config = Adapt.a11y.config;
-      if (!config._isEnabled || !config._options._isFocusNextOnDisabled) {
-        return;
-      }
-      var $element = $(event.target);
-      if ($element.is('[data-a11y-force-focus]')) {
-        _.defer(function() {
-          $element.removeAttr('tabindex data-a11y-force-focus');
-        });
-      }
-      // From here, only check source elements
-      if (event.target !== event.currentTarget) {
-        return;
-      }
-      // Check if element losing focus is losing focus
-      // due to the addition of a disabled class
-      if (!$element.is('[disabled]')) {
-        return;
-      }
-      // Move focus to next readable element
-      Adapt.a11y.focusNext($element);
-    },
-
-    /**
-     * Force focus when clicked on a tabbable element,
-     * making sure `document.activeElement` is updated.
-     * Stop event handling on aria-disabled elements.
-     *
-     * @param {JQuery.Event} event
-     */
-    _onClick: function(event) {
-      var config = Adapt.a11y.config;
-      if (!config._isEnabled) {
-        return;
-      }
-      var $element = $(event.target);
-      if (config._options._isFocusOnClickEnabled) {
-        var $stack = $().add($element).add($element.parents());
-        var $focusable = $stack.filter(config._options._tabbableElements);
-        if (!$focusable.length) {
-          return;
-        }
-        // Force focus for screen reader enter / space press
-        $focusable[0].focus();
-      }
-      if ($element.is('[aria-disabled=true]')) {
-        event.preventDefault();
-        event.stopImmediatePropagation();
-      }
+  _onBlur(event) {
+    var config = Adapt.a11y.config;
+    if (!config._isEnabled || !config._options._isFocusNextOnDisabled) {
+      return;
     }
+    var $element = $(event.target);
+    if ($element.is('[data-a11y-force-focus]')) {
+      _.defer(function() {
+        $element.removeAttr('tabindex data-a11y-force-focus');
+      });
+    }
+    // From here, only check source elements
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+    // Check if element losing focus is losing focus
+    // due to the addition of a disabled class
+    if (!$element.is('[disabled]')) {
+      return;
+    }
+    // Move focus to next readable element
+    Adapt.a11y.focusNext($element);
+  }
 
-  });
+  /**
+   * Force focus when clicked on a tabbable element,
+   * making sure `document.activeElement` is updated.
+   * Stop event handling on aria-disabled elements.
+   *
+   * @param {JQuery.Event} event
+   */
+  _onClick(event) {
+    var config = Adapt.a11y.config;
+    if (!config._isEnabled) {
+      return;
+    }
+    var $element = $(event.target);
+    if (config._options._isFocusOnClickEnabled) {
+      var $stack = $().add($element).add($element.parents());
+      var $focusable = $stack.filter(config._options._tabbableElements);
+      if (!$focusable.length) {
+        return;
+      }
+      // Force focus for screen reader enter / space press
+      $focusable[0].focus();
+    }
+    if ($element.is('[aria-disabled=true]')) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  }
 
-  return BrowserFocus;
-
-});
+}

--- a/src/core/js/a11y/browserFocus.js
+++ b/src/core/js/a11y/browserFocus.js
@@ -60,7 +60,7 @@ export default class BrowserFocus extends Backbone.Controller {
    *
    * @param {JQuery.Event} event
    */
-  _onClick: function(event) {
+  _onClick(event) {
     const $element = $(event.target);
     if ($element.is('[aria-disabled=true]')) {
       event.preventDefault();

--- a/src/core/js/a11y/deprecated.js
+++ b/src/core/js/a11y/deprecated.js
@@ -4,46 +4,46 @@ import Adapt from 'core/js/adapt';
  * The old API is rerouted to the new API with warnings.
  */
 
-_.extend($.fn, {
+Object.assign($.fn, {
 
-  isFixedPostion: function() {
+  isFixedPostion() {
     Adapt.a11y.log.removed('$("..").isFixedPostion was unneeded and has been removed, let us know if you need it back.');
     return false;
   },
 
-  a11y_aria_label: function() {
+  a11y_aria_label() {
     Adapt.a11y.log.removed('$("..").a11y_aria_label was incorrect behaviour.');
     return this;
   },
 
-  limitedScrollTo: function() {
+  limitedScrollTo() {
     Adapt.a11y.log.removed('$.limitedScrollTo had no impact on the screen reader cursor.');
     return this;
   },
 
-  a11y_text: function() {
+  a11y_text() {
     Adapt.a11y.log.removed('a11y_text is no longer required. https://tink.uk/understanding-screen-reader-interaction-modes/');
     return this;
   },
 
-  a11y_selected: function() {
+  a11y_selected() {
     Adapt.a11y.log.removed('$("..").a11y_selected is removed. Please use aria-live instead.');
     return this;
   },
 
-  a11y_on: function(isOn) {
+  a11y_on(isOn) {
     Adapt.a11y.log.deprecated('$("..").a11y_on, use Adapt.a11y.findTabbable($element); and Adapt.a11y.toggleAccessible($elements, isAccessible); instead.');
     const $tabbable = Adapt.a11y.findTabbable(this);
     Adapt.a11y.toggleAccessible($tabbable, isOn);
     return this;
   },
 
-  a11y_only: function() {
+  a11y_only() {
     Adapt.a11y.log.removed('$("..").a11y_only, use Adapt.a11y.popupOpened($popupElement); instead.');
     return this;
   },
 
-  scrollDisable: function() {
+  scrollDisable() {
     if (Adapt.a11y.config._options._isScrollDisableEnabled === false) {
       return this;
     }
@@ -52,7 +52,7 @@ _.extend($.fn, {
     return this;
   },
 
-  scrollEnable: function() {
+  scrollEnable() {
     if (Adapt.a11y.config._options._isScrollDisableEnabled === false) {
       return this;
     }
@@ -61,45 +61,45 @@ _.extend($.fn, {
     return this;
   },
 
-  a11y_popup: function() {
+  a11y_popup() {
     Adapt.a11y.log.deprecated('$("..").a11y_popup, use Adapt.a11y.popupOpened($popupElement); instead.');
     return Adapt.a11y.popupOpened(this);
   },
 
-  a11y_cntrl: function(isOn, withDisabled) {
+  a11y_cntrl(isOn, withDisabled) {
     Adapt.a11y.log.deprecated('$("..").a11y_cntrl, use Adapt.a11y.toggleAccessible($elements, isAccessible); and if needed Adapt.a11y.toggleEnabled($elements, isEnabled); instead.');
     Adapt.a11y.toggleAccessible(this, isOn);
     if (withDisabled) Adapt.a11y.toggleEnabled(this, isOn);
     return this;
   },
 
-  a11y_cntrl_enabled: function(isOn) {
+  a11y_cntrl_enabled(isOn) {
     Adapt.a11y.log.deprecated('$("..").a11y_cntrl_enabled, use Adapt.a11y.toggleAccessibleEnabled($elements, isAccessibleEnabled); instead.');
     Adapt.a11y.toggleAccessibleEnabled(this, isOn);
     return this;
   },
 
-  isReadable: function() {
+  isReadable() {
     Adapt.a11y.log.deprecated('$("..").isReadable, use Adapt.a11y.isReadable($element); instead.');
     return Adapt.a11y.isReadable(this);
   },
 
-  findForward: function(selector) {
+  findForward(selector) {
     Adapt.a11y.log.removed('$("..").findForward has been removed as the use cases are very small, let us know if you need it back.');
     return Adapt.a11y._findFirstForward(this, selector);
   },
 
-  findWalk: function(selector) {
+  findWalk(selector) {
     Adapt.a11y.log.removed('$("..").findWalk has been removed as the use cases are very small, let us know if you need it back.');
     return Adapt.a11y._findFindForwardDescendant(this, selector);
   },
 
-  focusNoScroll: function() {
+  focusNoScroll() {
     Adapt.a11y.log.deprecated('$("..").focusNoScroll, use Adapt.a11y.focus($element); instead.');
     return Adapt.a11y.focus(this);
   },
 
-  focusNext: function(returnOnly) {
+  focusNext(returnOnly) {
     Adapt.a11y.log.deprecated('$("..").focusNext, use Adapt.a11y.focusNext($element); or if needed Adapt.a11y.findFirstReadable($element); instead.');
     if (returnOnly) {
       return Adapt.a11y.findFirstReadable(this);
@@ -107,7 +107,7 @@ _.extend($.fn, {
     return Adapt.a11y.focusNext(this);
   },
 
-  focusOrNext: function(returnOnly) {
+  focusOrNext(returnOnly) {
     Adapt.a11y.log.deprecated('$("..").focusOrNext, use Adapt.a11y.focusFirst($element); or if needed Adapt.a11y.findFirstReadable($element); or Adapt.a11y.isReadable($element); instead.');
     if (returnOnly) {
       if (Adapt.a11y.isReadable(this)) return this;
@@ -116,7 +116,7 @@ _.extend($.fn, {
     return Adapt.a11y.focusFirst(this);
   },
 
-  a11y_focus: function(dontDefer) {
+  a11y_focus(dontDefer) {
     Adapt.a11y.log.deprecated('$("..").a11y_focus, use Adapt.a11y.focusFirst($element, { defer: true }); instead.');
     Adapt.a11y.focusFirst(this, { defer: !dontDefer });
     return this;
@@ -124,45 +124,45 @@ _.extend($.fn, {
 
 });
 
-_.extend($, {
+Object.assign($, {
 
-  a11y_alert: function() {
+  a11y_alert() {
     Adapt.a11y.log.removed('$.a11y_alert is removed. Please use aria-live instead.');
     return this;
   },
 
-  a11y_update: function() {
+  a11y_update() {
     Adapt.a11y.log.removed('a11y_update is no longer required.');
     return this;
   },
 
-  a11y_text: function (text) {
+  a11y_text(text) {
     Adapt.a11y.log.removed('a11y_text is no longer required. https://tink.uk/understanding-screen-reader-interaction-modes/');
     return text;
   },
 
-  a11y_on: function(isOn, selector) {
+  a11y_on(isOn, selector) {
     Adapt.a11y.log.deprecated('$("..").a11y_on, use Adapt.a11y.toggleHidden($elements, isHidden); instead.');
     return Adapt.a11y.toggleHidden(selector, !isOn);
   },
 
-  a11y_popdown: function($focusTarget) {
+  a11y_popdown($focusTarget) {
     Adapt.a11y.log.removed('$.a11y_popdown, use Adapt.a11y.popupClosed($focusTarget); instead.');
     return Adapt.a11y.popupClosed($focusTarget);
   },
 
-  a11y_focus: function(dontDefer) {
+  a11y_focus(dontDefer) {
     Adapt.a11y.log.deprecated('$.a11y_focus, use Adapt.a11y.focusFirst("body", { defer: true }); instead.');
     Adapt.a11y.focusFirst('body', { defer: !dontDefer });
     return this;
   },
 
-  a11y_normalize: function(html) {
+  a11y_normalize(html) {
     Adapt.a11y.log.deprecated('$.a11y_normalize, use Adapt.a11y.normalize("html"); instead.');
     return Adapt.a11y.normalize(html);
   },
 
-  a11y_remove_breaks: function(html) {
+  a11y_remove_breaks(html) {
     Adapt.a11y.log.deprecated('$.a11y_remove_breaks, use Adapt.a11y.removeBreaks("html"); instead.');
     return Adapt.a11y.removeBreaks(html);
   }

--- a/src/core/js/a11y/deprecated.js
+++ b/src/core/js/a11y/deprecated.js
@@ -33,7 +33,7 @@ _.extend($.fn, {
 
   a11y_on: function(isOn) {
     Adapt.a11y.log.deprecated('$("..").a11y_on, use Adapt.a11y.findTabbable($element); and Adapt.a11y.toggleAccessible($elements, isAccessible); instead.');
-    var $tabbable = Adapt.a11y.findTabbable(this);
+    const $tabbable = Adapt.a11y.findTabbable(this);
     Adapt.a11y.toggleAccessible($tabbable, isOn);
     return this;
   },

--- a/src/core/js/a11y/deprecated.js
+++ b/src/core/js/a11y/deprecated.js
@@ -1,174 +1,170 @@
-define([
-  'core/js/adapt'
-], function(Adapt) {
+import Adapt from 'core/js/adapt';
 
-  /**
-   * The old API is rerouted to the new API with warnings.
-   */
+/**
+ * The old API is rerouted to the new API with warnings.
+ */
 
-  _.extend($.fn, {
+_.extend($.fn, {
 
-    isFixedPostion: function() {
-      Adapt.a11y.log.removed('$("..").isFixedPostion was unneeded and has been removed, let us know if you need it back.');
-      return false;
-    },
+  isFixedPostion: function() {
+    Adapt.a11y.log.removed('$("..").isFixedPostion was unneeded and has been removed, let us know if you need it back.');
+    return false;
+  },
 
-    a11y_aria_label: function() {
-      Adapt.a11y.log.removed('$("..").a11y_aria_label was incorrect behaviour.');
-      return this;
-    },
+  a11y_aria_label: function() {
+    Adapt.a11y.log.removed('$("..").a11y_aria_label was incorrect behaviour.');
+    return this;
+  },
 
-    limitedScrollTo: function() {
-      Adapt.a11y.log.removed('$.limitedScrollTo had no impact on the screen reader cursor.');
-      return this;
-    },
+  limitedScrollTo: function() {
+    Adapt.a11y.log.removed('$.limitedScrollTo had no impact on the screen reader cursor.');
+    return this;
+  },
 
-    a11y_text: function() {
-      Adapt.a11y.log.removed('a11y_text is no longer required. https://tink.uk/understanding-screen-reader-interaction-modes/');
-      return this;
-    },
+  a11y_text: function() {
+    Adapt.a11y.log.removed('a11y_text is no longer required. https://tink.uk/understanding-screen-reader-interaction-modes/');
+    return this;
+  },
 
-    a11y_selected: function() {
-      Adapt.a11y.log.removed('$("..").a11y_selected is removed. Please use aria-live instead.');
-      return this;
-    },
+  a11y_selected: function() {
+    Adapt.a11y.log.removed('$("..").a11y_selected is removed. Please use aria-live instead.');
+    return this;
+  },
 
-    a11y_on: function(isOn) {
-      Adapt.a11y.log.deprecated('$("..").a11y_on, use Adapt.a11y.findTabbable($element); and Adapt.a11y.toggleAccessible($elements, isAccessible); instead.');
-      var $tabbable = Adapt.a11y.findTabbable(this);
-      Adapt.a11y.toggleAccessible($tabbable, isOn);
-      return this;
-    },
+  a11y_on: function(isOn) {
+    Adapt.a11y.log.deprecated('$("..").a11y_on, use Adapt.a11y.findTabbable($element); and Adapt.a11y.toggleAccessible($elements, isAccessible); instead.');
+    var $tabbable = Adapt.a11y.findTabbable(this);
+    Adapt.a11y.toggleAccessible($tabbable, isOn);
+    return this;
+  },
 
-    a11y_only: function() {
-      Adapt.a11y.log.removed('$("..").a11y_only, use Adapt.a11y.popupOpened($popupElement); instead.');
-      return this;
-    },
+  a11y_only: function() {
+    Adapt.a11y.log.removed('$("..").a11y_only, use Adapt.a11y.popupOpened($popupElement); instead.');
+    return this;
+  },
 
-    scrollDisable: function() {
-      if (Adapt.a11y.config._options._isScrollDisableEnabled === false) {
-        return this;
-      }
-      Adapt.a11y.log.deprecated('$("..").scrollDisable, use Adapt.a11y.scrollDisable($elements); instead.');
-      Adapt.a11y.scrollDisable(this);
-      return this;
-    },
-
-    scrollEnable: function() {
-      if (Adapt.a11y.config._options._isScrollDisableEnabled === false) {
-        return this;
-      }
-      Adapt.a11y.log.deprecated('$("..").scrollEnable, use Adapt.a11y.scrollEnable($elements); instead.');
-      Adapt.a11y.scrollEnable(this);
-      return this;
-    },
-
-    a11y_popup: function() {
-      Adapt.a11y.log.deprecated('$("..").a11y_popup, use Adapt.a11y.popupOpened($popupElement); instead.');
-      return Adapt.a11y.popupOpened(this);
-    },
-
-    a11y_cntrl: function(isOn, withDisabled) {
-      Adapt.a11y.log.deprecated('$("..").a11y_cntrl, use Adapt.a11y.toggleAccessible($elements, isAccessible); and if needed Adapt.a11y.toggleEnabled($elements, isEnabled); instead.');
-      Adapt.a11y.toggleAccessible(this, isOn);
-      if (withDisabled) Adapt.a11y.toggleEnabled(this, isOn);
-      return this;
-    },
-
-    a11y_cntrl_enabled: function(isOn) {
-      Adapt.a11y.log.deprecated('$("..").a11y_cntrl_enabled, use Adapt.a11y.toggleAccessibleEnabled($elements, isAccessibleEnabled); instead.');
-      Adapt.a11y.toggleAccessibleEnabled(this, isOn);
-      return this;
-    },
-
-    isReadable: function() {
-      Adapt.a11y.log.deprecated('$("..").isReadable, use Adapt.a11y.isReadable($element); instead.');
-      return Adapt.a11y.isReadable(this);
-    },
-
-    findForward: function(selector) {
-      Adapt.a11y.log.removed('$("..").findForward has been removed as the use cases are very small, let us know if you need it back.');
-      return Adapt.a11y._findFirstForward(this, selector);
-    },
-
-    findWalk: function(selector) {
-      Adapt.a11y.log.removed('$("..").findWalk has been removed as the use cases are very small, let us know if you need it back.');
-      return Adapt.a11y._findFindForwardDescendant(this, selector);
-    },
-
-    focusNoScroll: function() {
-      Adapt.a11y.log.deprecated('$("..").focusNoScroll, use Adapt.a11y.focus($element); instead.');
-      return Adapt.a11y.focus(this);
-    },
-
-    focusNext: function(returnOnly) {
-      Adapt.a11y.log.deprecated('$("..").focusNext, use Adapt.a11y.focusNext($element); or if needed Adapt.a11y.findFirstReadable($element); instead.');
-      if (returnOnly) {
-        return Adapt.a11y.findFirstReadable(this);
-      }
-      return Adapt.a11y.focusNext(this);
-    },
-
-    focusOrNext: function(returnOnly) {
-      Adapt.a11y.log.deprecated('$("..").focusOrNext, use Adapt.a11y.focusFirst($element); or if needed Adapt.a11y.findFirstReadable($element); or Adapt.a11y.isReadable($element); instead.');
-      if (returnOnly) {
-        if (Adapt.a11y.isReadable(this)) return this;
-        return Adapt.a11y.findFirstReadable(this);
-      }
-      return Adapt.a11y.focusFirst(this);
-    },
-
-    a11y_focus: function(dontDefer) {
-      Adapt.a11y.log.deprecated('$("..").a11y_focus, use Adapt.a11y.focusFirst($element, { defer: true }); instead.');
-      Adapt.a11y.focusFirst(this, { defer: !dontDefer });
+  scrollDisable: function() {
+    if (Adapt.a11y.config._options._isScrollDisableEnabled === false) {
       return this;
     }
+    Adapt.a11y.log.deprecated('$("..").scrollDisable, use Adapt.a11y.scrollDisable($elements); instead.');
+    Adapt.a11y.scrollDisable(this);
+    return this;
+  },
 
-  });
-
-  _.extend($, {
-
-    a11y_alert: function() {
-      Adapt.a11y.log.removed('$.a11y_alert is removed. Please use aria-live instead.');
+  scrollEnable: function() {
+    if (Adapt.a11y.config._options._isScrollDisableEnabled === false) {
       return this;
-    },
-
-    a11y_update: function() {
-      Adapt.a11y.log.removed('a11y_update is no longer required.');
-      return this;
-    },
-
-    a11y_text: function (text) {
-      Adapt.a11y.log.removed('a11y_text is no longer required. https://tink.uk/understanding-screen-reader-interaction-modes/');
-      return text;
-    },
-
-    a11y_on: function(isOn, selector) {
-      Adapt.a11y.log.deprecated('$("..").a11y_on, use Adapt.a11y.toggleHidden($elements, isHidden); instead.');
-      return Adapt.a11y.toggleHidden(selector, !isOn);
-    },
-
-    a11y_popdown: function($focusTarget) {
-      Adapt.a11y.log.removed('$.a11y_popdown, use Adapt.a11y.popupClosed($focusTarget); instead.');
-      return Adapt.a11y.popupClosed($focusTarget);
-    },
-
-    a11y_focus: function(dontDefer) {
-      Adapt.a11y.log.deprecated('$.a11y_focus, use Adapt.a11y.focusFirst("body", { defer: true }); instead.');
-      Adapt.a11y.focusFirst('body', { defer: !dontDefer });
-      return this;
-    },
-
-    a11y_normalize: function(html) {
-      Adapt.a11y.log.deprecated('$.a11y_normalize, use Adapt.a11y.normalize("html"); instead.');
-      return Adapt.a11y.normalize(html);
-    },
-
-    a11y_remove_breaks: function(html) {
-      Adapt.a11y.log.deprecated('$.a11y_remove_breaks, use Adapt.a11y.removeBreaks("html"); instead.');
-      return Adapt.a11y.removeBreaks(html);
     }
+    Adapt.a11y.log.deprecated('$("..").scrollEnable, use Adapt.a11y.scrollEnable($elements); instead.');
+    Adapt.a11y.scrollEnable(this);
+    return this;
+  },
 
-  });
+  a11y_popup: function() {
+    Adapt.a11y.log.deprecated('$("..").a11y_popup, use Adapt.a11y.popupOpened($popupElement); instead.');
+    return Adapt.a11y.popupOpened(this);
+  },
+
+  a11y_cntrl: function(isOn, withDisabled) {
+    Adapt.a11y.log.deprecated('$("..").a11y_cntrl, use Adapt.a11y.toggleAccessible($elements, isAccessible); and if needed Adapt.a11y.toggleEnabled($elements, isEnabled); instead.');
+    Adapt.a11y.toggleAccessible(this, isOn);
+    if (withDisabled) Adapt.a11y.toggleEnabled(this, isOn);
+    return this;
+  },
+
+  a11y_cntrl_enabled: function(isOn) {
+    Adapt.a11y.log.deprecated('$("..").a11y_cntrl_enabled, use Adapt.a11y.toggleAccessibleEnabled($elements, isAccessibleEnabled); instead.');
+    Adapt.a11y.toggleAccessibleEnabled(this, isOn);
+    return this;
+  },
+
+  isReadable: function() {
+    Adapt.a11y.log.deprecated('$("..").isReadable, use Adapt.a11y.isReadable($element); instead.');
+    return Adapt.a11y.isReadable(this);
+  },
+
+  findForward: function(selector) {
+    Adapt.a11y.log.removed('$("..").findForward has been removed as the use cases are very small, let us know if you need it back.');
+    return Adapt.a11y._findFirstForward(this, selector);
+  },
+
+  findWalk: function(selector) {
+    Adapt.a11y.log.removed('$("..").findWalk has been removed as the use cases are very small, let us know if you need it back.');
+    return Adapt.a11y._findFindForwardDescendant(this, selector);
+  },
+
+  focusNoScroll: function() {
+    Adapt.a11y.log.deprecated('$("..").focusNoScroll, use Adapt.a11y.focus($element); instead.');
+    return Adapt.a11y.focus(this);
+  },
+
+  focusNext: function(returnOnly) {
+    Adapt.a11y.log.deprecated('$("..").focusNext, use Adapt.a11y.focusNext($element); or if needed Adapt.a11y.findFirstReadable($element); instead.');
+    if (returnOnly) {
+      return Adapt.a11y.findFirstReadable(this);
+    }
+    return Adapt.a11y.focusNext(this);
+  },
+
+  focusOrNext: function(returnOnly) {
+    Adapt.a11y.log.deprecated('$("..").focusOrNext, use Adapt.a11y.focusFirst($element); or if needed Adapt.a11y.findFirstReadable($element); or Adapt.a11y.isReadable($element); instead.');
+    if (returnOnly) {
+      if (Adapt.a11y.isReadable(this)) return this;
+      return Adapt.a11y.findFirstReadable(this);
+    }
+    return Adapt.a11y.focusFirst(this);
+  },
+
+  a11y_focus: function(dontDefer) {
+    Adapt.a11y.log.deprecated('$("..").a11y_focus, use Adapt.a11y.focusFirst($element, { defer: true }); instead.');
+    Adapt.a11y.focusFirst(this, { defer: !dontDefer });
+    return this;
+  }
+
+});
+
+_.extend($, {
+
+  a11y_alert: function() {
+    Adapt.a11y.log.removed('$.a11y_alert is removed. Please use aria-live instead.');
+    return this;
+  },
+
+  a11y_update: function() {
+    Adapt.a11y.log.removed('a11y_update is no longer required.');
+    return this;
+  },
+
+  a11y_text: function (text) {
+    Adapt.a11y.log.removed('a11y_text is no longer required. https://tink.uk/understanding-screen-reader-interaction-modes/');
+    return text;
+  },
+
+  a11y_on: function(isOn, selector) {
+    Adapt.a11y.log.deprecated('$("..").a11y_on, use Adapt.a11y.toggleHidden($elements, isHidden); instead.');
+    return Adapt.a11y.toggleHidden(selector, !isOn);
+  },
+
+  a11y_popdown: function($focusTarget) {
+    Adapt.a11y.log.removed('$.a11y_popdown, use Adapt.a11y.popupClosed($focusTarget); instead.');
+    return Adapt.a11y.popupClosed($focusTarget);
+  },
+
+  a11y_focus: function(dontDefer) {
+    Adapt.a11y.log.deprecated('$.a11y_focus, use Adapt.a11y.focusFirst("body", { defer: true }); instead.');
+    Adapt.a11y.focusFirst('body', { defer: !dontDefer });
+    return this;
+  },
+
+  a11y_normalize: function(html) {
+    Adapt.a11y.log.deprecated('$.a11y_normalize, use Adapt.a11y.normalize("html"); instead.');
+    return Adapt.a11y.normalize(html);
+  },
+
+  a11y_remove_breaks: function(html) {
+    Adapt.a11y.log.deprecated('$.a11y_remove_breaks, use Adapt.a11y.removeBreaks("html"); instead.');
+    return Adapt.a11y.removeBreaks(html);
+  }
 
 });

--- a/src/core/js/a11y/focusOptions.js
+++ b/src/core/js/a11y/focusOptions.js
@@ -1,30 +1,26 @@
-define(function() {
+export default class FocusOptions {
 
   /**
    * Options parser for focus functions.
-   * @class
+   * @param {Object} options
+   * @param {boolean} [options.preventScroll=false] Stops the browser from scrolling to the focused point. https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus
+   * @param {boolean} [options.defer=false] Add a defer to the focus call, allowing for user interface settling.
    */
-  var FocusOptions = function(options) {
-    _.defaults(this, options, {
+  constructor({
+    preventScroll = false,
+    defer = false
+  } = {}) {
+    /**
+    * Stops the browser from scrolling to the focused point.
+    * https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus
+    * @type {boolean}
+    */
+    this.preventScroll = preventScroll;
+    /**
+     * Add a defer to the focus call, allowing for user interface settling.
+     * @type {boolean}
+     */
+    this.defer = defer;
+  }
 
-      /**
-       * Stops the browser from scrolling to the focused point.
-       * https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus
-       *
-       * @type {boolean}
-       */
-      preventScroll: true,
-
-      /**
-       * Add a defer to the focus call, allowing for user interface settling.
-       *
-       * @type {boolean}
-       */
-      defer: false
-
-    });
-  };
-
-  return FocusOptions;
-
-});
+}

--- a/src/core/js/a11y/keyboardFocusOutline.js
+++ b/src/core/js/a11y/keyboardFocusOutline.js
@@ -8,7 +8,7 @@ import Adapt from 'core/js/adapt';
 export default class KeyboardFocusOutline extends Backbone.Controller {
 
   initialize() {
-    _.bindAll(this, '_onKeyDown');
+    this._onKeyDown = this._onKeyDown.bind(this);
     this.$html = $('html');
     this.showOnKeys = {
       9: true, // tab

--- a/src/core/js/a11y/keyboardFocusOutline.js
+++ b/src/core/js/a11y/keyboardFocusOutline.js
@@ -1,74 +1,68 @@
-define([
-  'core/js/adapt'
-], function(Adapt) {
+import Adapt from 'core/js/adapt';
+
+/**
+ * Manages whether or not the focus outline should be entirely removed
+ * or removed until a key is pressed on a tabbable element.
+ * @class
+ */
+export default class KeyboardFocusOutline extends Backbone.Controller {
+
+  initialize() {
+    _.bindAll(this, '_onKeyDown');
+    this.$html = $('html');
+    this.showOnKeys = {
+      9: true, // tab
+      13: true, // enter
+      32: true, // space
+      37: true, // arrow left
+      38: true, // arrow up
+      39: true, // arrow right
+      40: true // arrow down
+    };
+    this.listenTo(Adapt, {
+      'accessibility:ready': this._attachEventListeners
+    });
+  }
+
+  _attachEventListeners() {
+    document.addEventListener('keydown', this._onKeyDown);
+    this._start();
+  }
 
   /**
-   * Manages whether or not the focus outline should be entirely removed
-   * or removed until a key is pressed on a tabbable element.
-   * @class
+   * Add styling classes if required.
    */
-  var KeyboardFocusOutline = Backbone.Controller.extend({
-
-    initialize: function() {
-      _.bindAll(this, '_onKeyDown');
-      this.$html = $('html');
-      this.showOnKeys = {
-        9: true, // tab
-        13: true, // enter
-        32: true, // space
-        37: true, // arrow left
-        38: true, // arrow up
-        39: true, // arrow right
-        40: true // arrow down
-      };
-      this.listenTo(Adapt, {
-        'accessibility:ready': this._attachEventListeners
-      });
-    },
-
-    _attachEventListeners: function() {
-      document.addEventListener('keydown', this._onKeyDown);
-      this._start();
-    },
-
-    /**
-     * Add styling classes if required.
-     */
-    _start: function() {
-      var config = Adapt.a11y.config;
-      if (config._options._isFocusOutlineDisabled) {
-        this.$html.addClass('a11y-disable-focusoutline');
-        return;
-      }
-      if (!config._isEnabled || !config._options._isFocusOutlineKeyboardOnlyEnabled) {
-        return;
-      }
+  _start() {
+    var config = Adapt.a11y.config;
+    if (config._options._isFocusOutlineDisabled) {
       this.$html.addClass('a11y-disable-focusoutline');
-    },
-
-    /**
-     * Handle key down events for on a tabbable element.
-     *
-     * @param {JQuery.Event} event
-     */
-    _onKeyDown: function(event) {
-      var config = Adapt.a11y.config;
-      if (config._options._isFocusOutlineDisabled) {
-        this.$html.addClass('a11y-disable-focusoutline');
-        return;
-      }
-      if (!config._isEnabled || !config._options._isFocusOutlineKeyboardOnlyEnabled || !this.showOnKeys[event.keyCode]) {
-        return;
-      }
-      var $element = $(event.target);
-      if (!$element.is(config._options._tabbableElements) || $element.is(config._options._focusOutlineKeyboardOnlyIgnore)) {
-        return;
-      }
-      this.$html.removeClass('a11y-disable-focusoutline');
+      return;
     }
+    if (!config._isEnabled || !config._options._isFocusOutlineKeyboardOnlyEnabled) {
+      return;
+    }
+    this.$html.addClass('a11y-disable-focusoutline');
+  }
 
-  });
+  /**
+   * Handle key down events for on a tabbable element.
+   *
+   * @param {JQuery.Event} event
+   */
+  _onKeyDown(event) {
+    var config = Adapt.a11y.config;
+    if (config._options._isFocusOutlineDisabled) {
+      this.$html.addClass('a11y-disable-focusoutline');
+      return;
+    }
+    if (!config._isEnabled || !config._options._isFocusOutlineKeyboardOnlyEnabled || !this.showOnKeys[event.keyCode]) {
+      return;
+    }
+    var $element = $(event.target);
+    if (!$element.is(config._options._tabbableElements) || $element.is(config._options._focusOutlineKeyboardOnlyIgnore)) {
+      return;
+    }
+    this.$html.removeClass('a11y-disable-focusoutline');
+  }
 
-  return KeyboardFocusOutline;
-
-});
+}

--- a/src/core/js/a11y/keyboardFocusOutline.js
+++ b/src/core/js/a11y/keyboardFocusOutline.js
@@ -33,7 +33,7 @@ export default class KeyboardFocusOutline extends Backbone.Controller {
    * Add styling classes if required.
    */
   _start() {
-    var config = Adapt.a11y.config;
+    const config = Adapt.a11y.config;
     if (config._options._isFocusOutlineDisabled) {
       this.$html.addClass('a11y-disable-focusoutline');
       return;
@@ -50,7 +50,7 @@ export default class KeyboardFocusOutline extends Backbone.Controller {
    * @param {JQuery.Event} event
    */
   _onKeyDown(event) {
-    var config = Adapt.a11y.config;
+    const config = Adapt.a11y.config;
     if (config._options._isFocusOutlineDisabled) {
       this.$html.addClass('a11y-disable-focusoutline');
       return;
@@ -58,7 +58,7 @@ export default class KeyboardFocusOutline extends Backbone.Controller {
     if (!config._isEnabled || !config._options._isFocusOutlineKeyboardOnlyEnabled || !this.showOnKeys[event.keyCode]) {
       return;
     }
-    var $element = $(event.target);
+    const $element = $(event.target);
     if (!$element.is(config._options._tabbableElements) || $element.is(config._options._focusOutlineKeyboardOnlyIgnore)) {
       return;
     }

--- a/src/core/js/a11y/log.js
+++ b/src/core/js/a11y/log.js
@@ -1,61 +1,55 @@
-define([
-  'core/js/adapt'
-], function(Adapt) {
+import Adapt from 'core/js/adapt';
 
-  /**
-   * Controller for managing accessibilty logging, specifically used for
-   * controlling the display of removed or deprecated API warnings.
-   */
-  class Log extends Backbone.Controller {
+/**
+ * Controller for managing accessibilty logging, specifically used for
+ * controlling the display of removed or deprecated API warnings.
+ */
+export default class Log extends Backbone.Controller {
 
-    initialize() {
-      this._warned = {};
-    }
-
-    _hasWarned(args) {
-      var config = Adapt.a11y.config;
-      if (!config._options._warnFirstOnly) {
-        return false;
-      }
-      var hash = args.map(String).join(':');
-      if (this._warned[hash]) {
-        return true;
-      }
-      this._warned[hash] = true;
-      return false;
-    }
-
-    _canWarn() {
-      var config = Adapt.a11y.config;
-      return Boolean(config._options._warn);
-    }
-
-    removed(...args) {
-      if (!this._canWarn) {
-        return;
-      }
-      args = ['A11Y'].concat(args);
-      if (this._hasWarned(args)) {
-        return;
-      }
-      Adapt.log.removed(...args);
-      return this;
-    }
-
-    deprecated(...args) {
-      if (!this._canWarn) {
-        return;
-      }
-      args = ['A11Y'].concat(args);
-      if (this._hasWarned(args)) {
-        return;
-      }
-      Adapt.log.deprecated(...args);
-      return this;
-    }
-
+  initialize() {
+    this._warned = {};
   }
 
-  return Log;
+  _hasWarned(args) {
+    var config = Adapt.a11y.config;
+    if (!config._options._warnFirstOnly) {
+      return false;
+    }
+    var hash = args.map(String).join(':');
+    if (this._warned[hash]) {
+      return true;
+    }
+    this._warned[hash] = true;
+    return false;
+  }
 
-});
+  _canWarn() {
+    var config = Adapt.a11y.config;
+    return Boolean(config._options._warn);
+  }
+
+  removed(...args) {
+    if (!this._canWarn) {
+      return;
+    }
+    args = ['A11Y'].concat(args);
+    if (this._hasWarned(args)) {
+      return;
+    }
+    Adapt.log.removed(...args);
+    return this;
+  }
+
+  deprecated(...args) {
+    if (!this._canWarn) {
+      return;
+    }
+    args = ['A11Y'].concat(args);
+    if (this._hasWarned(args)) {
+      return;
+    }
+    Adapt.log.deprecated(...args);
+    return this;
+  }
+
+}

--- a/src/core/js/a11y/log.js
+++ b/src/core/js/a11y/log.js
@@ -11,11 +11,11 @@ export default class Log extends Backbone.Controller {
   }
 
   _hasWarned(args) {
-    var config = Adapt.a11y.config;
+    const config = Adapt.a11y.config;
     if (!config._options._warnFirstOnly) {
       return false;
     }
-    var hash = args.map(String).join(':');
+    const hash = args.map(String).join(':');
     if (this._warned[hash]) {
       return true;
     }
@@ -24,7 +24,7 @@ export default class Log extends Backbone.Controller {
   }
 
   _canWarn() {
-    var config = Adapt.a11y.config;
+    const config = Adapt.a11y.config;
     return Boolean(config._options._warn);
   }
 

--- a/src/core/js/a11y/popup.js
+++ b/src/core/js/a11y/popup.js
@@ -79,19 +79,19 @@ export default class Popup extends Backbone.Controller {
    */
   _addPopupLayer($popupElement) {
     $popupElement = $($popupElement);
-    var config = Adapt.a11y.config;
+    const config = Adapt.a11y.config;
     if (!config._isEnabled || !config._options._isPopupManagementEnabled || $popupElement.length === 0) {
       return $popupElement;
     }
     this._floorStack.push($popupElement);
     this._focusStack.push($(document.activeElement));
-    var $elements = $(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes);
-    var $branch = $popupElement.add($popupElement.parents());
-    var $siblings = $branch.siblings().filter(config._options._tabbableElementsExcludes);
+    let $elements = $(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes);
+    const $branch = $popupElement.add($popupElement.parents());
+    const $siblings = $branch.siblings().filter(config._options._tabbableElementsExcludes);
     $elements = $elements.add($siblings);
     $elements.each(function(index, item) {
-      var $item = $(item);
-      var elementUID;
+      const $item = $(item);
+      let elementUID;
       if (typeof item.a11y_uid === 'undefined') {
         item.a11y_uid = 'UID' + ++this._elementUIDIndex;
       }
@@ -102,8 +102,8 @@ export default class Popup extends Backbone.Controller {
       if (this._ariaHiddens[elementUID] === undefined) {
         this._ariaHiddens[elementUID] = [];
       }
-      var tabindex = $item.attr('tabindex');
-      var ariaHidden = $item.attr('aria-hidden');
+      const tabindex = $item.attr('tabindex');
+      const ariaHidden = $item.attr('aria-hidden');
       this._tabIndexes[elementUID].push(tabindex === undefined ? '' : tabindex);
       this._ariaHiddens[elementUID].push(ariaHidden === undefined ? '' : ariaHidden);
       if (config._options._isPopupTabIndexManagementEnabled) {
@@ -113,7 +113,7 @@ export default class Popup extends Backbone.Controller {
         $item.attr('aria-hidden', true);
       }
     }.bind(this));
-    var $items = $popupElement.find(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes);
+    const $items = $popupElement.find(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes);
     if (config._options._isPopupTabIndexManagementEnabled) {
       $items.attr('tabindex', 0);
     }
@@ -135,7 +135,7 @@ export default class Popup extends Backbone.Controller {
    * @returns {Object} Returns `Adapt.a11y._popup`.
    */
   closed($focusElement, silent) {
-    var $previousFocusElement = this._removeLastPopupLayer();
+    const $previousFocusElement = this._removeLastPopupLayer();
     $focusElement = $focusElement || $previousFocusElement || $('body');
     if (!silent) {
       Adapt.trigger('popup:closed', $focusElement, true);
@@ -151,7 +151,7 @@ export default class Popup extends Backbone.Controller {
    * @returns {Object} Returns previously active element.
    */
   _removeLastPopupLayer() {
-    var config = Adapt.a11y.config;
+    const config = Adapt.a11y.config;
     if (!config._isEnabled || !config._options._isPopupManagementEnabled) {
       return $(document.activeElement);
     }
@@ -161,10 +161,10 @@ export default class Popup extends Backbone.Controller {
     }
     this._floorStack.pop();
     $(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes).each(function(index, item) {
-      var $item = $(item);
-      var previousTabIndex = '';
-      var previousAriaHidden = '';
-      var elementUID;
+      const $item = $(item);
+      let previousTabIndex = '';
+      let previousAriaHidden = '';
+      let elementUID;
       if (typeof item.a11y_uid === 'undefined') {
         // assign element a unique id
         item.a11y_uid = 'UID' + ++this._elementUIDIndex;
@@ -210,7 +210,7 @@ export default class Popup extends Backbone.Controller {
    * @returns {Object} Returns previously set focus element.
    */
   setCloseTo($focusElement) {
-    var $original = this._focusStack.pop();
+    const $original = this._focusStack.pop();
     this._focusStack.push($focusElement);
     return $original;
   }

--- a/src/core/js/a11y/popup.js
+++ b/src/core/js/a11y/popup.js
@@ -89,7 +89,7 @@ export default class Popup extends Backbone.Controller {
     const $branch = $popupElement.add($popupElement.parents());
     const $siblings = $branch.siblings().filter(config._options._tabbableElementsExcludes);
     $elements = $elements.add($siblings);
-    $elements.each(function(index, item) {
+    $elements.each((index, item) => {
       const $item = $(item);
       let elementUID;
       if (typeof item.a11y_uid === 'undefined') {
@@ -112,7 +112,7 @@ export default class Popup extends Backbone.Controller {
       if (config._options._isPopupAriaHiddenManagementEnabled) {
         $item.attr('aria-hidden', true);
       }
-    }.bind(this));
+    });
     const $items = $popupElement.find(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes);
     if (config._options._isPopupTabIndexManagementEnabled) {
       $items.attr('tabindex', 0);
@@ -160,7 +160,7 @@ export default class Popup extends Backbone.Controller {
       return;
     }
     this._floorStack.pop();
-    $(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes).each(function(index, item) {
+    $(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes).each((index, item) => {
       const $item = $(item);
       let previousTabIndex = '';
       let previousAriaHidden = '';
@@ -198,7 +198,7 @@ export default class Popup extends Backbone.Controller {
           });
         }
       }
-    }.bind(this));
+    });
     return this._focusStack.pop();
   }
 

--- a/src/core/js/a11y/popup.js
+++ b/src/core/js/a11y/popup.js
@@ -4,7 +4,7 @@ import Adapt from 'core/js/adapt';
  * Tabindex and aria-hidden manager for popups.
  * @class
  */
-export default class Popupe extends Backbone.Controller {
+export default class Popup extends Backbone.Controller {
 
   initialize() {
     /**

--- a/src/core/js/a11y/popup.js
+++ b/src/core/js/a11y/popup.js
@@ -1,225 +1,218 @@
-define([
-  'core/js/adapt'
-], function(Adapt) {
+import Adapt from 'core/js/adapt';
 
-  /**
-   * Tabindex and aria-hidden manager for popups.
-   * @class
-   */
-  var Popup = Backbone.Controller.extend({
+/**
+ * Tabindex and aria-hidden manager for popups.
+ * @class
+ */
+export default class Popupe extends Backbone.Controller {
 
+  initialize() {
     /**
      * List of elements which form the base at which elements are generally tabbale
      * and aria-hidden='false'.
      *
      * @type {Array<Object>}
      */
-    _floorStack: [$('body')],
+    this._floorStack = [$('body')];
     /**
      * List of elements to return the focus to once leaving each stack.
      *
      * @type {Array<Object>}
      */
-    _focusStack: [],
+    this._focusStack = [];
     /**
      * Hash of tabindex states for each tabbable element in the popup stack.
      *
      * @type {Object}
      */
-    _tabIndexes: {},
+    this._tabIndexes = {};
     /**
      * Hash of aria-hidden states for each tabbable element in the popup stack.
      *
      * @type {Object}
      */
-    _ariaHiddens: {},
+    this._ariaHiddens = {};
     /**
      * Incremented unique ids for elements belonging to a popup stack with saved
      * states,
      */
-    _elementUIDIndex: 0,
-
-    initialize: function() {
-      this.listenTo(Adapt, {
-        'popup:opened': function($element, ignoreInternalTrigger) {
-          if (ignoreInternalTrigger) {
-            return;
-          }
-          Adapt.a11y.log.deprecated('Adapt.trigger("popup:opened", $element) is replaced with Adapt.a11y.popupOpened($element);');
-          this.opened($element, true);
-        },
-        'popup:closed': function($target, ignoreInternalTrigger) {
-          if (ignoreInternalTrigger) {
-            return;
-          }
-          Adapt.a11y.log.deprecated('Adapt.trigger("popup:closed", $target) is replaced with Adapt.a11y.popupClosed($target);');
-          this.closed($target, true);
+    this._elementUIDIndex = 0;
+    this.listenTo(Adapt, {
+      'popup:opened'($element, ignoreInternalTrigger) {
+        if (ignoreInternalTrigger) {
+          return;
         }
-      });
-    },
-
-    /**
-     * Reorganise the tabindex and aria-hidden attributes in the document to
-     * restrict user interaction to the element specified.
-     *
-     * @param {Object} [$popupElement] Element encapulating the popup.
-     * @returns {Object} Returns `Adapt.a11y._popup`.
-     */
-    opened: function($popupElement, silent) {
-      // Capture currently active element or element specified
-      $popupElement = $popupElement || $(document.activeElement);
-      this._addPopupLayer($popupElement);
-      if (!silent) {
-        Adapt.trigger('popup:opened', $popupElement, true);
+        Adapt.a11y.log.deprecated('Adapt.trigger("popup:opened", $element) is replaced with Adapt.a11y.popupOpened($element);');
+        this.opened($element, true);
+      },
+      'popup:closed'($target, ignoreInternalTrigger) {
+        if (ignoreInternalTrigger) {
+          return;
+        }
+        Adapt.a11y.log.deprecated('Adapt.trigger("popup:closed", $target) is replaced with Adapt.a11y.popupClosed($target);');
+        this.closed($target, true);
       }
-      return this;
-    },
+    });
+  }
 
-    /**
-     * Restrict tabbing and screen reader access to selected element only.
-     *
-     * @param {Object} $popupElement Element encapulating the popup.
-     */
-    _addPopupLayer: function($popupElement) {
-      $popupElement = $($popupElement);
-      var config = Adapt.a11y.config;
-      if (!config._isEnabled || !config._options._isPopupManagementEnabled || $popupElement.length === 0) {
-        return $popupElement;
+  /**
+   * Reorganise the tabindex and aria-hidden attributes in the document to
+   * restrict user interaction to the element specified.
+   *
+   * @param {Object} [$popupElement] Element encapulating the popup.
+   * @returns {Object} Returns `Adapt.a11y._popup`.
+   */
+  opened($popupElement, silent) {
+    // Capture currently active element or element specified
+    $popupElement = $popupElement || $(document.activeElement);
+    this._addPopupLayer($popupElement);
+    if (!silent) {
+      Adapt.trigger('popup:opened', $popupElement, true);
+    }
+    return this;
+  }
+
+  /**
+   * Restrict tabbing and screen reader access to selected element only.
+   *
+   * @param {Object} $popupElement Element encapulating the popup.
+   */
+  _addPopupLayer($popupElement) {
+    $popupElement = $($popupElement);
+    var config = Adapt.a11y.config;
+    if (!config._isEnabled || !config._options._isPopupManagementEnabled || $popupElement.length === 0) {
+      return $popupElement;
+    }
+    this._floorStack.push($popupElement);
+    this._focusStack.push($(document.activeElement));
+    var $elements = $(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes);
+    var $branch = $popupElement.add($popupElement.parents());
+    var $siblings = $branch.siblings().filter(config._options._tabbableElementsExcludes);
+    $elements = $elements.add($siblings);
+    $elements.each(function(index, item) {
+      var $item = $(item);
+      var elementUID;
+      if (typeof item.a11y_uid === 'undefined') {
+        item.a11y_uid = 'UID' + ++this._elementUIDIndex;
       }
-      this._floorStack.push($popupElement);
-      this._focusStack.push($(document.activeElement));
-      var $elements = $(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes);
-      var $branch = $popupElement.add($popupElement.parents());
-      var $siblings = $branch.siblings().filter(config._options._tabbableElementsExcludes);
-      $elements = $elements.add($siblings);
-      $elements.each(function(index, item) {
-        var $item = $(item);
-        var elementUID;
-        if (typeof item.a11y_uid === 'undefined') {
-          item.a11y_uid = 'UID' + ++this._elementUIDIndex;
-        }
-        elementUID = item.a11y_uid;
-        if (this._tabIndexes[elementUID] === undefined) {
-          this._tabIndexes[elementUID] = [];
-        }
-        if (this._ariaHiddens[elementUID] === undefined) {
-          this._ariaHiddens[elementUID] = [];
-        }
-        var tabindex = $item.attr('tabindex');
-        var ariaHidden = $item.attr('aria-hidden');
-        this._tabIndexes[elementUID].push(tabindex === undefined ? '' : tabindex);
-        this._ariaHiddens[elementUID].push(ariaHidden === undefined ? '' : ariaHidden);
-        if (config._options._isPopupTabIndexManagementEnabled) {
-          $item.attr('tabindex', -1);
-        }
-        if (config._options._isPopupAriaHiddenManagementEnabled) {
-          $item.attr('aria-hidden', true);
-        }
-      }.bind(this));
-      var $items = $popupElement.find(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes);
+      elementUID = item.a11y_uid;
+      if (this._tabIndexes[elementUID] === undefined) {
+        this._tabIndexes[elementUID] = [];
+      }
+      if (this._ariaHiddens[elementUID] === undefined) {
+        this._ariaHiddens[elementUID] = [];
+      }
+      var tabindex = $item.attr('tabindex');
+      var ariaHidden = $item.attr('aria-hidden');
+      this._tabIndexes[elementUID].push(tabindex === undefined ? '' : tabindex);
+      this._ariaHiddens[elementUID].push(ariaHidden === undefined ? '' : ariaHidden);
       if (config._options._isPopupTabIndexManagementEnabled) {
-        $items.attr('tabindex', 0);
+        $item.attr('tabindex', -1);
       }
       if (config._options._isPopupAriaHiddenManagementEnabled) {
-        $items
-          .removeAttr('aria-hidden')
-          .removeClass('aria-hidden')
-          .parents(config._options._ariaHiddenExcludes)
-          .removeAttr('aria-hidden')
-          .removeClass('aria-hidden');
+        $item.attr('aria-hidden', true);
       }
-    },
-
-    /**
-     * Close the last popup on the stack, restoring tabindex and aria-hidden
-     * attributes.
-     *
-     * @param {Object} [$focusElement] Element at which to move focus.
-     * @returns {Object} Returns `Adapt.a11y._popup`.
-     */
-    closed: function($focusElement, silent) {
-      var $previousFocusElement = this._removeLastPopupLayer();
-      $focusElement = $focusElement || $previousFocusElement || $('body');
-      if (!silent) {
-        Adapt.trigger('popup:closed', $focusElement, true);
-      }
-      Adapt.a11y.focusFirst($($focusElement));
-      return this;
-    },
-
-    /**
-     * Restores tabbing and screen reader access to the state before the last
-     * `_addPopupLayer` call.
-     *
-     * @returns {Object} Returns previously active element.
-     */
-    _removeLastPopupLayer: function() {
-      var config = Adapt.a11y.config;
-      if (!config._isEnabled || !config._options._isPopupManagementEnabled) {
-        return $(document.activeElement);
-      }
-      // the body layer is the first element and must always exist
-      if (this._floorStack.length <= 1) {
-        return;
-      }
-      this._floorStack.pop();
-      $(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes).each(function(index, item) {
-        var $item = $(item);
-        var previousTabIndex = '';
-        var previousAriaHidden = '';
-        var elementUID;
-        if (typeof item.a11y_uid === 'undefined') {
-          // assign element a unique id
-          item.a11y_uid = 'UID' + ++this._elementUIDIndex;
-        }
-        elementUID = item.a11y_uid;
-        if (this._tabIndexes[elementUID] !== undefined && this._tabIndexes[elementUID].length !== 0) {
-          // get previous tabindex if saved
-          previousTabIndex = this._tabIndexes[elementUID].pop();
-          previousAriaHidden = this._ariaHiddens[elementUID].pop();
-        }
-        if (this._tabIndexes[elementUID] !== undefined && this._tabIndexes[elementUID].length === 0) {
-          // delete element tabindex store if empty
-          delete this._tabIndexes[elementUID];
-          delete this._ariaHiddens[elementUID];
-        }
-        if (config._options._isPopupTabIndexManagementEnabled) {
-          if (previousTabIndex === '') {
-            $item.removeAttr('tabindex');
-          } else {
-            $item.attr({
-              'tabindex': previousTabIndex
-            });
-          }
-        }
-        if (config._options._isPopupAriaHiddenManagementEnabled) {
-          if (previousAriaHidden === '') {
-            $item.removeAttr('aria-hidden');
-          } else {
-            $item.attr({
-              'aria-hidden': previousAriaHidden
-            });
-          }
-        }
-      }.bind(this));
-      return this._focusStack.pop();
-    },
-
-    /**
-     * When a popup is open, this function makes it possible to swap the element
-     * that should receive focus on popup close.
-     *
-     * @param {Object} $focusElement Set a new element to focus on.
-     * @returns {Object} Returns previously set focus element.
-     */
-    setCloseTo: function($focusElement) {
-      var $original = this._focusStack.pop();
-      this._focusStack.push($focusElement);
-      return $original;
+    }.bind(this));
+    var $items = $popupElement.find(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes);
+    if (config._options._isPopupTabIndexManagementEnabled) {
+      $items.attr('tabindex', 0);
     }
+    if (config._options._isPopupAriaHiddenManagementEnabled) {
+      $items
+        .removeAttr('aria-hidden')
+        .removeClass('aria-hidden')
+        .parents(config._options._ariaHiddenExcludes)
+        .removeAttr('aria-hidden')
+        .removeClass('aria-hidden');
+    }
+  }
 
-  });
+  /**
+   * Close the last popup on the stack, restoring tabindex and aria-hidden
+   * attributes.
+   *
+   * @param {Object} [$focusElement] Element at which to move focus.
+   * @returns {Object} Returns `Adapt.a11y._popup`.
+   */
+  closed($focusElement, silent) {
+    var $previousFocusElement = this._removeLastPopupLayer();
+    $focusElement = $focusElement || $previousFocusElement || $('body');
+    if (!silent) {
+      Adapt.trigger('popup:closed', $focusElement, true);
+    }
+    Adapt.a11y.focusFirst($($focusElement));
+    return this;
+  }
 
-  return Popup;
+  /**
+   * Restores tabbing and screen reader access to the state before the last
+   * `_addPopupLayer` call.
+   *
+   * @returns {Object} Returns previously active element.
+   */
+  _removeLastPopupLayer() {
+    var config = Adapt.a11y.config;
+    if (!config._isEnabled || !config._options._isPopupManagementEnabled) {
+      return $(document.activeElement);
+    }
+    // the body layer is the first element and must always exist
+    if (this._floorStack.length <= 1) {
+      return;
+    }
+    this._floorStack.pop();
+    $(config._options._tabbableElements).filter(config._options._tabbableElementsExcludes).each(function(index, item) {
+      var $item = $(item);
+      var previousTabIndex = '';
+      var previousAriaHidden = '';
+      var elementUID;
+      if (typeof item.a11y_uid === 'undefined') {
+        // assign element a unique id
+        item.a11y_uid = 'UID' + ++this._elementUIDIndex;
+      }
+      elementUID = item.a11y_uid;
+      if (this._tabIndexes[elementUID] !== undefined && this._tabIndexes[elementUID].length !== 0) {
+        // get previous tabindex if saved
+        previousTabIndex = this._tabIndexes[elementUID].pop();
+        previousAriaHidden = this._ariaHiddens[elementUID].pop();
+      }
+      if (this._tabIndexes[elementUID] !== undefined && this._tabIndexes[elementUID].length === 0) {
+        // delete element tabindex store if empty
+        delete this._tabIndexes[elementUID];
+        delete this._ariaHiddens[elementUID];
+      }
+      if (config._options._isPopupTabIndexManagementEnabled) {
+        if (previousTabIndex === '') {
+          $item.removeAttr('tabindex');
+        } else {
+          $item.attr({
+            'tabindex': previousTabIndex
+          });
+        }
+      }
+      if (config._options._isPopupAriaHiddenManagementEnabled) {
+        if (previousAriaHidden === '') {
+          $item.removeAttr('aria-hidden');
+        } else {
+          $item.attr({
+            'aria-hidden': previousAriaHidden
+          });
+        }
+      }
+    }.bind(this));
+    return this._focusStack.pop();
+  }
 
-});
+  /**
+   * When a popup is open, this function makes it possible to swap the element
+   * that should receive focus on popup close.
+   *
+   * @param {Object} $focusElement Set a new element to focus on.
+   * @returns {Object} Returns previously set focus element.
+   */
+  setCloseTo($focusElement) {
+    var $original = this._focusStack.pop();
+    this._focusStack.push($focusElement);
+    return $original;
+  }
+
+}

--- a/src/core/js/a11y/scroll.js
+++ b/src/core/js/a11y/scroll.js
@@ -1,313 +1,307 @@
-define(function() {
+/**
+ * Controller for blocking scroll events on specified elements.
+ * @class
+ */
+export default class Scroll extends Backbone.Controller {
+
+  initialize() {
+    _.bindAll(this, '_onTouchStart', '_onTouchEnd', '_onScrollEvent', '_onKeyDown');
+    this._scrollDisabledElements = $([]);
+    this.$window = $(window);
+    this.$body = $('body');
+    this._preventScrollOnKeys = {
+      37: true, // left
+      38: true, // up
+      39: true, // right
+      40: true // down
+    };
+    this._ignoreKeysOnElementsMatching = 'textarea, input, select';
+    this._isRunning = false;
+    this._touchStartEventObject = null;
+  }
 
   /**
-   * Controller for blocking scroll events on specified elements.
-   * @class
+   * Block scrolling on the given elements.
+   *
+   * @param {Object|string|Array} $elements
    */
-  var Scroll = Backbone.Controller.extend({
+  disable($elements) {
+    $elements = $($elements);
+    this._scrollDisabledElements = this._scrollDisabledElements.add($elements);
+    this._checkRunning();
+    return this;
+  }
 
-    initialize: function() {
-      _.bindAll(this, '_onTouchStart', '_onTouchEnd', '_onScrollEvent', '_onKeyDown');
-      this._scrollDisabledElements = $([]);
-      this.$window = $(window);
-      this.$body = $('body');
-      this._preventScrollOnKeys = {
-        37: true, // left
-        38: true, // up
-        39: true, // right
-        40: true // down
-      };
-      this._ignoreKeysOnElementsMatching = 'textarea, input, select';
-      this._isRunning = false;
-      this._touchStartEventObject = null;
-    },
-
-    /**
-     * Block scrolling on the given elements.
-     *
-     * @param {Object|string|Array} $elements
-     */
-    disable: function($elements) {
-      $elements = $($elements);
-      this._scrollDisabledElements = this._scrollDisabledElements.add($elements);
-      this._checkRunning();
+  /**
+   * Stop blocking scrolling on the given elements.
+   *
+   * @param {Object|string|Array} $items
+   */
+  enable($elements) {
+    $elements = $($elements);
+    if (!$elements || !$elements.length) {
+      this.clear();
       return this;
-    },
+    }
+    this._scrollDisabledElements = this._scrollDisabledElements.not($elements);
+    this._checkRunning();
+    return this;
+  }
 
-    /**
-     * Stop blocking scrolling on the given elements.
-     *
-     * @param {Object|string|Array} $items
-     */
-    enable: function($elements) {
-      $elements = $($elements);
-      if (!$elements || !$elements.length) {
-        this.clear();
-        return this;
-      }
-      this._scrollDisabledElements = this._scrollDisabledElements.not($elements);
-      this._checkRunning();
-      return this;
-    },
+  /**
+   * Stop blocking all scrolling.
+   */
+  clear() {
+    this._scrollDisabledElements = $([]);
+    this._checkRunning();
+    return this;
+  }
 
-    /**
-     * Stop blocking all scrolling.
-     */
-    clear: function() {
-      this._scrollDisabledElements = $([]);
-      this._checkRunning();
-      return this;
-    },
+  /**
+   * Start or stop listening for events to block if and when needed.
+   */
+  _checkRunning() {
+    if (!this._scrollDisabledElements.length) {
+      this._stop();
+      return;
+    }
+    this._start();
+  }
 
-    /**
-     * Start or stop listening for events to block if and when needed.
-     */
-    _checkRunning: function() {
-      if (!this._scrollDisabledElements.length) {
-        this._stop();
+  /**
+   * Start listening for events to block.
+   */
+  _start() {
+    if (this._isRunning) {
+      return;
+    }
+    this._isRunning = true;
+    window.addEventListener('touchstart', this._onTouchStart); // mobile
+    window.addEventListener('touchend', this._onTouchEnd); // mobile
+    window.addEventListener('touchmove', this._onScrollEvent, { passive: false }); // mobile
+    window.addEventListener('wheel', this._onScrollEvent, { passive: false });
+    document.addEventListener('wheel', this._onScrollEvent, { passive: false });
+    document.addEventListener('keydown', this._onKeyDown);
+  }
+
+  /**
+   * Capture the touchstart event object for deltaY calculations.
+   *
+   * @param {JQuery.Event} event
+   */
+  _onTouchStart(event) {
+    event = $.event.fix(event);
+    this._touchStartEventObject = event;
+    return true;
+  }
+
+  /**
+   * Clear touchstart event object.
+   */
+  _onTouchEnd() {
+    this._touchStartEventObject = null;
+    return true;
+  }
+
+  /**
+   * Process a native scroll event.
+   *
+   * @param {JQuery.Event} event
+   */
+  _onScrollEvent(event) {
+    event = $.event.fix(event);
+    return this._preventScroll(event);
+  }
+
+  /**
+   * Process a native keydown event.
+   *
+   * @param {JQuery.Event} event
+   */
+  _onKeyDown(event) {
+    event = $.event.fix(event);
+    if (!this._preventScrollOnKeys[event.keyCode]) {
+      return;
+    }
+    var $target = $(event.target);
+    if ($target.is(this._ignoreKeysOnElementsMatching)) {
+      return;
+    }
+    return this._preventScroll(event);
+  }
+
+  /**
+   * Process jquery event object.
+   *
+   * @param {JQuery.Event} event
+   */
+  _preventScroll(event) {
+    var isGesture = (event.touches && event.touches.length > 1);
+    if (isGesture) {
+      // allow multiple finger gestures through
+      // this will unfortunately allow two finger background scrolling on mobile devices
+      // one finger background scrolling will still be disabled
+      return;
+    }
+    var $target = $(event.target);
+    if (this._scrollDisabledElements.length) {
+      var scrollingParent = this._getScrollingParent(event, $target);
+      if (scrollingParent.filter(this._scrollDisabledElements).length === 0) {
+        this.$window.scroll();
         return;
       }
-      this._start();
-    },
+    }
+    event.preventDefault();
+    return false;
+  }
 
-    /**
-     * Start listening for events to block.
-     */
-    _start: function() {
-      if (this._isRunning) {
-        return;
-      }
-      this._isRunning = true;
-      window.addEventListener('touchstart', this._onTouchStart); // mobile
-      window.addEventListener('touchend', this._onTouchEnd); // mobile
-      window.addEventListener('touchmove', this._onScrollEvent, { passive: false }); // mobile
-      window.addEventListener('wheel', this._onScrollEvent, { passive: false });
-      document.addEventListener('wheel', this._onScrollEvent, { passive: false });
-      document.addEventListener('keydown', this._onKeyDown);
-    },
-
-    /**
-     * Capture the touchstart event object for deltaY calculations.
-     *
-     * @param {JQuery.Event} event
-     */
-    _onTouchStart: function(event) {
-      event = $.event.fix(event);
-      this._touchStartEventObject = event;
-      return true;
-    },
-
-    /**
-     * Clear touchstart event object.
-     */
-    _onTouchEnd: function() {
-      this._touchStartEventObject = null;
-      return true;
-    },
-
-    /**
-     * Process a native scroll event.
-     *
-     * @param {JQuery.Event} event
-     */
-    _onScrollEvent: function(event) {
-      event = $.event.fix(event);
-      return this._preventScroll(event);
-    },
-
-    /**
-     * Process a native keydown event.
-     *
-     * @param {JQuery.Event} event
-     */
-    _onKeyDown: function(event) {
-      event = $.event.fix(event);
-      if (!this._preventScrollOnKeys[event.keyCode]) {
-        return;
-      }
-      var $target = $(event.target);
-      if ($target.is(this._ignoreKeysOnElementsMatching)) {
-        return;
-      }
-      return this._preventScroll(event);
-    },
-
-    /**
-     * Process jquery event object.
-     *
-     * @param {JQuery.Event} event
-     */
-    _preventScroll: function(event) {
-      var isGesture = (event.touches && event.touches.length > 1);
-      if (isGesture) {
-        // allow multiple finger gestures through
-        // this will unfortunately allow two finger background scrolling on mobile devices
-        // one finger background scrolling will still be disabled
-        return;
-      }
-      var $target = $(event.target);
-      if (this._scrollDisabledElements.length) {
-        var scrollingParent = this._getScrollingParent(event, $target);
-        if (scrollingParent.filter(this._scrollDisabledElements).length === 0) {
-          this.$window.scroll();
-          return;
-        }
-      }
-      event.preventDefault();
-      return false;
-    },
-
-    /**
-     * Return the parent which will be scrolling from the current scroll event.
-     *
-     * @param {JQuery.Event} event
-     * @param {Object} $target jQuery element object.
-     */
-    _getScrollingParent: function(event, $target) {
-      var isTouchEvent = event.type === 'touchmove';
-      var hasTouchStartEvent = (this._touchStartEventObject && this._touchStartEventObject.originalEvent);
-      if (isTouchEvent && !hasTouchStartEvent) {
-        return $target;
-      }
-      var directionY = this._getScrollDirection(event);
-      if (directionY === 'none') {
+  /**
+   * Return the parent which will be scrolling from the current scroll event.
+   *
+   * @param {JQuery.Event} event
+   * @param {Object} $target jQuery element object.
+   */
+  _getScrollingParent(event, $target) {
+    var isTouchEvent = event.type === 'touchmove';
+    var hasTouchStartEvent = (this._touchStartEventObject && this._touchStartEventObject.originalEvent);
+    if (isTouchEvent && !hasTouchStartEvent) {
+      return $target;
+    }
+    var directionY = this._getScrollDirection(event);
+    if (directionY === 'none') {
+      return this.$body;
+    }
+    var parents = $target.parents();
+    for (var i = 0, l = parents.length; i < l; i++) {
+      var $parent = $(parents[i]);
+      if ($parent.is('body')) {
         return this.$body;
       }
-      var parents = $target.parents();
-      for (var i = 0, l = parents.length; i < l; i++) {
-        var $parent = $(parents[i]);
-        if ($parent.is('body')) {
-          return this.$body;
-        }
-        if (!this._isScrollable($parent)) {
-          continue;
-        }
-        if (!this._isScrolling($parent, directionY)) {
-          continue;
-        }
-        return $parent;
+      if (!this._isScrollable($parent)) {
+        continue;
       }
-      return this.$body;
-    },
-
-    /**
-     * Returns true if the specified target is scrollable.
-     *
-     * @param {Object} $target jQuery element object.
-     * @returns {boolean}
-     */
-    _isScrollable: function($target) {
-      var scrollType = $target.css('overflow-y');
-      if (scrollType !== 'auto' && scrollType !== 'scroll') {
-        return false;
+      if (!this._isScrolling($parent, directionY)) {
+        continue;
       }
-      var pointerEvents = $target.css('pointer-events');
-      if (pointerEvents === 'none') {
-        return false;
-      }
-      return true;
-    },
-
-    /**
-     * Returns true if the specified target is the scrolling target.
-     *
-     * @param {Object} $target jQuery element object.
-     * @param {string} directionY 'none' | 'up' | 'down'
-     *
-     * @returns {boolean}
-     */
-    _isScrolling: function($target, directionY) {
-      var scrollTop = Math.ceil($target.scrollTop());
-      var innerHeight = $target.outerHeight();
-      var scrollHeight = $target[0].scrollHeight;
-      var hasScrollingSpace = false;
-      switch (directionY) {
-        case 'down':
-          hasScrollingSpace = scrollTop + innerHeight < scrollHeight;
-          if (hasScrollingSpace) {
-            return true;
-          }
-          break;
-        case 'up':
-          hasScrollingSpace = scrollTop > 0;
-          if (hasScrollingSpace) {
-            return true;
-          }
-          break;
-      }
-      return false;
-    },
-
-    /**
-     * Returns the vertical direction of scroll.
-     *
-     * @param {JQuery.Event} event
-     * @returns {string} 'none' | 'up' | 'down'
-     */
-    _getScrollDirection: function(event) {
-      var deltaY = this._getScrollDelta(event);
-      if (deltaY === 0) {
-        return 'none';
-      }
-      return deltaY > 0 ? 'up' : 'down';
-    },
-
-    /**
-     * Returns the number of pixels which is intended to be scrolled.
-     *
-     * @param {JQuery.Event} event
-     * @returns {number}
-     */
-    _getScrollDelta: function(event) {
-      var deltaY = 0;
-      var isTouchEvent = event.type === 'touchmove';
-      var originalEvent = event.originalEvent;
-      if (isTouchEvent) {
-        // Touch events
-        // iOS previous + current scroll pos
-        var startOriginalEvent = this._touchStartEventObject.originalEvent;
-        var currentY = originalEvent.pageY;
-        var previousY = startOriginalEvent.pageY;
-        if (currentY === 0 || currentY === previousY) {
-          // Android chrome current scroll pos
-          currentY = originalEvent.touches[0].pageY;
-          previousY = startOriginalEvent.touches[0].pageY;
-        }
-        // Touch: delta calculated from touchstart pos vs touchmove pos
-        deltaY = currentY - previousY;
-      } else {
-        // Mouse events
-        var hasDeltaY = (originalEvent.wheelDeltaY || originalEvent.deltaY !== undefined);
-        if (hasDeltaY) {
-          // Desktop: Firefox & IE delta inverted
-          deltaY = -originalEvent.deltaY;
-        } else {
-          // Desktop: Chrome & Safari wheel delta
-          deltaY = (originalEvent.wheelDelta || 0);
-        }
-      }
-      return deltaY;
-    },
-
-    /**
-     * Stop listening for events to block.
-     */
-    _stop: function() {
-      if (!this._isRunning) {
-        return;
-      }
-      this._isRunning = false;
-      window.removeEventListener('touchstart', this._onTouchStart); // mobile
-      window.removeEventListener('touchend', this._onTouchEnd); // mobile
-      // shouldn't need to supply 3rd arg when removing, but IE11 won't remove the event listener if you don't - see https://github.com/adaptlearning/adapt_framework/issues/2466
-      window.removeEventListener('touchmove', this._onScrollEvent, { passive: false }); // mobile
-      window.removeEventListener('wheel', this._onScrollEvent, { passive: false });
-      document.removeEventListener('wheel', this._onScrollEvent, { passive: false });
-      document.removeEventListener('keydown', this._onKeyDown);
+      return $parent;
     }
+    return this.$body;
+  }
 
-  });
+  /**
+   * Returns true if the specified target is scrollable.
+   *
+   * @param {Object} $target jQuery element object.
+   * @returns {boolean}
+   */
+  _isScrollable($target) {
+    var scrollType = $target.css('overflow-y');
+    if (scrollType !== 'auto' && scrollType !== 'scroll') {
+      return false;
+    }
+    var pointerEvents = $target.css('pointer-events');
+    if (pointerEvents === 'none') {
+      return false;
+    }
+    return true;
+  }
 
-  return Scroll;
+  /**
+   * Returns true if the specified target is the scrolling target.
+   *
+   * @param {Object} $target jQuery element object.
+   * @param {string} directionY 'none' | 'up' | 'down'
+   *
+   * @returns {boolean}
+   */
+  _isScrolling($target, directionY) {
+    var scrollTop = Math.ceil($target.scrollTop());
+    var innerHeight = $target.outerHeight();
+    var scrollHeight = $target[0].scrollHeight;
+    var hasScrollingSpace = false;
+    switch (directionY) {
+      case 'down':
+        hasScrollingSpace = scrollTop + innerHeight < scrollHeight;
+        if (hasScrollingSpace) {
+          return true;
+        }
+        break;
+      case 'up':
+        hasScrollingSpace = scrollTop > 0;
+        if (hasScrollingSpace) {
+          return true;
+        }
+        break;
+    }
+    return false;
+  }
 
-});
+  /**
+   * Returns the vertical direction of scroll.
+   *
+   * @param {JQuery.Event} event
+   * @returns {string} 'none' | 'up' | 'down'
+   */
+  _getScrollDirection(event) {
+    var deltaY = this._getScrollDelta(event);
+    if (deltaY === 0) {
+      return 'none';
+    }
+    return deltaY > 0 ? 'up' : 'down';
+  }
+
+  /**
+   * Returns the number of pixels which is intended to be scrolled.
+   *
+   * @param {JQuery.Event} event
+   * @returns {number}
+   */
+  _getScrollDelta(event) {
+    var deltaY = 0;
+    var isTouchEvent = event.type === 'touchmove';
+    var originalEvent = event.originalEvent;
+    if (isTouchEvent) {
+      // Touch events
+      // iOS previous + current scroll pos
+      var startOriginalEvent = this._touchStartEventObject.originalEvent;
+      var currentY = originalEvent.pageY;
+      var previousY = startOriginalEvent.pageY;
+      if (currentY === 0 || currentY === previousY) {
+        // Android chrome current scroll pos
+        currentY = originalEvent.touches[0].pageY;
+        previousY = startOriginalEvent.touches[0].pageY;
+      }
+      // Touch: delta calculated from touchstart pos vs touchmove pos
+      deltaY = currentY - previousY;
+    } else {
+      // Mouse events
+      var hasDeltaY = (originalEvent.wheelDeltaY || originalEvent.deltaY !== undefined);
+      if (hasDeltaY) {
+        // Desktop: Firefox & IE delta inverted
+        deltaY = -originalEvent.deltaY;
+      } else {
+        // Desktop: Chrome & Safari wheel delta
+        deltaY = (originalEvent.wheelDelta || 0);
+      }
+    }
+    return deltaY;
+  }
+
+  /**
+   * Stop listening for events to block.
+   */
+  _stop() {
+    if (!this._isRunning) {
+      return;
+    }
+    this._isRunning = false;
+    window.removeEventListener('touchstart', this._onTouchStart); // mobile
+    window.removeEventListener('touchend', this._onTouchEnd); // mobile
+    // shouldn't need to supply 3rd arg when removing, but IE11 won't remove the event listener if you don't - see https://github.com/adaptlearning/adapt_framework/issues/2466
+    window.removeEventListener('touchmove', this._onScrollEvent, { passive: false }); // mobile
+    window.removeEventListener('wheel', this._onScrollEvent, { passive: false });
+    document.removeEventListener('wheel', this._onScrollEvent, { passive: false });
+    document.removeEventListener('keydown', this._onKeyDown);
+  }
+
+}

--- a/src/core/js/a11y/scroll.js
+++ b/src/core/js/a11y/scroll.js
@@ -123,7 +123,7 @@ export default class Scroll extends Backbone.Controller {
     if (!this._preventScrollOnKeys[event.keyCode]) {
       return;
     }
-    var $target = $(event.target);
+    const $target = $(event.target);
     if ($target.is(this._ignoreKeysOnElementsMatching)) {
       return;
     }
@@ -136,16 +136,16 @@ export default class Scroll extends Backbone.Controller {
    * @param {JQuery.Event} event
    */
   _preventScroll(event) {
-    var isGesture = (event.touches && event.touches.length > 1);
+    const isGesture = (event.touches && event.touches.length > 1);
     if (isGesture) {
       // allow multiple finger gestures through
       // this will unfortunately allow two finger background scrolling on mobile devices
       // one finger background scrolling will still be disabled
       return;
     }
-    var $target = $(event.target);
+    const $target = $(event.target);
     if (this._scrollDisabledElements.length) {
-      var scrollingParent = this._getScrollingParent(event, $target);
+      const scrollingParent = this._getScrollingParent(event, $target);
       if (scrollingParent.filter(this._scrollDisabledElements).length === 0) {
         this.$window.scroll();
         return;
@@ -162,18 +162,18 @@ export default class Scroll extends Backbone.Controller {
    * @param {Object} $target jQuery element object.
    */
   _getScrollingParent(event, $target) {
-    var isTouchEvent = event.type === 'touchmove';
-    var hasTouchStartEvent = (this._touchStartEventObject && this._touchStartEventObject.originalEvent);
+    const isTouchEvent = event.type === 'touchmove';
+    const hasTouchStartEvent = (this._touchStartEventObject && this._touchStartEventObject.originalEvent);
     if (isTouchEvent && !hasTouchStartEvent) {
       return $target;
     }
-    var directionY = this._getScrollDirection(event);
+    const directionY = this._getScrollDirection(event);
     if (directionY === 'none') {
       return this.$body;
     }
-    var parents = $target.parents();
-    for (var i = 0, l = parents.length; i < l; i++) {
-      var $parent = $(parents[i]);
+    const parents = $target.parents();
+    for (let i = 0, l = parents.length; i < l; i++) {
+      const $parent = $(parents[i]);
       if ($parent.is('body')) {
         return this.$body;
       }
@@ -195,11 +195,11 @@ export default class Scroll extends Backbone.Controller {
    * @returns {boolean}
    */
   _isScrollable($target) {
-    var scrollType = $target.css('overflow-y');
+    const scrollType = $target.css('overflow-y');
     if (scrollType !== 'auto' && scrollType !== 'scroll') {
       return false;
     }
-    var pointerEvents = $target.css('pointer-events');
+    const pointerEvents = $target.css('pointer-events');
     if (pointerEvents === 'none') {
       return false;
     }
@@ -215,10 +215,10 @@ export default class Scroll extends Backbone.Controller {
    * @returns {boolean}
    */
   _isScrolling($target, directionY) {
-    var scrollTop = Math.ceil($target.scrollTop());
-    var innerHeight = $target.outerHeight();
-    var scrollHeight = $target[0].scrollHeight;
-    var hasScrollingSpace = false;
+    const scrollTop = Math.ceil($target.scrollTop());
+    const innerHeight = $target.outerHeight();
+    const scrollHeight = $target[0].scrollHeight;
+    let hasScrollingSpace = false;
     switch (directionY) {
       case 'down':
         hasScrollingSpace = scrollTop + innerHeight < scrollHeight;
@@ -243,7 +243,7 @@ export default class Scroll extends Backbone.Controller {
    * @returns {string} 'none' | 'up' | 'down'
    */
   _getScrollDirection(event) {
-    var deltaY = this._getScrollDelta(event);
+    const deltaY = this._getScrollDelta(event);
     if (deltaY === 0) {
       return 'none';
     }
@@ -257,15 +257,15 @@ export default class Scroll extends Backbone.Controller {
    * @returns {number}
    */
   _getScrollDelta(event) {
-    var deltaY = 0;
-    var isTouchEvent = event.type === 'touchmove';
-    var originalEvent = event.originalEvent;
+    let deltaY = 0;
+    const isTouchEvent = event.type === 'touchmove';
+    const originalEvent = event.originalEvent;
     if (isTouchEvent) {
       // Touch events
       // iOS previous + current scroll pos
-      var startOriginalEvent = this._touchStartEventObject.originalEvent;
-      var currentY = originalEvent.pageY;
-      var previousY = startOriginalEvent.pageY;
+      const startOriginalEvent = this._touchStartEventObject.originalEvent;
+      let currentY = originalEvent.pageY;
+      let previousY = startOriginalEvent.pageY;
       if (currentY === 0 || currentY === previousY) {
         // Android chrome current scroll pos
         currentY = originalEvent.touches[0].pageY;
@@ -275,7 +275,7 @@ export default class Scroll extends Backbone.Controller {
       deltaY = currentY - previousY;
     } else {
       // Mouse events
-      var hasDeltaY = (originalEvent.wheelDeltaY || originalEvent.deltaY !== undefined);
+      const hasDeltaY = (originalEvent.wheelDeltaY || originalEvent.deltaY !== undefined);
       if (hasDeltaY) {
         // Desktop: Firefox & IE delta inverted
         deltaY = -originalEvent.deltaY;

--- a/src/core/js/a11y/scroll.js
+++ b/src/core/js/a11y/scroll.js
@@ -5,7 +5,10 @@
 export default class Scroll extends Backbone.Controller {
 
   initialize() {
-    _.bindAll(this, '_onTouchStart', '_onTouchEnd', '_onScrollEvent', '_onKeyDown');
+    this._onTouchStart = this._onTouchStart.bind(this);
+    this._onTouchEnd = this._onTouchEnd.bind(this);
+    this._onScrollEvent = this._onScrollEvent.bind(this);
+    this._onKeyDown = this._onKeyDown.bind(this);
     this._scrollDisabledElements = $([]);
     this.$window = $(window);
     this.$body = $('body');

--- a/src/core/js/a11y/wrapFocus.js
+++ b/src/core/js/a11y/wrapFocus.js
@@ -14,7 +14,7 @@ export default class WrapFocus extends Backbone.Controller {
   }
 
   _attachEventListeners() {
-    var config = Adapt.a11y.config;
+    const config = Adapt.a11y.config;
     $('body').on('click focus', config._options._focusguard, this._onWrapAround);
   }
 
@@ -25,7 +25,7 @@ export default class WrapFocus extends Backbone.Controller {
    * @param {JQuery.Event} event
    */
   _onWrapAround(event) {
-    var config = Adapt.a11y.config;
+    const config = Adapt.a11y.config;
     if (!config._isEnabled || !config._options._isPopupWrapFocusEnabled) {
       return;
     }

--- a/src/core/js/a11y/wrapFocus.js
+++ b/src/core/js/a11y/wrapFocus.js
@@ -1,43 +1,37 @@
-define([
-  'core/js/adapt'
-], function(Adapt) {
+import Adapt from 'core/js/adapt';
+
+/**
+ * Controller for managing tab wrapping for popups.
+ * @class
+ */
+export default class WrapFocus extends Backbone.Controller {
+
+  initialize() {
+    _.bindAll(this, '_onWrapAround');
+    this.listenTo(Adapt, {
+      'accessibility:ready': this._attachEventListeners
+    });
+  }
+
+  _attachEventListeners() {
+    var config = Adapt.a11y.config;
+    $('body').on('click focus', config._options._focusguard, this._onWrapAround);
+  }
 
   /**
-   * Controller for managing tab wrapping for popups.
-   * @class
+   * If click or focus is received on any element with the focusguard class,
+   * loop focus around to the top of the document.
+   *
+   * @param {JQuery.Event} event
    */
-  var WrapFocus = Backbone.Controller.extend({
-
-    initialize: function() {
-      _.bindAll(this, '_onWrapAround');
-      this.listenTo(Adapt, {
-        'accessibility:ready': this._attachEventListeners
-      });
-    },
-
-    _attachEventListeners: function() {
-      var config = Adapt.a11y.config;
-      $('body').on('click focus', config._options._focusguard, this._onWrapAround);
-    },
-
-    /**
-     * If click or focus is received on any element with the focusguard class,
-     * loop focus around to the top of the document.
-     *
-     * @param {JQuery.Event} event
-     */
-    _onWrapAround: function(event) {
-      var config = Adapt.a11y.config;
-      if (!config._isEnabled || !config._options._isPopupWrapFocusEnabled) {
-        return;
-      }
-      event.preventDefault();
-      event.stopPropagation();
-      Adapt.a11y.focusFirst('body', { defer: false });
+  _onWrapAround(event) {
+    var config = Adapt.a11y.config;
+    if (!config._isEnabled || !config._options._isPopupWrapFocusEnabled) {
+      return;
     }
+    event.preventDefault();
+    event.stopPropagation();
+    Adapt.a11y.focusFirst('body', { defer: false });
+  }
 
-  });
-
-  return WrapFocus;
-
-});
+}

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -1,19 +1,15 @@
-define([
-  'core/js/adapt',
-  './a11y'
-], function(Adapt, a11y) {
+import Adapt from 'core/js/adapt';
+import a11y from 'core/js/a11y';
 
-  /**
-   * Backwards compatibility `Adapt.accessibility` reroutes to `Adapt.a11y`
-   * with a warning.
-   */
-  Object.defineProperty(Adapt, 'accessibility', {
+/**
+ * Backwards compatibility `Adapt.accessibility` reroutes to `Adapt.a11y`
+ * with a warning.
+ */
+Object.defineProperty(Adapt, 'accessibility', {
 
-    get: function() {
-      a11y.log.deprecated('Adapt.accessibility has moved to Adapt.a11y');
-      return (Adapt.accessibility = a11y);
-    }
-
-  });
+  get: function() {
+    a11y.log.deprecated('Adapt.accessibility has moved to Adapt.a11y');
+    return (Adapt.accessibility = a11y);
+  }
 
 });

--- a/src/core/js/accessibility.js
+++ b/src/core/js/accessibility.js
@@ -7,9 +7,9 @@ import a11y from 'core/js/a11y';
  */
 Object.defineProperty(Adapt, 'accessibility', {
 
-  get: function() {
+  get() {
     a11y.log.deprecated('Adapt.accessibility has moved to Adapt.a11y');
-    return (Adapt.accessibility = a11y);
+    return a11y;
   }
 
 });

--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -214,10 +214,10 @@ class AdaptSingleton extends LockingModel {
     }
     if (nameModelViewOrData instanceof Backbone.View) {
       let foundName;
-      _.find(this.store, (entry, name) => {
+      Object.entries(this.store).forEach(([key, entry]) => {
         if (!entry || !entry.view) return;
         if (!(nameModelViewOrData instanceof entry.view)) return;
-        foundName = name;
+        foundName = key;
         return true;
       });
       return foundName;

--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -1,7 +1,7 @@
 import Wait from 'core/js/wait';
-import 'core/js/models/lockingModel';
+import LockingModel from 'core/js/models/lockingModel';
 
-class AdaptSingleton extends Backbone.Model {
+class AdaptSingleton extends LockingModel {
 
   initialize() {
     this.loadScript = window.__loadScript;

--- a/src/core/js/childEvent.js
+++ b/src/core/js/childEvent.js
@@ -1,104 +1,98 @@
-define([
-  'core/js/adapt'
-], function(Adapt) {
+import Adapt from 'core/js/adapt';
+
+/**
+ * Event object triggered for controlling child view rendering.
+ * Sent with 'view:addChild' and 'view:requestChild' events.
+ * All plugins receive the same object reference in their event handler and
+ * as such, this object becomes a place of consensus for plugins to decide how
+ * to handle rendering for this child.
+ */
+export default class ChildEvent extends Backbone.Controller {
 
   /**
-   * Event object triggered for controlling child view rendering.
-   * Sent with 'view:addChild' and 'view:requestChild' events.
-   * All plugins receive the same object reference in their event handler and
-   * as such, this object becomes a place of consensus for plugins to decide how
-   * to handle rendering for this child.
+   * @param {string} type Event type
+   * @param {AdaptView} target Parent view
+   * @param {AdaptModel} model Child model
    */
-  class ChildEvent extends Backbone.Controller {
-
-    /**
-     * @param {string} type Event type
-     * @param {AdaptView} target Parent view
-     * @param {AdaptModel} model Child model
-     */
-    initialize(type, target, model) {
-      /** @type {string} */
-      this.type = type;
-      /** @type {AdaptView} */
-      this.target = target;
-      /** @type {boolean} Force the child model to render */
-      this.isForced = false;
-      /** @type {boolean} Stop rendering before the child model */
-      this.isStoppedImmediate = false;
-      /** @type {boolean} Stop rendering after the child model */
-      this.isStoppedNext = false;
-      /** @type {boolean} Contains a model to render in response to a requestChild event */
-      this.hasRequestChild = false;
-      this._model = model;
-    }
-
-    /**
-     * Get the model to be rendered.
-     * @returns {AdaptModel}
-     */
-    get model() {
-      return this._model;
-    }
-
-    /**
-     * Set the model to render in response to a 'view:requestChild' event.
-     * @param {AdaptModel}
-     */
-    set model(model) {
-      if (this.type !== 'requestChild') {
-        Adapt.log.warn(`Cannot change model in ${this.type} event.`);
-        return;
-      }
-      if (this._model) {
-        Adapt.log.warn(`Cannot inject two models in one sitting. ${model.get('_id')} attempts to overwrite ${this._model.get('_id')}`);
-        return;
-      }
-      this._model = model;
-      this.hasRequestChild = true;
-    }
-
-    /**
-     * Reset all render stops.
-     */
-    reset() {
-      this.isStoppedImmediate = false;
-      this.isStoppedNext = false;
-    }
-
-    /**
-     * Force model to render.
-     */
-    force() {
-      this.isForced = true;
-    }
-
-    /**
-     * General stop. Stop immediately or stop next with flag to false.
-     * @param {boolean} [immediate=true] Flag to stop immediate or next.
-     */
-    stop(immediate = true) {
-      if (!immediate) {
-        return this.stopNext();
-      }
-      this.isStoppedImmediate = true;
-    }
-
-    /**
-     * Shortcut to stop(false). Stop the render after the contained model is rendered.
-     */
-    stopNext() {
-      this.isStoppedNext = true;
-    }
-
-    /**
-     * Trigger an event to signify that a final decision has been reached.
-     */
-    close() {
-      this.trigger('closed');
-    }
-
+  initialize(type, target, model) {
+    /** @type {string} */
+    this.type = type;
+    /** @type {AdaptView} */
+    this.target = target;
+    /** @type {boolean} Force the child model to render */
+    this.isForced = false;
+    /** @type {boolean} Stop rendering before the child model */
+    this.isStoppedImmediate = false;
+    /** @type {boolean} Stop rendering after the child model */
+    this.isStoppedNext = false;
+    /** @type {boolean} Contains a model to render in response to a requestChild event */
+    this.hasRequestChild = false;
+    this._model = model;
   }
 
-  return ChildEvent;
+  /**
+   * Get the model to be rendered.
+   * @returns {AdaptModel}
+   */
+  get model() {
+    return this._model;
+  }
 
-});
+  /**
+   * Set the model to render in response to a 'view:requestChild' event.
+   * @param {AdaptModel}
+   */
+  set model(model) {
+    if (this.type !== 'requestChild') {
+      Adapt.log.warn(`Cannot change model in ${this.type} event.`);
+      return;
+    }
+    if (this._model) {
+      Adapt.log.warn(`Cannot inject two models in one sitting. ${model.get('_id')} attempts to overwrite ${this._model.get('_id')}`);
+      return;
+    }
+    this._model = model;
+    this.hasRequestChild = true;
+  }
+
+  /**
+   * Reset all render stops.
+   */
+  reset() {
+    this.isStoppedImmediate = false;
+    this.isStoppedNext = false;
+  }
+
+  /**
+   * Force model to render.
+   */
+  force() {
+    this.isForced = true;
+  }
+
+  /**
+   * General stop. Stop immediately or stop next with flag to false.
+   * @param {boolean} [immediate=true] Flag to stop immediate or next.
+   */
+  stop(immediate = true) {
+    if (!immediate) {
+      return this.stopNext();
+    }
+    this.isStoppedImmediate = true;
+  }
+
+  /**
+   * Shortcut to stop(false). Stop the render after the contained model is rendered.
+   */
+  stopNext() {
+    this.isStoppedNext = true;
+  }
+
+  /**
+   * Trigger an event to signify that a final decision has been reached.
+   */
+  close() {
+    this.trigger('closed');
+  }
+
+}

--- a/src/core/js/collections/adaptCollection.js
+++ b/src/core/js/collections/adaptCollection.js
@@ -1,19 +1,13 @@
-define([
-  'core/js/adapt'
-], function(Adapt) {
+import Adapt from 'core/js/adapt';
 
-  class AdaptCollection extends Backbone.Collection {
+export default class AdaptCollection extends Backbone.Collection {
 
-    initialize(models, options) {
-      this.once('reset', this.loadedData, this);
-    }
-
-    loadedData() {
-      Adapt.trigger('adaptCollection:dataLoaded');
-    }
-
+  initialize(models, options) {
+    this.once('reset', this.loadedData, this);
   }
 
-  return AdaptCollection;
+  loadedData() {
+    Adapt.trigger('adaptCollection:dataLoaded');
+  }
 
-});
+}

--- a/src/core/js/collections/adaptSubsetCollection.js
+++ b/src/core/js/collections/adaptSubsetCollection.js
@@ -1,22 +1,16 @@
-define([
-  './adaptCollection'
-], function(AdaptCollection) {
+import AdaptCollection from 'core/js/collections/adaptCollection';
 
-  class AdaptSubsetCollection extends AdaptCollection {
+export default class AdaptSubsetCollection extends AdaptCollection {
 
-    initialize(models, options) {
-      super.initialize(models, options);
-      this.parent = options.parent;
-      this.listenTo(this.parent, 'reset', this.loadSubset);
-    }
-
-    loadSubset() {
-      this.set(this.parent.filter(model => model instanceof this.model));
-      this._byAdaptID = this.groupBy('_id');
-    }
-
+  initialize(models, options) {
+    super.initialize(models, options);
+    this.parent = options.parent;
+    this.listenTo(this.parent, 'reset', this.loadSubset);
   }
 
-  return AdaptSubsetCollection;
+  loadSubset() {
+    this.set(this.parent.filter(model => model instanceof this.model));
+    this._byAdaptID = this.groupBy('_id');
+  }
 
-});
+}

--- a/src/core/js/collections/notifyPushCollection.js
+++ b/src/core/js/collections/notifyPushCollection.js
@@ -1,53 +1,49 @@
-define([
-  'core/js/adapt',
-  'core/js/views/notifyPushView',
-  'core/js/models/notifyModel'
-], function(Adapt, NotifyPushView, NotifyModel) {
+import Adapt from 'core/js/adapt';
+import NotifyPushView from 'core/js/views/notifyPushView';
+import NotifyModel from 'core/js/models/notifyModel';
 
-  // Build a collection to store push notifications
-  var NotifyPushCollection = Backbone.Collection.extend({
+// Build a collection to store push notifications
+export default class NotifyPushCollection extends Backbone.Collection {
 
-    model: NotifyModel,
+  model() {
+    return NotifyModel;
+  }
 
-    initialize: function() {
-      this.listenTo(this, 'add', this.onPushAdded);
-      this.listenTo(Adapt, 'notify:pushRemoved', this.onRemovePush);
-    },
+  initialize() {
+    this.listenTo(this, 'add', this.onPushAdded);
+    this.listenTo(Adapt, 'notify:pushRemoved', this.onRemovePush);
+  }
 
-    onPushAdded: function(model) {
-      this.checkPushCanShow(model);
-    },
+  onPushAdded(model) {
+    this.checkPushCanShow(model);
+  }
 
-    checkPushCanShow: function(model) {
-      if (this.canShowPush()) {
-        model.set('_isActive', true);
-        this.showPush(model);
-      }
-    },
-
-    canShowPush: function() {
-      var availablePushNotifications = this.where({ _isActive: true });
-      if (availablePushNotifications.length >= 2) {
-        return false;
-      }
-      return true;
-    },
-
-    showPush: function(model) {
-      new NotifyPushView({
-        model: model
-      });
-    },
-
-    onRemovePush: function(view) {
-      var inactivePushNotifications = this.where({ _isActive: false });
-      if (inactivePushNotifications.length > 0) {
-        this.checkPushCanShow(inactivePushNotifications[0]);
-      }
+  checkPushCanShow(model) {
+    if (this.canShowPush()) {
+      model.set('_isActive', true);
+      this.showPush(model);
     }
+  }
 
-  });
+  canShowPush() {
+    var availablePushNotifications = this.where({ _isActive: true });
+    if (availablePushNotifications.length >= 2) {
+      return false;
+    }
+    return true;
+  }
 
-  return NotifyPushCollection;
+  showPush(model) {
+    new NotifyPushView({
+      model: model
+    });
+  }
 
-});
+  onRemovePush(view) {
+    var inactivePushNotifications = this.where({ _isActive: false });
+    if (inactivePushNotifications.length > 0) {
+      this.checkPushCanShow(inactivePushNotifications[0]);
+    }
+  }
+
+}

--- a/src/core/js/collections/notifyPushCollection.js
+++ b/src/core/js/collections/notifyPushCollection.js
@@ -25,7 +25,7 @@ export default class NotifyPushCollection extends Backbone.Collection {
   }
 
   canShowPush() {
-    var availablePushNotifications = this.where({ _isActive: true });
+    const availablePushNotifications = this.where({ _isActive: true });
     return (availablePushNotifications.length < 2);
   }
 
@@ -36,7 +36,7 @@ export default class NotifyPushCollection extends Backbone.Collection {
   }
 
   onRemovePush(view) {
-    var inactivePushNotifications = this.where({ _isActive: false });
+    const inactivePushNotifications = this.where({ _isActive: false });
     if (inactivePushNotifications.length > 0) {
       this.checkPushCanShow(inactivePushNotifications[0]);
     }

--- a/src/core/js/collections/notifyPushCollection.js
+++ b/src/core/js/collections/notifyPushCollection.js
@@ -19,18 +19,14 @@ export default class NotifyPushCollection extends Backbone.Collection {
   }
 
   checkPushCanShow(model) {
-    if (this.canShowPush()) {
-      model.set('_isActive', true);
-      this.showPush(model);
-    }
+    if (!this.canShowPush()) return;
+    model.set('_isActive', true);
+    this.showPush(model);
   }
 
   canShowPush() {
     var availablePushNotifications = this.where({ _isActive: true });
-    if (availablePushNotifications.length >= 2) {
-      return false;
-    }
-    return true;
+    return (availablePushNotifications.length < 2);
   }
 
   showPush(model) {

--- a/src/core/js/collections/notifyPushCollection.js
+++ b/src/core/js/collections/notifyPushCollection.js
@@ -5,11 +5,8 @@ import NotifyModel from 'core/js/models/notifyModel';
 // Build a collection to store push notifications
 export default class NotifyPushCollection extends Backbone.Collection {
 
-  model() {
-    return NotifyModel;
-  }
-
   initialize() {
+    this.model = NotifyModel;
     this.listenTo(this, 'add', this.onPushAdded);
     this.listenTo(Adapt, 'notify:pushRemoved', this.onRemovePush);
   }

--- a/src/core/js/data.js
+++ b/src/core/js/data.js
@@ -1,216 +1,213 @@
-define([
-  'core/js/adapt',
-  'core/js/collections/adaptCollection',
-  'core/js/models/buildModel',
-  'core/js/models/configModel',
-  'core/js/models/courseModel',
-  'core/js/models/lockingModel',
-  'core/js/startController'
-], function(Adapt, AdaptCollection, BuildModel, ConfigModel, CourseModel) {
+import Adapt from 'core/js/adapt';
+import AdaptCollection from 'core/js/collections/adaptCollection';
+import BuildModel from 'core/js/models/buildModel';
+import ConfigModel from 'core/js/models/configModel';
 
-  class Data extends AdaptCollection {
+import 'core/js/models/courseModel';
+import 'core/js/models/lockingModel';
+import 'core/js/startController';
 
-    model(json) {
-      const ModelClass = Adapt.getModelClass(json);
-      if (!ModelClass) {
-        return new Backbone.Model(json);
-      }
-      return new ModelClass(json, { parse: true });
+class Data extends AdaptCollection {
+
+  model(json) {
+    const ModelClass = Adapt.getModelClass(json);
+    if (!ModelClass) {
+      return new Backbone.Model(json);
     }
+    return new ModelClass(json, { parse: true });
+  }
 
-    initialize() {
-      super.initialize();
-      this.on({
-        'add': this.onAdded,
-        'remove': this.onRemoved
-      });
+  initialize() {
+    super.initialize();
+    this.on({
+      'add': this.onAdded,
+      'remove': this.onRemoved
+    });
+  }
+
+  async init () {
+    this.reset();
+    this._byAdaptID = {};
+    Adapt.build = new BuildModel(null, { url: 'adapt/js/build.min.js', reset: true });
+    await Adapt.build.whenReady();
+    $('html').attr('data-adapt-framework-version', Adapt.build.get('package').version);
+    this.loadConfigData();
+  }
+
+  onAdded(model) {
+    this._byAdaptID[model.get('_id')] = model;
+  }
+
+  onRemoved(model) {
+    delete this._byAdaptID[model.get('_id')];
+  }
+
+  loadConfigData() {
+    Adapt.config = new ConfigModel(null, { url: 'course/config.' + Adapt.build.get('jsonext'), reset: true });
+    this.listenToOnce(Adapt, 'configModel:loadCourseData', this.onLoadCourseData);
+    this.listenTo(Adapt.config, {
+      'change:_activeLanguage': this.onLanguageChange,
+      'change:_defaultDirection': this.onDirectionChange
+    });
+  }
+
+  onDirectionChange(model, direction) {
+    if (direction === 'rtl') {
+      $('html').removeClass('dir-ltr').addClass('dir-rtl').attr('dir', 'rtl');
+    } else {
+      $('html').removeClass('dir-rtl').addClass('dir-ltr').attr('dir', 'ltr');
     }
+  }
 
-    async init () {
-      this.reset();
-      this._byAdaptID = {};
-      Adapt.build = new BuildModel(null, { url: 'adapt/js/build.min.js', reset: true });
-      await Adapt.build.whenReady();
-      $('html').attr('data-adapt-framework-version', Adapt.build.get('package').version);
-      this.loadConfigData();
+  /**
+   * Before we actually go to load the course data, we first need to check to see if a language has been set
+   * If it has we can go ahead and start loading; if it hasn't, apply the defaultLanguage from config.json
+   */
+  onLoadCourseData() {
+    if (!Adapt.config.get('_activeLanguage')) {
+      Adapt.config.set('_activeLanguage', Adapt.config.get('_defaultLanguage'));
+      return;
     }
+    this.loadCourseData();
+  }
 
-    onAdded(model) {
-      this._byAdaptID[model.get('_id')] = model;
+  onLanguageChange(model, language) {
+    Adapt.offlineStorage.set('lang', language);
+    // set `_isStarted` back to `false` when changing language so that the learner's answers
+    // to questions get restored in the new language when `_restoreStateOnLanguageChange: true`
+    // see https://github.com/adaptlearning/adapt_framework/issues/2977
+    if (Adapt.get('_isStarted')) {
+      Adapt.set('_isStarted', false);
     }
+    this.loadCourseData(language);
+  }
 
-    onRemoved(model) {
-      delete this._byAdaptID[model.get('_id')];
-    }
+  async loadCourseData(newLanguage) {
 
-    loadConfigData() {
-      Adapt.config = new ConfigModel(null, { url: 'course/config.' + Adapt.build.get('jsonext'), reset: true });
-      this.listenToOnce(Adapt, 'configModel:loadCourseData', this.onLoadCourseData);
-      this.listenTo(Adapt.config, {
-        'change:_activeLanguage': this.onLanguageChange,
-        'change:_defaultDirection': this.onDirectionChange
-      });
-    }
+    // All code that needs to run before adapt starts should go here
+    const language = Adapt.config.get('_activeLanguage');
+    const courseFolder = 'course/' + language + '/';
 
-    onDirectionChange(model, direction) {
-      if (direction === 'rtl') {
-        $('html').removeClass('dir-ltr').addClass('dir-rtl').attr('dir', 'rtl');
-      } else {
-        $('html').removeClass('dir-rtl').addClass('dir-ltr').attr('dir', 'ltr');
-      }
-    }
+    $('html').attr('lang', language);
 
-    /**
-     * Before we actually go to load the course data, we first need to check to see if a language has been set
-     * If it has we can go ahead and start loading; if it hasn't, apply the defaultLanguage from config.json
-     */
-    onLoadCourseData() {
-      if (!Adapt.config.get('_activeLanguage')) {
-        Adapt.config.set('_activeLanguage', Adapt.config.get('_defaultLanguage'));
-        return;
-      }
-      this.loadCourseData();
-    }
-
-    onLanguageChange(model, language) {
-      Adapt.offlineStorage.set('lang', language);
-      // set `_isStarted` back to `false` when changing language so that the learner's answers
-      // to questions get restored in the new language when `_restoreStateOnLanguageChange: true`
-      // see https://github.com/adaptlearning/adapt_framework/issues/2977
-      if (Adapt.get('_isStarted')) {
-        Adapt.set('_isStarted', false);
-      }
-      this.loadCourseData(language);
-    }
-
-    async loadCourseData(newLanguage) {
-
-      // All code that needs to run before adapt starts should go here
-      const language = Adapt.config.get('_activeLanguage');
-      const courseFolder = 'course/' + language + '/';
-
-      $('html').attr('lang', language);
-
-      await this.loadManifestFiles(courseFolder);
-      await this.triggerDataLoaded();
-      await this.triggerDataReady(newLanguage);
-      this.triggerInit();
-
-    }
-
-    getJSON(path) {
-      return new Promise((resolve, reject) => {
-        $.getJSON(path, data => {
-          // Add path to data incase it's necessary later
-          data.__path__ = path;
-          resolve(data);
-        }).fail(reject);
-      });
-    }
-
-    async loadManifestFiles(languagePath) {
-      this.trigger('loading');
-      this.reset();
-      const manifestPath = languagePath + 'language_data_manifest.js';
-      let manifest;
-      try {
-        manifest = await this.getJSON(manifestPath);
-      } catch (err) {
-        manifest = ['course.json', 'contentObjects.json', 'articles.json', 'blocks.json', 'components.json'];
-        Adapt.log.warnOnce(`Manifest path '${manifestPath} not found. Using traditional files: ${manifest.join(', ')}`);
-      }
-      const allFileData = await Promise.all(manifest.map(filePath => {
-        return this.getJSON(`${languagePath}${filePath}`);
-      }));
-      // Flatten all file data into a single array of model data
-      const allModelData = allFileData.reduce((result, fileData) => {
-        if (Array.isArray(fileData)) {
-          result.push(...fileData);
-        } else if (fileData instanceof Object) {
-          result.push(fileData);
-        } else {
-          Adapt.log.warnOnce(`File data isn't an array or object: ${fileData.__path__}`);
-        }
-        return result;
-      }, []);
-      // Add course model first to allow other model/views to utilize its settings
-      const course = allModelData.find(modelData => modelData._type === 'course');
-      if (!course) {
-        throw new Error(`Expected a model data with "_type": "course", none found.`);
-      }
-      Adapt.trigger('courseModel:dataLoading');
-      Adapt.course = this.push(course);
-      Adapt.trigger('courseModel:dataLoaded');
-      // Add other models
-      allModelData.forEach(modelData => {
-        if (modelData._type === 'course') {
-          return;
-        }
-        this.push(modelData);
-      });
-      this.trigger('reset');
-      this.trigger('loaded');
-      await Adapt.wait.queue();
-    }
-
-    async triggerDataLoaded() {
-      Adapt.log.debug('Firing app:dataLoaded');
-      try {
-        // Setup the newly added models
-        this.forEach(model => model.setupModel && model.setupModel());
-        Adapt.trigger('app:dataLoaded');
-      } catch (e) {
-        Adapt.log.error('Error during app:dataLoading trigger', e);
-      }
-      await Adapt.wait.queue();
-    }
-
-    async triggerDataReady(newLanguage) {
-      if (newLanguage) {
-        Adapt.trigger('app:languageChanged', newLanguage);
-        _.defer(() => {
-          Adapt.startController.loadCourseData();
-          const hash = Adapt.startController.isEnabled() ? Adapt.startController.getStartHash(true) : '#/';
-          Adapt.router.navigate(hash, { trigger: true, replace: true });
-        });
-      }
-      Adapt.log.debug('Firing app:dataReady');
-      try {
-        Adapt.trigger('app:dataReady');
-      } catch (e) {
-        Adapt.log.error('Error during app:dataReady trigger', e);
-      }
-      await Adapt.wait.queue();
-    }
-
-    triggerInit() {
-      this.isReady = true;
-      this.trigger('ready');
-    }
-
-    whenReady() {
-      if (this.isReady) return Promise.resolve();
-      return new Promise(resolve => {
-        this.once('ready', resolve);
-      });
-    }
-
-    /**
-     * Looks up a model by its `_id` property
-     * @param {string} id The id of the item e.g. "co-05"
-     * @return {Backbone.Model}
-     */
-    findById(id) {
-      const model = this._byAdaptID[id];
-      if (!model) {
-        console.warn(`Adapt.findById() unable to find collection type for id: ${id}`);
-        return;
-      }
-      return model;
-    }
+    await this.loadManifestFiles(courseFolder);
+    await this.triggerDataLoaded();
+    await this.triggerDataReady(newLanguage);
+    this.triggerInit();
 
   }
 
-  return (Adapt.data = new Data());
+  getJSON(path) {
+    return new Promise((resolve, reject) => {
+      $.getJSON(path, data => {
+        // Add path to data incase it's necessary later
+        data.__path__ = path;
+        resolve(data);
+      }).fail(reject);
+    });
+  }
 
-});
+  async loadManifestFiles(languagePath) {
+    this.trigger('loading');
+    this.reset();
+    const manifestPath = languagePath + 'language_data_manifest.js';
+    let manifest;
+    try {
+      manifest = await this.getJSON(manifestPath);
+    } catch (err) {
+      manifest = ['course.json', 'contentObjects.json', 'articles.json', 'blocks.json', 'components.json'];
+      Adapt.log.warnOnce(`Manifest path '${manifestPath} not found. Using traditional files: ${manifest.join(', ')}`);
+    }
+    const allFileData = await Promise.all(manifest.map(filePath => {
+      return this.getJSON(`${languagePath}${filePath}`);
+    }));
+    // Flatten all file data into a single array of model data
+    const allModelData = allFileData.reduce((result, fileData) => {
+      if (Array.isArray(fileData)) {
+        result.push(...fileData);
+      } else if (fileData instanceof Object) {
+        result.push(fileData);
+      } else {
+        Adapt.log.warnOnce(`File data isn't an array or object: ${fileData.__path__}`);
+      }
+      return result;
+    }, []);
+    // Add course model first to allow other model/views to utilize its settings
+    const course = allModelData.find(modelData => modelData._type === 'course');
+    if (!course) {
+      throw new Error(`Expected a model data with "_type": "course", none found.`);
+    }
+    Adapt.trigger('courseModel:dataLoading');
+    Adapt.course = this.push(course);
+    Adapt.trigger('courseModel:dataLoaded');
+    // Add other models
+    allModelData.forEach(modelData => {
+      if (modelData._type === 'course') {
+        return;
+      }
+      this.push(modelData);
+    });
+    this.trigger('reset');
+    this.trigger('loaded');
+    await Adapt.wait.queue();
+  }
+
+  async triggerDataLoaded() {
+    Adapt.log.debug('Firing app:dataLoaded');
+    try {
+      // Setup the newly added models
+      this.forEach(model => model.setupModel && model.setupModel());
+      Adapt.trigger('app:dataLoaded');
+    } catch (e) {
+      Adapt.log.error('Error during app:dataLoading trigger', e);
+    }
+    await Adapt.wait.queue();
+  }
+
+  async triggerDataReady(newLanguage) {
+    if (newLanguage) {
+      Adapt.trigger('app:languageChanged', newLanguage);
+      _.defer(() => {
+        Adapt.startController.loadCourseData();
+        const hash = Adapt.startController.isEnabled() ? Adapt.startController.getStartHash(true) : '#/';
+        Adapt.router.navigate(hash, { trigger: true, replace: true });
+      });
+    }
+    Adapt.log.debug('Firing app:dataReady');
+    try {
+      Adapt.trigger('app:dataReady');
+    } catch (e) {
+      Adapt.log.error('Error during app:dataReady trigger', e);
+    }
+    await Adapt.wait.queue();
+  }
+
+  triggerInit() {
+    this.isReady = true;
+    this.trigger('ready');
+  }
+
+  whenReady() {
+    if (this.isReady) return Promise.resolve();
+    return new Promise(resolve => {
+      this.once('ready', resolve);
+    });
+  }
+
+  /**
+   * Looks up a model by its `_id` property
+   * @param {string} id The id of the item e.g. "co-05"
+   * @return {Backbone.Model}
+   */
+  findById(id) {
+    const model = this._byAdaptID[id];
+    if (!model) {
+      console.warn(`Adapt.findById() unable to find collection type for id: ${id}`);
+      return;
+    }
+    return model;
+  }
+
+}
+
+export default (Adapt.data = new Data());

--- a/src/core/js/data.js
+++ b/src/core/js/data.js
@@ -2,9 +2,9 @@ import Adapt from 'core/js/adapt';
 import AdaptCollection from 'core/js/collections/adaptCollection';
 import BuildModel from 'core/js/models/buildModel';
 import ConfigModel from 'core/js/models/configModel';
+import LockingModel from 'core/js/models/lockingModel';
 
 import 'core/js/models/courseModel';
-import 'core/js/models/lockingModel';
 import 'core/js/startController';
 
 class Data extends AdaptCollection {
@@ -12,7 +12,7 @@ class Data extends AdaptCollection {
   model(json) {
     const ModelClass = Adapt.getModelClass(json);
     if (!ModelClass) {
-      return new Backbone.Model(json);
+      return new LockingModel(json);
     }
     return new ModelClass(json, { parse: true });
   }

--- a/src/core/js/device.js
+++ b/src/core/js/device.js
@@ -97,16 +97,9 @@ class Device extends Backbone.Controller {
   }
 
   getOperatingSystem() {
-    let os = '';
     const flags = ['windows', 'mac', 'linux', 'windowsphone', 'chromeos', 'android',
       'ios', 'blackberry', 'firefoxos', 'webos', 'bada', 'tizen', 'sailfish'];
-
-    for (let i = 0; i < flags.length; i++) {
-      if (Bowser[flags[i]]) {
-        os = flags[i];
-        break;
-      }
-    }
+    let os = flags.find(name => Bowser[name]) || '';
 
     if (os === '') {
       // Fall back to using navigator.platform in case Bowser can't detect the OS.
@@ -131,17 +124,8 @@ class Device extends Backbone.Controller {
   }
 
   getRenderingEngine() {
-    let engine = '';
     const flags = ['webkit', 'blink', 'gecko', 'msie', 'msedge'];
-
-    for (let i = 0; i < flags.length; i++) {
-      if (Bowser[flags[i]]) {
-        engine = flags[i];
-        break;
-      }
-    }
-
-    return engine;
+    return flags.find(name => Bowser[name]) || '';
   }
 
   onWindowResize() {
@@ -188,18 +172,8 @@ class Device extends Backbone.Controller {
   }
 
   getAppleDeviceType() {
-    let type = '';
-
     const flags = ['iphone', 'ipad', 'ipod'];
-
-    for (let i = 0; i < flags.length; i++) {
-      if (Bowser[flags[i]]) {
-        type = flags[i];
-        break;
-      }
-    }
-
-    return type;
+    return flags.find(name => Bowser[name]) || '';
   }
 
   pixelDensity() {

--- a/src/core/js/device.js
+++ b/src/core/js/device.js
@@ -104,20 +104,11 @@ class Device extends Backbone.Controller {
     if (os === '') {
       // Fall back to using navigator.platform in case Bowser can't detect the OS.
       const platform = navigator.platform;
-      const platforms = ['Win', 'Mac', 'Linux'];
-      os = 'PlatformUnknown';
-
-      for (let j = 0; j < platforms.length; j++) {
-        if (platform.indexOf(platforms[j]) !== -1) {
-          os = platforms[j].toLowerCase();
-          break;
-        }
-      }
-
+      const match = platform.match(/win|mac|linux/i);
+      if (match) os = match[0];
       // Set consistency with the Bowser flags.
-      if (os === 'win') {
-        os = 'windows';
-      }
+      if (os === 'win') os = 'windows';
+      if (!os) os = 'PlatformUnknown';
     }
 
     return os;

--- a/src/core/js/device.js
+++ b/src/core/js/device.js
@@ -103,8 +103,8 @@ class Device extends Backbone.Controller {
 
     if (os === '') {
       // Fall back to using navigator.platform in case Bowser can't detect the OS.
-      const platform = navigator.platform;
-      const match = platform.match(/win|mac|linux/i);
+      const platform = navigator.platform.toLowerCase();
+      const match = platform.match(/win|mac|linux/);
       if (match) os = match[0];
       // Set consistency with the Bowser flags.
       if (os === 'win') os = 'windows';

--- a/src/core/js/device.js
+++ b/src/core/js/device.js
@@ -51,24 +51,24 @@ class Device extends Backbone.Controller {
    * @returns {string} 'large', 'medium' or 'small'
    */
   checkScreenSize() {
-    var screenSizeConfig = Adapt.config.get('screenSize');
-    var screenSize;
+    const screenSizeConfig = Adapt.config.get('screenSize');
+    let screenSize;
 
-    var screensizeEmThreshold = 300;
-    var baseFontSize = 16;
+    const screensizeEmThreshold = 300;
+    const baseFontSize = 16;
 
     // Check to see if the screen size value is larger than the em threshold
     // If value is larger than em threshold, convert value (assumed px) to ems
     // Otherwise assume value is in ems
-    var mediumEmBreakpoint = screenSizeConfig.medium > screensizeEmThreshold
+    const mediumEmBreakpoint = screenSizeConfig.medium > screensizeEmThreshold
       ? screenSizeConfig.medium / baseFontSize
       : screenSizeConfig.medium;
-    var smallEmBreakpoint = screenSizeConfig.small > screensizeEmThreshold
+    const smallEmBreakpoint = screenSizeConfig.small > screensizeEmThreshold
       ? screenSizeConfig.small / baseFontSize
       : screenSizeConfig.small;
 
-    var fontSize = parseFloat($('html').css('font-size'));
-    var screenSizeEmWidth = (this.screenWidth / fontSize);
+    const fontSize = parseFloat($('html').css('font-size'));
+    const screenSizeEmWidth = (this.screenWidth / fontSize);
 
     // Check to see if client screen width is larger than medium em breakpoint
     // If so apply large, otherwise check to see if client screen width is
@@ -97,11 +97,11 @@ class Device extends Backbone.Controller {
   }
 
   getOperatingSystem() {
-    var os = '';
-    var flags = ['windows', 'mac', 'linux', 'windowsphone', 'chromeos', 'android',
+    let os = '';
+    const flags = ['windows', 'mac', 'linux', 'windowsphone', 'chromeos', 'android',
       'ios', 'blackberry', 'firefoxos', 'webos', 'bada', 'tizen', 'sailfish'];
 
-    for (var i = 0; i < flags.length; i++) {
+    for (let i = 0; i < flags.length; i++) {
       if (Bowser[flags[i]]) {
         os = flags[i];
         break;
@@ -110,11 +110,11 @@ class Device extends Backbone.Controller {
 
     if (os === '') {
       // Fall back to using navigator.platform in case Bowser can't detect the OS.
-      var platform = navigator.platform;
-      var platforms = ['Win', 'Mac', 'Linux'];
+      const platform = navigator.platform;
+      const platforms = ['Win', 'Mac', 'Linux'];
       os = 'PlatformUnknown';
 
-      for (var j = 0; j < platforms.length; j++) {
+      for (let j = 0; j < platforms.length; j++) {
         if (platform.indexOf(platforms[j]) !== -1) {
           os = platforms[j].toLowerCase();
           break;
@@ -131,10 +131,10 @@ class Device extends Backbone.Controller {
   }
 
   getRenderingEngine() {
-    var engine = '';
-    var flags = ['webkit', 'blink', 'gecko', 'msie', 'msedge'];
+    let engine = '';
+    const flags = ['webkit', 'blink', 'gecko', 'msie', 'msedge'];
 
-    for (var i = 0; i < flags.length; i++) {
+    for (let i = 0; i < flags.length; i++) {
       if (Bowser[flags[i]]) {
         engine = flags[i];
         break;
@@ -146,8 +146,8 @@ class Device extends Backbone.Controller {
 
   onWindowResize() {
     // Calculate the screen properties.
-    var previousWidth = this.screenWidth;
-    var previousHeight = this.screenHeight;
+    const previousWidth = this.screenWidth;
+    const previousHeight = this.screenHeight;
 
     this.screenWidth = this.getScreenWidth();
     this.screenHeight = this.getScreenHeight();
@@ -157,7 +157,7 @@ class Device extends Backbone.Controller {
       return;
     }
 
-    var newScreenSize = this.checkScreenSize();
+    const newScreenSize = this.checkScreenSize();
 
     if (newScreenSize !== this.screenSize) {
       this.screenSize = newScreenSize;
@@ -188,11 +188,11 @@ class Device extends Backbone.Controller {
   }
 
   getAppleDeviceType() {
-    var type = '';
+    let type = '';
 
-    var flags = ['iphone', 'ipad', 'ipod'];
+    const flags = ['iphone', 'ipad', 'ipod'];
 
-    for (var i = 0; i < flags.length; i++) {
+    for (let i = 0; i < flags.length; i++) {
       if (Bowser[flags[i]]) {
         type = flags[i];
         break;
@@ -203,7 +203,7 @@ class Device extends Backbone.Controller {
   }
 
   pixelDensity() {
-    var pixelDensity = (window.devicePixelRatio || 1);
+    const pixelDensity = (window.devicePixelRatio || 1);
 
     if (pixelDensity >= 3) {
       return 'ultra-high';

--- a/src/core/js/drawer.js
+++ b/src/core/js/drawer.js
@@ -1,32 +1,28 @@
-define([
-  'core/js/adapt',
-  'core/js/views/drawerView'
-], function(Adapt, DrawerView) {
+import Adapt from 'core/js/adapt';
+import DrawerView from 'core/js/views/drawerView';
 
-  var DrawerCollection = new Backbone.Collection(null, { comparator: 'drawerOrder' });
-  var Drawer = {};
+const DrawerCollection = new Backbone.Collection(null, { comparator: 'drawerOrder' });
+const Drawer = {};
 
-  Drawer.addItem = function(drawerObject, eventCallback) {
-    drawerObject.eventCallback = eventCallback;
-    DrawerCollection.add(drawerObject);
-  };
+Drawer.addItem = function(drawerObject, eventCallback) {
+  drawerObject.eventCallback = eventCallback;
+  DrawerCollection.add(drawerObject);
+};
 
-  Drawer.triggerCustomView = function(view, hasBackButton) {
-    if (hasBackButton !== false) {
-      hasBackButton = true;
-    }
-    Adapt.trigger('drawer:triggerCustomView', view, hasBackButton);
-  };
+Drawer.triggerCustomView = function(view, hasBackButton) {
+  if (hasBackButton !== false) {
+    hasBackButton = true;
+  }
+  Adapt.trigger('drawer:triggerCustomView', view, hasBackButton);
+};
 
-  Adapt.on({
-    'adapt:start': function() {
-      new DrawerView({ collection: DrawerCollection });
-    },
-    'app:languageChanged': function() {
-      Adapt.trigger('drawer:remove');
-    }
-  });
-
-  Adapt.drawer = Drawer;
-
+Adapt.on({
+  'adapt:start': function() {
+    new DrawerView({ collection: DrawerCollection });
+  },
+  'app:languageChanged': function() {
+    Adapt.trigger('drawer:remove');
+  }
 });
+
+export default (Adapt.drawer = Drawer);

--- a/src/core/js/drawer.js
+++ b/src/core/js/drawer.js
@@ -17,10 +17,10 @@ Drawer.triggerCustomView = function(view, hasBackButton) {
 };
 
 Adapt.on({
-  'adapt:start': function() {
+  'adapt:start'() {
     new DrawerView({ collection: DrawerCollection });
   },
-  'app:languageChanged': function() {
+  'app:languageChanged'() {
     Adapt.trigger('drawer:remove');
   }
 });

--- a/src/core/js/enums/buttonStateEnum.js
+++ b/src/core/js/enums/buttonStateEnum.js
@@ -1,15 +1,11 @@
-define(function() {
+const BUTTON_STATE = ENUM([
+  'SUBMIT',
+  'CORRECT',
+  'INCORRECT',
+  'SHOW_CORRECT_ANSWER',
+  'HIDE_CORRECT_ANSWER',
+  'SHOW_FEEDBACK',
+  'RESET'
+]);
 
-  var BUTTON_STATE = ENUM([
-    'SUBMIT',
-    'CORRECT',
-    'INCORRECT',
-    'SHOW_CORRECT_ANSWER',
-    'HIDE_CORRECT_ANSWER',
-    'SHOW_FEEDBACK',
-    'RESET'
-  ]);
-
-  return BUTTON_STATE;
-
-});
+export default BUTTON_STATE;

--- a/src/core/js/enums/completionStateEnum.js
+++ b/src/core/js/enums/completionStateEnum.js
@@ -1,12 +1,8 @@
-define(function() {
+const COMPLETION_STATE = ENUM([
+  'INCOMPLETE',
+  'COMPLETED',
+  'PASSED',
+  'FAILED'
+]);
 
-  var COMPLETION_STATE = ENUM([
-    'INCOMPLETE',
-    'COMPLETED',
-    'PASSED',
-    'FAILED'
-  ]);
-
-  return COMPLETION_STATE;
-
-});
+export default COMPLETION_STATE;

--- a/src/core/js/enums/logLevelEnum.js
+++ b/src/core/js/enums/logLevelEnum.js
@@ -1,14 +1,10 @@
-define(function() {
+// Used to determine if log call should be printed based on log level
+const LOG_LEVEL = ENUM([
+  'DEBUG',
+  'INFO',
+  'WARN',
+  'ERROR',
+  'FATAL'
+]);
 
-  // Used to determine if log call should be printed based on log level
-  var LOG_LEVEL = ENUM([
-    'DEBUG',
-    'INFO',
-    'WARN',
-    'ERROR',
-    'FATAL'
-  ]);
-
-  return LOG_LEVEL;
-
-});
+export default LOG_LEVEL;

--- a/src/core/js/fixes.js
+++ b/src/core/js/fixes.js
@@ -1,3 +1,1 @@
-define([
-  './fixes/img.lazyload'
-], function() {});
+import 'core/js/fixes/img.lazyload';

--- a/src/core/js/fixes/img.lazyload.js
+++ b/src/core/js/fixes/img.lazyload.js
@@ -1,38 +1,34 @@
-define([
-  'core/js/adapt',
-  '../templates'
-], function(Adapt) {
+import Adapt from 'core/js/adapt';
+import 'core/js/templates';
 
-  /**
-   * 27 April 2020 https://github.com/adaptlearning/adapt_framework/issues/2734
-   * Chrome on Android defers load events on images when lite mode is enabled
-   * and as part of a data saving technique.
-   *
-   * Add a loading="eager" attribute to all template and partial img tags where
-   * the loading attribute is missing.
-   */
-  Adapt.on('app:dataReady', function() {
-    const config = Adapt.config.get('_fixes');
-    if (config && config._imgLazyLoad === false) return;
-    applyImgLoadingFix();
-  });
-
-  function applyImgLoadingFix() {
-    const findImgTag = /<img([^>]*)>/gi;
-    const hasLoadingAttr = / loading=/gi;
-    Adapt.on('template:postRender partial:postRender', function(event) {
-      const imgTagsFound = event.value.match(findImgTag);
-      if (!imgTagsFound) {
-        return;
-      }
-      event.value = imgTagsFound.reduce((value, img) => {
-        if (hasLoadingAttr.test(img)) {
-          return value;
-        }
-        // Add loading="eager" by default
-        return value.replace(img, img.replace(findImgTag, '<img loading="eager"$1>'));
-      }, event.value);
-    });
-  }
-
+/**
+ * 27 April 2020 https://github.com/adaptlearning/adapt_framework/issues/2734
+ * Chrome on Android defers load events on images when lite mode is enabled
+ * and as part of a data saving technique.
+ *
+ * Add a loading="eager" attribute to all template and partial img tags where
+ * the loading attribute is missing.
+ */
+Adapt.on('app:dataReady', function() {
+  const config = Adapt.config.get('_fixes');
+  if (config && config._imgLazyLoad === false) return;
+  applyImgLoadingFix();
 });
+
+function applyImgLoadingFix() {
+  const findImgTag = /<img([^>]*)>/gi;
+  const hasLoadingAttr = / loading=/gi;
+  Adapt.on('template:postRender partial:postRender', function(event) {
+    const imgTagsFound = event.value.match(findImgTag);
+    if (!imgTagsFound) {
+      return;
+    }
+    event.value = imgTagsFound.reduce((value, img) => {
+      if (hasLoadingAttr.test(img)) {
+        return value;
+      }
+      // Add loading="eager" by default
+      return value.replace(img, img.replace(findImgTag, '<img loading="eager"$1>'));
+    }, event.value);
+  });
+}

--- a/src/core/js/fixes/img.lazyload.js
+++ b/src/core/js/fixes/img.lazyload.js
@@ -9,7 +9,7 @@ import 'core/js/templates';
  * Add a loading="eager" attribute to all template and partial img tags where
  * the loading attribute is missing.
  */
-Adapt.on('app:dataReady', function() {
+Adapt.on('app:dataReady', () => {
   const config = Adapt.config.get('_fixes');
   if (config && config._imgLazyLoad === false) return;
   applyImgLoadingFix();
@@ -18,7 +18,7 @@ Adapt.on('app:dataReady', function() {
 function applyImgLoadingFix() {
   const findImgTag = /<img([^>]*)>/gi;
   const hasLoadingAttr = / loading=/gi;
-  Adapt.on('template:postRender partial:postRender', function(event) {
+  Adapt.on('template:postRender partial:postRender', event => {
     const imgTagsFound = event.value.match(findImgTag);
     if (!imgTagsFound) {
       return;

--- a/src/core/js/headings.js
+++ b/src/core/js/headings.js
@@ -8,7 +8,7 @@ class Headings extends Backbone.Controller {
   }
 
   onViewRender(view) {
-    var $headingSeats = view.$('.js-heading');
+    const $headingSeats = view.$('.js-heading');
     $headingSeats.each(function(index, el) {
       new HeadingView({
         el: el,

--- a/src/core/js/headings.js
+++ b/src/core/js/headings.js
@@ -9,12 +9,7 @@ class Headings extends Backbone.Controller {
 
   onViewRender(view) {
     const $headingSeats = view.$('.js-heading');
-    $headingSeats.each((index, el) => {
-      new HeadingView({
-        el: el,
-        model: view.model
-      });
-    });
+    $headingSeats.each((index, el) => new HeadingView({ el, model: view.model }));
   }
 
 }

--- a/src/core/js/headings.js
+++ b/src/core/js/headings.js
@@ -1,26 +1,22 @@
-define([
-  './adapt',
-  './views/headingView'
-], function(Adapt, HeadingView) {
+import Adapt from './adapt';
+import HeadingView from './views/headingView';
 
-  var Headings = Backbone.Controller.extend({
+class Headings extends Backbone.Controller {
 
-    initialize: function() {
-      this.listenTo(Adapt, 'view:render', this.onViewRender);
-    },
+  initialize() {
+    this.listenTo(Adapt, 'view:render', this.onViewRender);
+  }
 
-    onViewRender: function(view) {
-      var $headingSeats = view.$('.js-heading');
-      $headingSeats.each(function(index, el) {
-        new HeadingView({
-          el: el,
-          model: view.model
-        });
+  onViewRender(view) {
+    var $headingSeats = view.$('.js-heading');
+    $headingSeats.each(function(index, el) {
+      new HeadingView({
+        el: el,
+        model: view.model
       });
-    }
+    });
+  }
 
-  });
+}
 
-  return new Headings();
-
-});
+export default new Headings();

--- a/src/core/js/headings.js
+++ b/src/core/js/headings.js
@@ -9,7 +9,7 @@ class Headings extends Backbone.Controller {
 
   onViewRender(view) {
     const $headingSeats = view.$('.js-heading');
-    $headingSeats.each(function(index, el) {
+    $headingSeats.each((index, el) => {
       new HeadingView({
         el: el,
         model: view.model

--- a/src/core/js/helpers.js
+++ b/src/core/js/helpers.js
@@ -14,31 +14,31 @@ const defaultAriaLevels = {
 
 const helpers = {
 
-  lowercase: function(text) {
+  lowercase(text) {
     return text.toLowerCase();
   },
 
-  capitalise: function(text) {
+  capitalise(text) {
     return text.charAt(0).toUpperCase() + text.slice(1);
   },
 
-  inc: function(index) {
+  inc(index) {
     return index + 1;
   },
 
-  dec: function(index) {
+  dec(index) {
     return index - 1;
   },
 
-  odd: function (index) {
+  odd (index) {
     return (index + 1) % 2 === 0 ? 'even' : 'odd';
   },
 
-  equals: function(value, text, block) {
+  equals(value, text, block) {
     return helpers.compare.call(this, value, '==', text, block);
   },
 
-  compare: function(value, operator, text, block) {
+  compare(value, operator, text, block) {
     // Comparison operators
     switch (operator) {
       case '===':
@@ -64,7 +64,7 @@ const helpers = {
     return block.inverse(this);
   },
 
-  math: function(lvalue, operator, rvalue, options) {
+  math(lvalue, operator, rvalue, options) {
     // Mathematical operators
     lvalue = parseFloat(lvalue);
     rvalue = parseFloat(rvalue);
@@ -85,10 +85,10 @@ const helpers = {
    * <div class='component__header {{_component}}__header'></div>
    * {{/any}}
    */
-  any: function() {
-    const args = Array.prototype.slice.call(arguments, 0, -1);
-    const block = Array.prototype.slice.call(arguments, -1)[0];
-    return _.any(args) ? (block.fn ? block.fn(this) : true) : (block.inverse ? block.inverse(this) : false);
+  any(...args) {
+    const specified = args.slice(0, -1);
+    const block = args.slice(-1)[0];
+    return specified.some(Boolean) ? (block.fn ? block.fn(this) : true) : (block.inverse ? block.inverse(this) : false);
   },
 
   /**
@@ -99,10 +99,10 @@ const helpers = {
    * <div class='component__header {{_component}}__header'></div>
    * {{/all}}
    */
-  all: function() {
-    const args = Array.prototype.slice.call(arguments, 0, -1);
-    const block = Array.prototype.slice.call(arguments, -1)[0];
-    return _.all(args) ? (block.fn ? block.fn(this) : true) : (block.inverse ? block.inverse(this) : false);
+  all(...args) {
+    const specified = args.slice(0, -1);
+    const block = args.slice(-1)[0];
+    return specified.every(Boolean) ? (block.fn ? block.fn(this) : true) : (block.inverse ? block.inverse(this) : false);
   },
 
   /**
@@ -113,17 +113,16 @@ const helpers = {
    * <div class='component__header {{_component}}__header'></div>
    * {{/none}}
    */
-  none: function() {
-    const args = Array.prototype.slice.call(arguments, 0, -1);
-    const block = Array.prototype.slice.call(arguments, -1)[0];
-
-    return !_.any(args) ? (block.fn ? block.fn(this) : true) : (block.inverse ? block.inverse(this) : false);
+  none(...args) {
+    const specified = args.slice(0, -1);
+    const block = args.slice(-1)[0];
+    return !specified.some(Boolean) ? (block.fn ? block.fn(this) : true) : (block.inverse ? block.inverse(this) : false);
   },
 
   /**
    * Allow JSON to be a template i.e. you can use handlebars {{expressions}} within your JSON
    */
-  compile: function(template, context) {
+  compile(template, context) {
     if (!template) {
       return '';
     }
@@ -139,7 +138,7 @@ const helpers = {
   /**
    * Allow JSON to be a template and accessible text
    */
-  compile_a11y_text: function(template, context) {
+  compile_a11y_text(template, context) {
     Adapt.a11y.log.deprecated('a11y_text is no longer required. https://tink.uk/understanding-screen-reader-interaction-modes/');
     return helpers.compile.call(this, template, context);
   },
@@ -147,7 +146,7 @@ const helpers = {
   /**
    * Allow JSON to be a template and normalized text
    */
-  compile_a11y_normalize: function(template, context) {
+  compile_a11y_normalize(template, context) {
     if (!template) {
       return '';
     }
@@ -158,7 +157,7 @@ const helpers = {
   /**
    * Remove all html tags except styling tags
    */
-  compile_a11y_remove_breaks: function(template, context) {
+  compile_a11y_remove_breaks(template, context) {
     if (!template) {
       return '';
     }
@@ -168,7 +167,7 @@ const helpers = {
   /**
    * makes the _globals object in course.json available to a template
    */
-  import_globals: function(context) {
+  import_globals(context) {
     if (context.data.root._globals) {
       return '';
     }
@@ -179,7 +178,7 @@ const helpers = {
   /**
    * makes the Adapt module data available to a template
    */
-  import_adapt: function(context) {
+  import_adapt(context) {
 
     if (context.data.root.Adapt) {
       return;
@@ -225,7 +224,7 @@ const helpers = {
    * @param {string} [override]
    * @returns {string}
    */
-  component_description: function(override, context) {
+  component_description(override, context) {
     if (!this._isA11yComponentDescriptionEnabled) {
       return;
     }
@@ -248,7 +247,7 @@ const helpers = {
     return new Handlebars.SafeString('<div class="aria-label">' + description + '</div>');
   },
 
-  a11y_text: function(text) {
+  a11y_text(text) {
     Adapt.a11y.log.deprecated('a11y_text is no longer required. https://tink.uk/understanding-screen-reader-interaction-modes/');
     return text;
   },
@@ -259,7 +258,7 @@ const helpers = {
    * @param {string} htmls Any htmls.
    * @returns {string}
    */
-  a11y_normalize: function(htmls) {
+  a11y_normalize(htmls) {
     return Adapt.a11y.normalize.apply(Adapt.a11y, arguments);
   },
 
@@ -269,7 +268,7 @@ const helpers = {
    * @param {string} htmls Any htmls.
    * @returns {string}
    */
-  a11y_remove_breaks: function(htmls) {
+  a11y_remove_breaks(htmls) {
     return Adapt.a11y.removeBreaks.apply(Adapt.a11y, arguments);
   },
 
@@ -281,7 +280,7 @@ const helpers = {
    * @param {string} htmls
    * @returns {string}
    */
-  a11y_aria_label: function(htmls) {
+  a11y_aria_label(htmls) {
     let values = Array.prototype.slice.call(arguments, 0, -1);
     values = values.filter(Boolean);
     return new Handlebars.SafeString('<div class="aria-label">' + values.join(' ') + '</div>');
@@ -295,7 +294,7 @@ const helpers = {
    * @param {string} htmls Aria label texts.
    * @returns {string}
    */
-  a11y_aria_label_relative: function(htmls) {
+  a11y_aria_label_relative(htmls) {
     let values = Array.prototype.slice.call(arguments, 0, -1);
     values = values.filter(Boolean);
     return new Handlebars.SafeString('<div class="aria-label relative">' + values.join(' ') + '</div>');
@@ -312,7 +311,7 @@ const helpers = {
    * @param {string} texts Aria label texts.
    * @returns {string}
    */
-  a11y_aria_image: function(texts) {
+  a11y_aria_image(texts) {
     let values = Array.prototype.slice.call(arguments, 0, -1);
     values = values.filter(Boolean);
     return new Handlebars.SafeString('<div class="aria-label" role="img" aria-label="' + values.join(' ') + '"></div>');
@@ -324,7 +323,7 @@ const helpers = {
    *
    * @returns {string}
    */
-  a11y_wrap_focus: function() {
+  a11y_wrap_focus() {
     const cfg = Adapt.config.get('_accessibility');
     if (cfg._isPopupWrapFocusEnabled === false) return '';
     return new Handlebars.SafeString('<a class="a11y-focusguard a11y-ignore a11y-ignore-focus" role="presentation">&nbsp;</a>');
@@ -339,7 +338,7 @@ const helpers = {
    * @param {number|string} levelOrType
    * @returns {string}
    */
-  a11y_attrs_heading: function(levelOrType) {
+  a11y_attrs_heading(levelOrType) {
     // get the global configuration from config.json
     const cfg = Adapt.config.get('_accessibility');
     // default level to use if nothing overrides it
@@ -364,7 +363,7 @@ const helpers = {
     return new Handlebars.SafeString(' role="heading" aria-level="' + level + '" ');
   },
 
-  a11y_attrs_tabbable: function() {
+  a11y_attrs_tabbable() {
     Adapt.a11y.log.deprecated('a11y_attrs_tabbable should not be used. tabbable elements should be natively tabbable.');
     return new Handlebars.SafeString(' role="region" tabindex="0" ');
   },
@@ -375,7 +374,7 @@ const helpers = {
    * @param {string} alternatives Text that will be read by the screen reader (instead of what's displayed on screen)
    * @example {{a11y_alt_text '$5bn' 'five billion dollars'}} or {{a11y_alt_text 'Here are some bits to read' 'There are' _items.length 'items to read'}}
    */
-  a11y_alt_text: function(visible, alternatives) {
+  a11y_alt_text(visible, alternatives) {
     let values = Array.prototype.slice.call(arguments, 1, -1);
     values = values.filter(Boolean);
     return new Handlebars.SafeString('<span aria-hidden="true">' + visible + '</span><span class="aria-label">' + values.join(' ') + '</span>');
@@ -384,19 +383,19 @@ const helpers = {
 };
 
 // Compatibility references
-_.extend(helpers, {
+Object.assign(helpers, {
 
-  if_value_equals: function() {
+  if_value_equals() {
     Adapt.a11y.log.deprecated('if_value_equals, use equals instead.');
     return helpers.equals.apply(this, arguments);
   },
 
-  numbers: function() {
+  numbers() {
     Adapt.a11y.log.deprecated('numbers, use inc instead.');
     return helpers.inc.apply(this, arguments);
   },
 
-  lowerCase: function() {
+  lowerCase() {
     Adapt.a11y.log.deprecated('lowerCase, use lowercase instead.');
     return helpers.lowercase.apply(this, arguments);
   }

--- a/src/core/js/helpers.js
+++ b/src/core/js/helpers.js
@@ -1,416 +1,411 @@
-define([
-  'handlebars',
-  'core/js/adapt'
-], function(Handlebars, Adapt) {
+import Adapt from 'core/js/adapt';
 
-  var defaultAriaLevels = {
-    '_menu': 1,
-    '_menuGroup': 2,
-    '_menuItem': 2,
-    '_page': 1,
-    '_article': 2,
-    '_block': 3,
-    '_component': 4,
-    '_componentItem': 5,
-    '_notify': 1
-  };
+const defaultAriaLevels = {
+  '_menu': 1,
+  '_menuGroup': 2,
+  '_menuItem': 2,
+  '_page': 1,
+  '_article': 2,
+  '_block': 3,
+  '_component': 4,
+  '_componentItem': 5,
+  '_notify': 1
+};
 
-  var helpers = {
+const helpers = {
 
-    lowercase: function(text) {
-      return text.toLowerCase();
-    },
+  lowercase: function(text) {
+    return text.toLowerCase();
+  },
 
-    capitalise: function(text) {
-      return text.charAt(0).toUpperCase() + text.slice(1);
-    },
+  capitalise: function(text) {
+    return text.charAt(0).toUpperCase() + text.slice(1);
+  },
 
-    inc: function(index) {
-      return index + 1;
-    },
+  inc: function(index) {
+    return index + 1;
+  },
 
-    dec: function(index) {
-      return index - 1;
-    },
+  dec: function(index) {
+    return index - 1;
+  },
 
-    odd: function (index) {
-      return (index + 1) % 2 === 0 ? 'even' : 'odd';
-    },
+  odd: function (index) {
+    return (index + 1) % 2 === 0 ? 'even' : 'odd';
+  },
 
-    equals: function(value, text, block) {
-      return helpers.compare.call(this, value, '==', text, block);
-    },
+  equals: function(value, text, block) {
+    return helpers.compare.call(this, value, '==', text, block);
+  },
 
-    compare: function(value, operator, text, block) {
-      // Comparison operators
-      switch (operator) {
-        case '===':
-          if (value === text) return block.fn(this);
-          break;
-        case '=': case '==':
-          // eslint-disable-next-line eqeqeq
-          if (value == text) return block.fn(this);
-          break;
-        case '>=':
-          if (value >= text) return block.fn(this);
-          break;
-        case '<=':
-          if (value <= text) return block.fn(this);
-          break;
-        case '>':
-          if (value > text) return block.fn(this);
-          break;
-        case '<':
-          if (value < text) return block.fn(this);
-          break;
-      }
-      return block.inverse(this);
-    },
+  compare: function(value, operator, text, block) {
+    // Comparison operators
+    switch (operator) {
+      case '===':
+        if (value === text) return block.fn(this);
+        break;
+      case '=': case '==':
+        // eslint-disable-next-line eqeqeq
+        if (value == text) return block.fn(this);
+        break;
+      case '>=':
+        if (value >= text) return block.fn(this);
+        break;
+      case '<=':
+        if (value <= text) return block.fn(this);
+        break;
+      case '>':
+        if (value > text) return block.fn(this);
+        break;
+      case '<':
+        if (value < text) return block.fn(this);
+        break;
+    }
+    return block.inverse(this);
+  },
 
-    math: function(lvalue, operator, rvalue, options) {
-      // Mathematical operators
-      lvalue = parseFloat(lvalue);
-      rvalue = parseFloat(rvalue);
-      switch (operator) {
-        case '+': return lvalue + rvalue;
-        case '-': return lvalue - rvalue;
-        case '*': return lvalue * rvalue;
-        case '/': return lvalue / rvalue;
-        case '%': return lvalue % rvalue;
-      }
-    },
+  math: function(lvalue, operator, rvalue, options) {
+    // Mathematical operators
+    lvalue = parseFloat(lvalue);
+    rvalue = parseFloat(rvalue);
+    switch (operator) {
+      case '+': return lvalue + rvalue;
+      case '-': return lvalue - rvalue;
+      case '*': return lvalue * rvalue;
+      case '/': return lvalue / rvalue;
+      case '%': return lvalue % rvalue;
+    }
+  },
 
-    /**
-     * Equivalent to:
-     *  if (conditionA || conditionB)
-     * @example
-     * {{#any displayTitle body instruction}}
-     * <div class='component__header {{_component}}__header'></div>
-     * {{/any}}
-     */
-    any: function() {
-      var args = Array.prototype.slice.call(arguments, 0, -1);
-      var block = Array.prototype.slice.call(arguments, -1)[0];
-      return _.any(args) ? (block.fn ? block.fn(this) : true) : (block.inverse ? block.inverse(this) : false);
-    },
+  /**
+   * Equivalent to:
+   *  if (conditionA || conditionB)
+   * @example
+   * {{#any displayTitle body instruction}}
+   * <div class='component__header {{_component}}__header'></div>
+   * {{/any}}
+   */
+  any: function() {
+    const args = Array.prototype.slice.call(arguments, 0, -1);
+    const block = Array.prototype.slice.call(arguments, -1)[0];
+    return _.any(args) ? (block.fn ? block.fn(this) : true) : (block.inverse ? block.inverse(this) : false);
+  },
 
-    /**
-     * Equivalent to:
-     *  if (conditionA && conditionB)
-     * @example
-     * {{#all displayTitle body instruction}}
-     * <div class='component__header {{_component}}__header'></div>
-     * {{/all}}
-     */
-    all: function() {
-      var args = Array.prototype.slice.call(arguments, 0, -1);
-      var block = Array.prototype.slice.call(arguments, -1)[0];
-      return _.all(args) ? (block.fn ? block.fn(this) : true) : (block.inverse ? block.inverse(this) : false);
-    },
+  /**
+   * Equivalent to:
+   *  if (conditionA && conditionB)
+   * @example
+   * {{#all displayTitle body instruction}}
+   * <div class='component__header {{_component}}__header'></div>
+   * {{/all}}
+   */
+  all: function() {
+    const args = Array.prototype.slice.call(arguments, 0, -1);
+    const block = Array.prototype.slice.call(arguments, -1)[0];
+    return _.all(args) ? (block.fn ? block.fn(this) : true) : (block.inverse ? block.inverse(this) : false);
+  },
 
-    /**
-     * Equivalent to:
-     *  if (!conditionA && !conditionB)
-     * @example
-     * {{#none displayTitle body instruction}}
-     * <div class='component__header {{_component}}__header'></div>
-     * {{/none}}
-     */
-    none: function() {
-      var args = Array.prototype.slice.call(arguments, 0, -1);
-      var block = Array.prototype.slice.call(arguments, -1)[0];
+  /**
+   * Equivalent to:
+   *  if (!conditionA && !conditionB)
+   * @example
+   * {{#none displayTitle body instruction}}
+   * <div class='component__header {{_component}}__header'></div>
+   * {{/none}}
+   */
+  none: function() {
+    const args = Array.prototype.slice.call(arguments, 0, -1);
+    const block = Array.prototype.slice.call(arguments, -1)[0];
 
-      return !_.any(args) ? (block.fn ? block.fn(this) : true) : (block.inverse ? block.inverse(this) : false);
-    },
+    return !_.any(args) ? (block.fn ? block.fn(this) : true) : (block.inverse ? block.inverse(this) : false);
+  },
 
-    /**
-     * Allow JSON to be a template i.e. you can use handlebars {{expressions}} within your JSON
-     */
-    compile: function(template, context) {
-      if (!template) {
-        return '';
-      }
-      if (template instanceof Object) template = template.toString();
-      var data = this;
-      if (context) {
-        // choose between a passed argument context or the default handlebars helper context
-        data = (!context.data || !context.data.root ? context : context.data.root);
-      }
-      return Handlebars.compile(template)(data);
-    },
-
-    /**
-     * Allow JSON to be a template and accessible text
-     */
-    compile_a11y_text: function(template, context) {
-      Adapt.a11y.log.deprecated('a11y_text is no longer required. https://tink.uk/understanding-screen-reader-interaction-modes/');
-      return helpers.compile.call(this, template, context);
-    },
-
-    /**
-     * Allow JSON to be a template and normalized text
-     */
-    compile_a11y_normalize: function(template, context) {
-      if (!template) {
-        return '';
-      }
-      if (template instanceof Object) template = template.toString();
-      return Handlebars.helpers.a11y_normalize.call(this, helpers.compile.call(this, template, context));
-    },
-
-    /**
-     * Remove all html tags except styling tags
-     */
-    compile_a11y_remove_breaks: function(template, context) {
-      if (!template) {
-        return '';
-      }
-      return Handlebars.helpers.a11y_remove_breaks.call(this, helpers.compile.call(this, template, context));
-    },
-
-    /**
-     * makes the _globals object in course.json available to a template
-     */
-    import_globals: function(context) {
-      if (context.data.root._globals) {
-        return '';
-      }
-      context.data.root._globals = Adapt.course.get('_globals');
+  /**
+   * Allow JSON to be a template i.e. you can use handlebars {{expressions}} within your JSON
+   */
+  compile: function(template, context) {
+    if (!template) {
       return '';
-    },
+    }
+    if (template instanceof Object) template = template.toString();
+    let data = this;
+    if (context) {
+      // choose between a passed argument context or the default handlebars helper context
+      data = (!context.data || !context.data.root ? context : context.data.root);
+    }
+    return Handlebars.compile(template)(data);
+  },
 
-    /**
-     * makes the Adapt module data available to a template
-     */
-    import_adapt: function(context) {
+  /**
+   * Allow JSON to be a template and accessible text
+   */
+  compile_a11y_text: function(template, context) {
+    Adapt.a11y.log.deprecated('a11y_text is no longer required. https://tink.uk/understanding-screen-reader-interaction-modes/');
+    return helpers.compile.call(this, template, context);
+  },
 
-      if (context.data.root.Adapt) {
-        return;
-      }
-      var adapt = context.data.root.Adapt = {};
-
-      var i, l, name;
-
-      var directImport = ['config', 'course'];
-      for (i = 0, l = directImport.length; i < l; i++) {
-        name = directImport[i];
-        // convert the model to a json object and add to the current context
-        adapt[name] = Adapt[name].toJSON();
-      }
-
-      var indexedImport = ['contentObjects', 'articles', 'blocks', 'components'];
-      for (i = 0, l = indexedImport.length; i < l; i++) {
-        name = indexedImport[i];
-        // convert the collection of models to an array of json objects
-        var importArray = Adapt[name].toJSON();
-        // convert the array of json models to an object indexed by id
-        var importIndex = {};
-        for (var i1 = 0, l1 = importArray.length; i1 < l1; i1++) {
-          var item = importArray[i1];
-          importIndex[item._id] = item;
-        }
-        // add the indexed object to the current context
-        adapt[name] = importIndex;
-      }
-
+  /**
+   * Allow JSON to be a template and normalized text
+   */
+  compile_a11y_normalize: function(template, context) {
+    if (!template) {
       return '';
+    }
+    if (template instanceof Object) template = template.toString();
+    return Handlebars.helpers.a11y_normalize.call(this, helpers.compile.call(this, template, context));
+  },
 
-    },
+  /**
+   * Remove all html tags except styling tags
+   */
+  compile_a11y_remove_breaks: function(template, context) {
+    if (!template) {
+      return '';
+    }
+    return Handlebars.helpers.a11y_remove_breaks.call(this, helpers.compile.call(this, template, context));
+  },
 
-    /**
-     * Allow components to fetch their component description.
-     *
-     * Creates an aria label using the `a11y_aria_label` helper containing
-     * the component description specified in the
-     * `_globals._component[componentName].ariaRegion`. This value is defined
-     * in the `properties.schema:globals.ariaRegion`.
-     *
-     * @param {string} [override]
-     * @returns {string}
-     */
-    component_description: function(override, context) {
-      if (!this._isA11yComponentDescriptionEnabled) {
-        return;
-      }
-      var isNotDefined = (!this._globals._components || !this._globals._components['_' + this._component]);
-      if (isNotDefined) {
-        return;
-      }
-      var hasOverride = (arguments.length > 1);
-      var description;
-      if (hasOverride) {
-        description = override;
-        description = helpers.compile(description, context);
-      } else {
-        description = this._globals._components['_' + this._component].ariaRegion;
-        description = helpers.compile(description, override);
-      }
-      if (!description) {
-        return;
-      }
-      return new Handlebars.SafeString('<div class="aria-label">' + description + '</div>');
-    },
+  /**
+   * makes the _globals object in course.json available to a template
+   */
+  import_globals: function(context) {
+    if (context.data.root._globals) {
+      return '';
+    }
+    context.data.root._globals = Adapt.course.get('_globals');
+    return '';
+  },
 
-    a11y_text: function(text) {
-      Adapt.a11y.log.deprecated('a11y_text is no longer required. https://tink.uk/understanding-screen-reader-interaction-modes/');
-      return text;
-    },
+  /**
+   * makes the Adapt module data available to a template
+   */
+  import_adapt: function(context) {
 
-    /**
-     * Handlebars helper for `Adapt.a11y.normalize(htmls)`.
-     *
-     * @param {string} htmls Any htmls.
-     * @returns {string}
-     */
-    a11y_normalize: function(htmls) {
-      return Adapt.a11y.normalize.apply(Adapt.a11y, arguments);
-    },
+    if (context.data.root.Adapt) {
+      return;
+    }
+    const adapt = context.data.root.Adapt = {};
 
-    /**
-     * Handlebars helper for `Adapt.a11y.removeBreaks(htmls)`.
-     *
-     * @param {string} htmls Any htmls.
-     * @returns {string}
-     */
-    a11y_remove_breaks: function(htmls) {
-      return Adapt.a11y.removeBreaks.apply(Adapt.a11y, arguments);
-    },
+    let i, l, name;
 
-    /**
-     * Creates a div styled with tiny, transparent text.
-     * It it absolutely positioned.
-     * The text is not visibly readable but is read by screen readers.
-     *
-     * @param {string} htmls
-     * @returns {string}
-     */
-    a11y_aria_label: function(htmls) {
-      var values = Array.prototype.slice.call(arguments, 0, -1);
-      values = values.filter(Boolean);
-      return new Handlebars.SafeString('<div class="aria-label">' + values.join(' ') + '</div>');
-    },
-
-    /**
-     * Creates a div styled with tiny, transparent text.
-     * It it relatively positioned.
-     * The text is not visibly readable but is read by screen readers.
-     *
-     * @param {string} htmls Aria label texts.
-     * @returns {string}
-     */
-    a11y_aria_label_relative: function(htmls) {
-      var values = Array.prototype.slice.call(arguments, 0, -1);
-      values = values.filter(Boolean);
-      return new Handlebars.SafeString('<div class="aria-label relative">' + values.join(' ') + '</div>');
-    },
-
-    /**
-     * Creates a div styled with tiny, transparent text and `role"=img"`.
-     * It is used for representing an image to a screen reader user in an
-     * order which cannot be represented in the DOM in a way that achieves the
-     * styling objectives.
-     * It it absolutely positioned.
-     * The text is not visibly readable but is read by screen readers.
-     *
-     * @param {string} texts Aria label texts.
-     * @returns {string}
-     */
-    a11y_aria_image: function(texts) {
-      var values = Array.prototype.slice.call(arguments, 0, -1);
-      values = values.filter(Boolean);
-      return new Handlebars.SafeString('<div class="aria-label" role="img" aria-label="' + values.join(' ') + '"></div>');
-    },
-
-    /**
-     * Returns an `a` tag which when receiving focus causes the focus to wrap
-     * to the top of the readable document.
-     *
-     * @returns {string}
-     */
-    a11y_wrap_focus: function() {
-      var cfg = Adapt.config.get('_accessibility');
-      if (cfg._isPopupWrapFocusEnabled === false) return '';
-      return new Handlebars.SafeString('<a class="a11y-focusguard a11y-ignore a11y-ignore-focus" role="presentation">&nbsp;</a>');
-    },
-
-    /**
-     * Creates the attributes for a subject heading text. `role="heading"` and
-     * `aria-level="#"`. It will use the `_ariaLevel` attribute from the current
-     * context if specified, a number if given as the `levelOrType` parameter,
-     * or a name from the configured aria levels hash.
-     *
-     * @param {number|string} levelOrType
-     * @returns {string}
-     */
-    a11y_attrs_heading: function(levelOrType) {
-      // get the global configuration from config.json
-      var cfg = Adapt.config.get('_accessibility');
-      // default level to use if nothing overrides it
-      var level = 1;
-
-      // first check to see if the Handlebars context has an override
-      if (this._ariaLevel) {
-        levelOrType = this._ariaLevel;
-      }
-
-      if (isNaN(levelOrType) === false) {
-        // if a number is passed just use this
-        level = levelOrType;
-      } else if (_.isString(levelOrType)) {
-        // if a string is passed check if it is defined in global configuration
-        cfg._ariaLevels = cfg._ariaLevels || defaultAriaLevels;
-        if (cfg._ariaLevels && cfg._ariaLevels['_' + levelOrType] !== undefined) {
-          level = cfg._ariaLevels['_' + levelOrType];
-        }
-      }
-
-      return new Handlebars.SafeString(' role="heading" aria-level="' + level + '" ');
-    },
-
-    a11y_attrs_tabbable: function() {
-      Adapt.a11y.log.deprecated('a11y_attrs_tabbable should not be used. tabbable elements should be natively tabbable.');
-      return new Handlebars.SafeString(' role="region" tabindex="0" ');
-    },
-
-    /**
-     * Produce display text with alternative screen reader version.
-     * @param {string} visible Text that will be displayed on screen
-     * @param {string} alternatives Text that will be read by the screen reader (instead of what's displayed on screen)
-     * @example {{a11y_alt_text '$5bn' 'five billion dollars'}} or {{a11y_alt_text 'Here are some bits to read' 'There are' _items.length 'items to read'}}
-     */
-    a11y_alt_text: function(visible, alternatives) {
-      var values = Array.prototype.slice.call(arguments, 1, -1);
-      values = values.filter(Boolean);
-      return new Handlebars.SafeString('<span aria-hidden="true">' + visible + '</span><span class="aria-label">' + values.join(' ') + '</span>');
+    const directImport = ['config', 'course'];
+    for (i = 0, l = directImport.length; i < l; i++) {
+      name = directImport[i];
+      // convert the model to a json object and add to the current context
+      adapt[name] = Adapt[name].toJSON();
     }
 
-  };
-
-  // Compatibility references
-  _.extend(helpers, {
-
-    if_value_equals: function() {
-      Adapt.a11y.log.deprecated('if_value_equals, use equals instead.');
-      return helpers.equals.apply(this, arguments);
-    },
-
-    numbers: function() {
-      Adapt.a11y.log.deprecated('numbers, use inc instead.');
-      return helpers.inc.apply(this, arguments);
-    },
-
-    lowerCase: function() {
-      Adapt.a11y.log.deprecated('lowerCase, use lowercase instead.');
-      return helpers.lowercase.apply(this, arguments);
+    const indexedImport = ['contentObjects', 'articles', 'blocks', 'components'];
+    for (i = 0, l = indexedImport.length; i < l; i++) {
+      name = indexedImport[i];
+      // convert the collection of models to an array of json objects
+      const importArray = Adapt[name].toJSON();
+      // convert the array of json models to an object indexed by id
+      const importIndex = {};
+      for (let i1 = 0, l1 = importArray.length; i1 < l1; i1++) {
+        const item = importArray[i1];
+        importIndex[item._id] = item;
+      }
+      // add the indexed object to the current context
+      adapt[name] = importIndex;
     }
 
-  });
+    return '';
 
-  for (var name in helpers) {
-    if (!helpers.hasOwnProperty(name)) continue;
-    Handlebars.registerHelper(name, helpers[name]);
+  },
+
+  /**
+   * Allow components to fetch their component description.
+   *
+   * Creates an aria label using the `a11y_aria_label` helper containing
+   * the component description specified in the
+   * `_globals._component[componentName].ariaRegion`. This value is defined
+   * in the `properties.schema:globals.ariaRegion`.
+   *
+   * @param {string} [override]
+   * @returns {string}
+   */
+  component_description: function(override, context) {
+    if (!this._isA11yComponentDescriptionEnabled) {
+      return;
+    }
+    const isNotDefined = (!this._globals._components || !this._globals._components['_' + this._component]);
+    if (isNotDefined) {
+      return;
+    }
+    const hasOverride = (arguments.length > 1);
+    let description;
+    if (hasOverride) {
+      description = override;
+      description = helpers.compile(description, context);
+    } else {
+      description = this._globals._components['_' + this._component].ariaRegion;
+      description = helpers.compile(description, override);
+    }
+    if (!description) {
+      return;
+    }
+    return new Handlebars.SafeString('<div class="aria-label">' + description + '</div>');
+  },
+
+  a11y_text: function(text) {
+    Adapt.a11y.log.deprecated('a11y_text is no longer required. https://tink.uk/understanding-screen-reader-interaction-modes/');
+    return text;
+  },
+
+  /**
+   * Handlebars helper for `Adapt.a11y.normalize(htmls)`.
+   *
+   * @param {string} htmls Any htmls.
+   * @returns {string}
+   */
+  a11y_normalize: function(htmls) {
+    return Adapt.a11y.normalize.apply(Adapt.a11y, arguments);
+  },
+
+  /**
+   * Handlebars helper for `Adapt.a11y.removeBreaks(htmls)`.
+   *
+   * @param {string} htmls Any htmls.
+   * @returns {string}
+   */
+  a11y_remove_breaks: function(htmls) {
+    return Adapt.a11y.removeBreaks.apply(Adapt.a11y, arguments);
+  },
+
+  /**
+   * Creates a div styled with tiny, transparent text.
+   * It it absolutely positioned.
+   * The text is not visibly readable but is read by screen readers.
+   *
+   * @param {string} htmls
+   * @returns {string}
+   */
+  a11y_aria_label: function(htmls) {
+    let values = Array.prototype.slice.call(arguments, 0, -1);
+    values = values.filter(Boolean);
+    return new Handlebars.SafeString('<div class="aria-label">' + values.join(' ') + '</div>');
+  },
+
+  /**
+   * Creates a div styled with tiny, transparent text.
+   * It it relatively positioned.
+   * The text is not visibly readable but is read by screen readers.
+   *
+   * @param {string} htmls Aria label texts.
+   * @returns {string}
+   */
+  a11y_aria_label_relative: function(htmls) {
+    let values = Array.prototype.slice.call(arguments, 0, -1);
+    values = values.filter(Boolean);
+    return new Handlebars.SafeString('<div class="aria-label relative">' + values.join(' ') + '</div>');
+  },
+
+  /**
+   * Creates a div styled with tiny, transparent text and `role"=img"`.
+   * It is used for representing an image to a screen reader user in an
+   * order which cannot be represented in the DOM in a way that achieves the
+   * styling objectives.
+   * It it absolutely positioned.
+   * The text is not visibly readable but is read by screen readers.
+   *
+   * @param {string} texts Aria label texts.
+   * @returns {string}
+   */
+  a11y_aria_image: function(texts) {
+    let values = Array.prototype.slice.call(arguments, 0, -1);
+    values = values.filter(Boolean);
+    return new Handlebars.SafeString('<div class="aria-label" role="img" aria-label="' + values.join(' ') + '"></div>');
+  },
+
+  /**
+   * Returns an `a` tag which when receiving focus causes the focus to wrap
+   * to the top of the readable document.
+   *
+   * @returns {string}
+   */
+  a11y_wrap_focus: function() {
+    const cfg = Adapt.config.get('_accessibility');
+    if (cfg._isPopupWrapFocusEnabled === false) return '';
+    return new Handlebars.SafeString('<a class="a11y-focusguard a11y-ignore a11y-ignore-focus" role="presentation">&nbsp;</a>');
+  },
+
+  /**
+   * Creates the attributes for a subject heading text. `role="heading"` and
+   * `aria-level="#"`. It will use the `_ariaLevel` attribute from the current
+   * context if specified, a number if given as the `levelOrType` parameter,
+   * or a name from the configured aria levels hash.
+   *
+   * @param {number|string} levelOrType
+   * @returns {string}
+   */
+  a11y_attrs_heading: function(levelOrType) {
+    // get the global configuration from config.json
+    const cfg = Adapt.config.get('_accessibility');
+    // default level to use if nothing overrides it
+    let level = 1;
+
+    // first check to see if the Handlebars context has an override
+    if (this._ariaLevel) {
+      levelOrType = this._ariaLevel;
+    }
+
+    if (isNaN(levelOrType) === false) {
+      // if a number is passed just use this
+      level = levelOrType;
+    } else if (_.isString(levelOrType)) {
+      // if a string is passed check if it is defined in global configuration
+      cfg._ariaLevels = cfg._ariaLevels || defaultAriaLevels;
+      if (cfg._ariaLevels && cfg._ariaLevels['_' + levelOrType] !== undefined) {
+        level = cfg._ariaLevels['_' + levelOrType];
+      }
+    }
+
+    return new Handlebars.SafeString(' role="heading" aria-level="' + level + '" ');
+  },
+
+  a11y_attrs_tabbable: function() {
+    Adapt.a11y.log.deprecated('a11y_attrs_tabbable should not be used. tabbable elements should be natively tabbable.');
+    return new Handlebars.SafeString(' role="region" tabindex="0" ');
+  },
+
+  /**
+   * Produce display text with alternative screen reader version.
+   * @param {string} visible Text that will be displayed on screen
+   * @param {string} alternatives Text that will be read by the screen reader (instead of what's displayed on screen)
+   * @example {{a11y_alt_text '$5bn' 'five billion dollars'}} or {{a11y_alt_text 'Here are some bits to read' 'There are' _items.length 'items to read'}}
+   */
+  a11y_alt_text: function(visible, alternatives) {
+    let values = Array.prototype.slice.call(arguments, 1, -1);
+    values = values.filter(Boolean);
+    return new Handlebars.SafeString('<span aria-hidden="true">' + visible + '</span><span class="aria-label">' + values.join(' ') + '</span>');
   }
 
-  return helpers;
+};
+
+// Compatibility references
+_.extend(helpers, {
+
+  if_value_equals: function() {
+    Adapt.a11y.log.deprecated('if_value_equals, use equals instead.');
+    return helpers.equals.apply(this, arguments);
+  },
+
+  numbers: function() {
+    Adapt.a11y.log.deprecated('numbers, use inc instead.');
+    return helpers.inc.apply(this, arguments);
+  },
+
+  lowerCase: function() {
+    Adapt.a11y.log.deprecated('lowerCase, use lowercase instead.');
+    return helpers.lowercase.apply(this, arguments);
+  }
 
 });
+
+for (let name in helpers) {
+  if (!helpers.hasOwnProperty(name)) continue;
+  Handlebars.registerHelper(name, helpers[name]);
+}
+
+export default helpers;

--- a/src/core/js/logging.js
+++ b/src/core/js/logging.js
@@ -1,140 +1,136 @@
-define([
-  'core/js/adapt',
-  'core/js/enums/logLevelEnum'
-], function(Adapt, LOG_LEVEL) {
+import Adapt from 'core/js/adapt';
+import LOG_LEVEL from 'core/js/enums/logLevelEnum';
 
-  class Logging extends Backbone.Controller {
+class Logging extends Backbone.Controller {
 
-    initialize() {
-      this._config = {
-        _isEnabled: true,
-        _level: LOG_LEVEL.INFO.asLowerCase, // Default log level
-        _console: true, // Log to console
-        _warnFirstOnly: true // Show only first of identical removed and deprecated warnings
-      };
-      this._warned = {};
-      this.listenToOnce(Adapt, 'configModel:dataLoaded', this.onLoadConfigData);
-    }
+  initialize() {
+    this._config = {
+      _isEnabled: true,
+      _level: LOG_LEVEL.INFO.asLowerCase, // Default log level
+      _console: true, // Log to console
+      _warnFirstOnly: true // Show only first of identical removed and deprecated warnings
+    };
+    this._warned = {};
+    this.listenToOnce(Adapt, 'configModel:dataLoaded', this.onLoadConfigData);
+  }
 
-    onLoadConfigData() {
+  onLoadConfigData() {
 
-      this.loadConfig();
+    this.loadConfig();
 
-      this.debug('Logging config loaded');
+    this.debug('Logging config loaded');
 
-      this.trigger('log:ready');
-
-    }
-
-    loadConfig() {
-
-      if (Adapt.config.has('_logging')) {
-        this._config = Adapt.config.get('_logging');
-      }
-
-      this.checkQueryStringOverride();
-
-    }
-
-    checkQueryStringOverride() {
-
-      // Override default log level with level present in query string
-      const matches = window.location.search.match(/[?&]loglevel=([a-z]*)/i);
-      if (!matches || matches.length < 2) return;
-
-      const override = LOG_LEVEL(matches[1].toUpperCase());
-      if (!override) return;
-
-      this._config._level = override.asLowerCase;
-      this.debug('Loglevel override in query string:', this._config._level);
-
-    }
-
-    debug(...args) {
-      this._log(LOG_LEVEL.DEBUG, args);
-    }
-
-    info(...args) {
-      this._log(LOG_LEVEL.INFO, args);
-    }
-
-    warn(...args) {
-      this._log(LOG_LEVEL.WARN, args);
-    }
-
-    error(...args) {
-      this._log(LOG_LEVEL.ERROR, args);
-    }
-
-    fatal(...args) {
-      this._log(LOG_LEVEL.FATAL, args);
-    }
-
-    removed(...args) {
-      args = ['REMOVED'].concat(args);
-      this.warnOnce(...args);
-    }
-
-    deprecated(...args) {
-      args = ['DEPRECATED'].concat(args);
-      this.warnOnce(...args);
-    }
-
-    warnOnce(...args) {
-      if (this._hasWarned(args)) {
-        return;
-      }
-      this._log(LOG_LEVEL.WARN, args);
-    }
-
-    _log(level, data) {
-
-      const isEnabled = (this._config._isEnabled);
-      if (!isEnabled) return;
-
-      const configLevel = LOG_LEVEL(this._config._level.toUpperCase());
-
-      const isLogLevelAllowed = (level >= configLevel);
-      if (!isLogLevelAllowed) return;
-
-      this._logToConsole(level, data);
-
-      // Allow error reporting plugins to hook and report to logging systems
-      this.trigger('log', level, data);
-      this.trigger('log:' + level.asLowerCase, level, data);
-
-    }
-
-    _logToConsole(level, data) {
-
-      const shouldLogToConsole = (this._config._console);
-      if (!shouldLogToConsole) return;
-
-      const log = [level.asUpperCase + ':'];
-      data && log.push(...data);
-
-      // is there a matching console method we can use e.g. console.error()?
-      if (console[level.asLowerCase]) {
-        console[level.asLowerCase](...log);
-      } else {
-        console.log(...log);
-      }
-    }
-
-    _hasWarned(args) {
-      if (!this._config._warnFirstOnly) {
-        return false;
-      }
-      const hash = args.map(String).join(':');
-      if (this._warned[hash]) {
-        return true;
-      }
-      this._warned[hash] = true;
-      return false;
-    }
+    this.trigger('log:ready');
 
   }
 
-  return (Adapt.log = new Logging());
+  loadConfig() {
 
-});
+    if (Adapt.config.has('_logging')) {
+      this._config = Adapt.config.get('_logging');
+    }
+
+    this.checkQueryStringOverride();
+
+  }
+
+  checkQueryStringOverride() {
+
+    // Override default log level with level present in query string
+    const matches = window.location.search.match(/[?&]loglevel=([a-z]*)/i);
+    if (!matches || matches.length < 2) return;
+
+    const override = LOG_LEVEL(matches[1].toUpperCase());
+    if (!override) return;
+
+    this._config._level = override.asLowerCase;
+    this.debug('Loglevel override in query string:', this._config._level);
+
+  }
+
+  debug(...args) {
+    this._log(LOG_LEVEL.DEBUG, args);
+  }
+
+  info(...args) {
+    this._log(LOG_LEVEL.INFO, args);
+  }
+
+  warn(...args) {
+    this._log(LOG_LEVEL.WARN, args);
+  }
+
+  error(...args) {
+    this._log(LOG_LEVEL.ERROR, args);
+  }
+
+  fatal(...args) {
+    this._log(LOG_LEVEL.FATAL, args);
+  }
+
+  removed(...args) {
+    args = ['REMOVED'].concat(args);
+    this.warnOnce(...args);
+  }
+
+  deprecated(...args) {
+    args = ['DEPRECATED'].concat(args);
+    this.warnOnce(...args);
+  }
+
+  warnOnce(...args) {
+    if (this._hasWarned(args)) {
+      return;
+    }
+    this._log(LOG_LEVEL.WARN, args);
+  }
+
+  _log(level, data) {
+
+    const isEnabled = (this._config._isEnabled);
+    if (!isEnabled) return;
+
+    const configLevel = LOG_LEVEL(this._config._level.toUpperCase());
+
+    const isLogLevelAllowed = (level >= configLevel);
+    if (!isLogLevelAllowed) return;
+
+    this._logToConsole(level, data);
+
+    // Allow error reporting plugins to hook and report to logging systems
+    this.trigger('log', level, data);
+    this.trigger('log:' + level.asLowerCase, level, data);
+
+  }
+
+  _logToConsole(level, data) {
+
+    const shouldLogToConsole = (this._config._console);
+    if (!shouldLogToConsole) return;
+
+    const log = [level.asUpperCase + ':'];
+    data && log.push(...data);
+
+    // is there a matching console method we can use e.g. console.error()?
+    if (console[level.asLowerCase]) {
+      console[level.asLowerCase](...log);
+    } else {
+      console.log(...log);
+    }
+  }
+
+  _hasWarned(args) {
+    if (!this._config._warnFirstOnly) {
+      return false;
+    }
+    const hash = args.map(String).join(':');
+    if (this._warned[hash]) {
+      return true;
+    }
+    this._warned[hash] = true;
+    return false;
+  }
+
+}
+
+export default (Adapt.log = new Logging());

--- a/src/core/js/modelEvent.js
+++ b/src/core/js/modelEvent.js
@@ -1,36 +1,25 @@
-define(function() {
+export default class ModelEvent extends Backbone.Controller {
 
-  var ModelEvent = Backbone.Controller.extend({
+  /**
+   * @param {string} type Event name / type
+   * @param {Backbone.Model} target Origin model
+   * @param {*} [value] Any value that should be carried through on the event
+   */
+  initialize(type, target, value) {
+    this.type = type;
+    this.target = target;
+    this.value = value;
+    this.canBubble = true;
+    this.deepPath = [target];
+    this.timeStamp = null;
+  }
 
-    type: null,
-    target: null,
-    value: null,
-    canBubble: true,
-    deepPath: null,
-    timeStamp: null,
+  stopPropagation() {
+    this.canBubble = false;
+  }
 
-    /**
-     * @param {string} type Event name / type
-     * @param {Backbone.Model} target Origin model
-     * @param {*} [value] Any value that should be carried through on the event
-     */
-    initialize: function(type, target, value) {
-      this.type = type;
-      this.target = target;
-      this.value = value;
-      this.deepPath = [target];
-    },
+  addPath(target) {
+    this.deepPath.unshift(target);
+  }
 
-    stopPropagation: function() {
-      this.canBubble = false;
-    },
-
-    addPath: function(target) {
-      this.deepPath.unshift(target);
-    }
-
-  });
-
-  return ModelEvent;
-
-});
+}

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -1,8 +1,9 @@
 import Adapt from 'core/js/adapt';
 import ModelEvent from 'core/js/modelEvent';
+import LockingModel from 'core/js/models/lockingModel';
 import 'core/js/logging';
 
-export default class AdaptModel extends Backbone.Model {
+export default class AdaptModel extends LockingModel {
 
   toJSON() {
     // Perform shallow clone

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -1,859 +1,853 @@
-define([
-  'core/js/adapt',
-  'core/js/modelEvent',
-  'core/js/logging'
-], function (Adapt, ModelEvent) {
+import Adapt from 'core/js/adapt';
+import ModelEvent from 'core/js/modelEvent';
+import 'core/js/logging';
 
-  class AdaptModel extends Backbone.Model {
+export default class AdaptModel extends Backbone.Model {
 
-    toJSON() {
-      // Perform shallow clone
-      const json = _.clone(this.attributes);
-      // Remove deprecated values as they are not true json
-      delete json._children;
-      delete json._parent;
-      // Perform deep clone
-      return $.extend(true, {}, json);
+  toJSON() {
+    // Perform shallow clone
+    const json = _.clone(this.attributes);
+    // Remove deprecated values as they are not true json
+    delete json._children;
+    delete json._parent;
+    // Perform deep clone
+    return $.extend(true, {}, json);
+  }
+
+  get(name) {
+    switch (name) {
+      case '_parent':
+      case '_children':
+        Adapt.log.deprecated(`Use model.getChildren() or model.getParent() instead of model.get('_children') or model.get('_parent')`);
+    }
+    return super.get(name);
+  }
+
+  defaults() {
+    return {
+      _canShowFeedback: true,
+      _classes: '',
+      _canReset: false,
+      _canRequestChild: false,
+      _isComplete: false,
+      _isInteractionComplete: false,
+      _isA11yRegionEnabled: false,
+      _isA11yCompletionDescriptionEnabled: true,
+      _requireCompletionOf: -1,
+      _isEnabled: true,
+      _isResetOnRevisit: false,
+      _isAvailable: true,
+      _isOptional: false,
+      _isRendered: false,
+      _isReady: false,
+      _isVisible: true,
+      _isLocked: false,
+      _isHidden: false
+    };
+  }
+
+  /**
+   * The AAT always sets the value of `_isResetOnRevisit` to a String
+   * which is fine for the 'soft' and 'hard' values - but 'false' needs
+   * converting to Boolean - see #2825
+   */
+  parse(data) {
+    if (data._isResetOnRevisit === 'false') {
+      data._isResetOnRevisit = false;
+    }
+    return data;
+  }
+
+  trackable() {
+    return [
+      '_id',
+      '_isComplete',
+      '_isInteractionComplete'
+    ];
+  }
+
+  trackableType() {
+    return [
+      String,
+      Boolean,
+      Boolean
+    ];
+  }
+
+  bubblingEvents() {
+    return [
+      'change:_isComplete',
+      'change:_isInteractionComplete',
+      'change:_isActive'
+    ];
+  }
+
+  setupModel() {
+    if (this.hasManagedChildren) {
+      this.setupChildListeners();
     }
 
-    get(name) {
-      switch (name) {
-        case '_parent':
-        case '_children':
-          Adapt.log.deprecated(`Use model.getChildren() or model.getParent() instead of model.get('_children') or model.get('_parent')`);
-      }
-      return super.get(name);
-    }
+    this.init();
 
-    defaults() {
-      return {
-        _canShowFeedback: true,
-        _classes: '',
-        _canReset: false,
-        _canRequestChild: false,
-        _isComplete: false,
-        _isInteractionComplete: false,
-        _isA11yRegionEnabled: false,
-        _isA11yCompletionDescriptionEnabled: true,
-        _requireCompletionOf: -1,
-        _isEnabled: true,
-        _isResetOnRevisit: false,
-        _isAvailable: true,
-        _isOptional: false,
-        _isRendered: false,
-        _isReady: false,
-        _isVisible: true,
-        _isLocked: false,
-        _isHidden: false
-      };
-    }
-
-    /**
-     * The AAT always sets the value of `_isResetOnRevisit` to a String
-     * which is fine for the 'soft' and 'hard' values - but 'false' needs
-     * converting to Boolean - see #2825
-     */
-    parse(data) {
-      if (data._isResetOnRevisit === 'false') {
-        data._isResetOnRevisit = false;
-      }
-      return data;
-    }
-
-    trackable() {
-      return [
-        '_id',
-        '_isComplete',
-        '_isInteractionComplete'
-      ];
-    }
-
-    trackableType() {
-      return [
-        String,
-        Boolean,
-        Boolean
-      ];
-    }
-
-    bubblingEvents() {
-      return [
-        'change:_isComplete',
-        'change:_isInteractionComplete',
-        'change:_isActive'
-      ];
-    }
-
-    setupModel() {
+    _.defer(() => {
       if (this.hasManagedChildren) {
-        this.setupChildListeners();
+        this.checkCompletionStatus();
+
+        this.checkInteractionCompletionStatus();
+
+        this.checkLocking();
       }
 
-      this.init();
+      this.setupTrackables();
 
-      _.defer(() => {
-        if (this.hasManagedChildren) {
-          this.checkCompletionStatus();
+    });
 
-          this.checkInteractionCompletionStatus();
+  }
 
-          this.checkLocking();
-        }
+  setupTrackables() {
 
-        this.setupTrackables();
+    // Limit state trigger calls and make state change callbacks batched-asynchronous
+    const originalTrackableStateFunction = this.triggerTrackableState;
+    this.triggerTrackableState = _.compose(
+      () => {
 
-      });
+        // Flag that the function is awaiting trigger
+        this.triggerTrackableState.isQueued = true;
 
-    }
+      },
+      _.debounce(() => {
 
-    setupTrackables() {
+        // Trigger original function
+        originalTrackableStateFunction.apply(this);
 
-      // Limit state trigger calls and make state change callbacks batched-asynchronous
-      const originalTrackableStateFunction = this.triggerTrackableState;
-      this.triggerTrackableState = _.compose(
-        () => {
+        // Unset waiting flag
+        this.triggerTrackableState.isQueued = false;
 
-          // Flag that the function is awaiting trigger
-          this.triggerTrackableState.isQueued = true;
+      }, 17)
+    );
 
-        },
-        _.debounce(() => {
+    // Listen to model changes, trigger trackable state change when appropriate
+    this.listenTo(this, 'change', ({ changed }) => {
 
-          // Trigger original function
-          originalTrackableStateFunction.apply(this);
-
-          // Unset waiting flag
-          this.triggerTrackableState.isQueued = false;
-
-        }, 17)
-      );
-
-      // Listen to model changes, trigger trackable state change when appropriate
-      this.listenTo(this, 'change', ({ changed }) => {
-
-        // Skip if trigger queued or adapt hasn't started yet
-        if (this.triggerTrackableState.isQueued || !Adapt.attributes._isStarted) {
-          return;
-        }
-
-        // Check that property is trackable
-        const trackablePropertyNames = _.result(this, 'trackable', []);
-        const changedPropertyNames = Object.keys(changed);
-        const isTrackable = changedPropertyNames.find(item => {
-          return trackablePropertyNames.includes(item);
-        });
-
-        if (isTrackable) {
-          // Trigger trackable state change
-          this.triggerTrackableState();
-        }
-      });
-    }
-
-    setupChildListeners() {
-      const children = this.getChildren();
-      if (!children.length) {
+      // Skip if trigger queued or adapt hasn't started yet
+      if (this.triggerTrackableState.isQueued || !Adapt.attributes._isStarted) {
         return;
       }
 
-      this.listenTo(children, {
-        'all': this.onAll,
-        'bubble': this.bubble,
-        'change:_isReady': this.checkReadyStatus,
-        'change:_isComplete': this.onIsComplete,
-        'change:_isInteractionComplete': this.checkInteractionCompletionStatus
+      // Check that property is trackable
+      const trackablePropertyNames = _.result(this, 'trackable', []);
+      const changedPropertyNames = Object.keys(changed);
+      const isTrackable = changedPropertyNames.find(item => {
+        return trackablePropertyNames.includes(item);
       });
-    }
 
-    init() {}
-
-    getTrackableState() {
-
-      const trackable = this.resultExtend('trackable', []);
-      const json = this.toJSON();
-
-      const args = trackable;
-      args.unshift(json);
-
-      return _.pick(...args);
-
-    }
-
-    setTrackableState(state) {
-
-      const trackable = this.resultExtend('trackable', []);
-
-      const args = trackable;
-      args.unshift(state);
-
-      state = _.pick(...args);
-
-      this.set(state);
-
-      return this;
-
-    }
-
-    triggerTrackableState() {
-
-      Adapt.trigger('state:change', this, this.getTrackableState());
-
-    }
-
-    reset(type, force) {
-      if (!this.get('_canReset') && !force) return;
-
-      type = type || true;
-
-      switch (type) {
-        case 'hard': case true:
-          this.set({
-            _isEnabled: true,
-            _isComplete: false,
-            _isInteractionComplete: false
-          });
-          break;
-        case 'soft':
-          this.set({
-            _isEnabled: true,
-            _isInteractionComplete: false
-          });
-          break;
+      if (isTrackable) {
+        // Trigger trackable state change
+        this.triggerTrackableState();
       }
+    });
+  }
+
+  setupChildListeners() {
+    const children = this.getChildren();
+    if (!children.length) {
+      return;
     }
 
-    /**
-     * Checks if any child models which have been _isRendered are not _isReady.
-     * If all rendered child models are marked ready then this model will be
-     * marked _isReady: true as well.
-     * @param {AdaptModel} [model]
-     * @param {boolean} [value]
-     * @returns {boolean}
-     */
-    checkReadyStatus(model, value) {
-      if (value === false) {
-        // Do not respond to _isReady: false as _isReady is unset throughout
-        // the rendering process
-        return false;
-      }
-      // Filter children based upon whether they are available
-      // Check if any _isRendered: true children return _isReady: false
-      // If not - set this model to _isReady: true
-      const children = this.getAvailableChildModels();
-      if (children.find(child => child.get('_isReady') === false && child.get('_isRendered'))) {
-        return false;
-      }
+    this.listenTo(children, {
+      'all': this.onAll,
+      'bubble': this.bubble,
+      'change:_isReady': this.checkReadyStatus,
+      'change:_isComplete': this.onIsComplete,
+      'change:_isInteractionComplete': this.checkInteractionCompletionStatus
+    });
+  }
 
-      this.set('_isReady', true);
+  init() {}
+
+  getTrackableState() {
+
+    const trackable = this.resultExtend('trackable', []);
+    const json = this.toJSON();
+
+    const args = trackable;
+    args.unshift(json);
+
+    return _.pick(...args);
+
+  }
+
+  setTrackableState(state) {
+
+    const trackable = this.resultExtend('trackable', []);
+
+    const args = trackable;
+    args.unshift(state);
+
+    state = _.pick(...args);
+
+    this.set(state);
+
+    return this;
+
+  }
+
+  triggerTrackableState() {
+
+    Adapt.trigger('state:change', this, this.getTrackableState());
+
+  }
+
+  reset(type, force) {
+    if (!this.get('_canReset') && !force) return;
+
+    type = type || true;
+
+    switch (type) {
+      case 'hard': case true:
+        this.set({
+          _isEnabled: true,
+          _isComplete: false,
+          _isInteractionComplete: false
+        });
+        break;
+      case 'soft':
+        this.set({
+          _isEnabled: true,
+          _isInteractionComplete: false
+        });
+        break;
+    }
+  }
+
+  /**
+   * Checks if any child models which have been _isRendered are not _isReady.
+   * If all rendered child models are marked ready then this model will be
+   * marked _isReady: true as well.
+   * @param {AdaptModel} [model]
+   * @param {boolean} [value]
+   * @returns {boolean}
+   */
+  checkReadyStatus(model, value) {
+    if (value === false) {
+      // Do not respond to _isReady: false as _isReady is unset throughout
+      // the rendering process
+      return false;
+    }
+    // Filter children based upon whether they are available
+    // Check if any _isRendered: true children return _isReady: false
+    // If not - set this model to _isReady: true
+    const children = this.getAvailableChildModels();
+    if (children.find(child => child.get('_isReady') === false && child.get('_isRendered'))) {
+      return false;
+    }
+
+    this.set('_isReady', true);
+    return true;
+  }
+
+  setCompletionStatus() {
+    if (!this.get('_isVisible')) return;
+
+    this.set({
+      _isComplete: true,
+      _isInteractionComplete: true
+    });
+  }
+
+  checkCompletionStatus() {
+    // defer to allow other change:_isComplete handlers to fire before cascading to parent
+    Adapt.checkingCompletion();
+    _.defer(this.checkCompletionStatusFor.bind(this), '_isComplete');
+  }
+
+  checkInteractionCompletionStatus() {
+    // defer to allow other change:_isInteractionComplete handlers to fire before cascading to parent
+    Adapt.checkingCompletion();
+    _.defer(this.checkCompletionStatusFor.bind(this), '_isInteractionComplete');
+  }
+
+  /**
+   * Function for checking whether the supplied completion attribute should be set to true or false.
+   * It iterates over our immediate children, checking the same completion attribute on any mandatory child
+   * to see if enough/all of them them have been completed. If enough/all have, we set our attribute to true;
+   * if not, we set it to false.
+   * @param {string} [completionAttribute] Either '_isComplete' or '_isInteractionComplete'. Defaults to '_isComplete' if not supplied.
+   */
+
+  checkCompletionStatusFor(completionAttribute = '_isComplete') {
+    let completed = false;
+    const children = this.getAvailableChildModels();
+    const requireCompletionOf = this.get('_requireCompletionOf');
+
+    if (requireCompletionOf === -1) { // a value of -1 indicates that ALL mandatory children must be completed
+      completed = children.every(child => {
+        return child.get(completionAttribute) || child.get('_isOptional');
+      });
+    } else {
+      completed = (children.filter(child => {
+        return child.get(completionAttribute) && !child.get('_isOptional');
+      }).length >= requireCompletionOf);
+    }
+
+    this.set(completionAttribute, completed);
+
+    Adapt.checkedCompletion();
+  }
+
+  /**
+   * Returns a string describing the type group of this model.
+   * Strings should be lowercase and not plurlaized.
+   * i.e. 'page', 'menu', 'contentobject', 'component', 'article', 'block'
+   * Override in inheritance chain.
+   * @returns {string}
+   */
+  getTypeGroup() {}
+
+  /**
+   * Returns true if this model is of the type group described.
+   * Automatically manages pluralization typeGroup and matches lowercase only.
+   * Pluralized typeGroups and uppercase characters in typeGroups are discouraged.
+   * @param {string} type Type group name i.e. course, contentobject, article, block, component
+   * @returns {boolean}
+   */
+  isTypeGroup(typeGroup) {
+    const hasUpperCase = /[A-Z]+/.test(typeGroup);
+    const isPluralized = typeGroup.slice(-1) === 's';
+    const lowerCased = typeGroup.toLowerCase();
+    const singular = isPluralized && lowerCased.slice(0, -1); // remove pluralization if ending in s
+    const singularLowerCased = (singular || lowerCased).toLowerCase();
+    if (isPluralized || hasUpperCase) {
+      Adapt.log.deprecated(`'${typeGroup}' appears pluralized or contains uppercase characters, suggest using the singular, lowercase type group '${singularLowerCased}'.`);
+    }
+    const pluralizedLowerCaseTypes = [
+      singularLowerCased,
+      !isPluralized && `${lowerCased}s` // pluralize if not ending in s
+    ].filter(Boolean);
+    const typeGroups = this.getTypeGroups();
+    if (_.intersection(pluralizedLowerCaseTypes, typeGroups).length) {
       return true;
     }
+    return false;
+  }
 
-    setCompletionStatus() {
-      if (!this.get('_isVisible')) return;
+  /**
+   * Returns an array of strings describing the model type groups.
+   * All strings are lowercase and should not be pluralized.
+   * i.e. ['course', 'menu', 'contentobject'], ['page', 'contentobject'], ['component']
+   * @returns {[string]}
+   */
+  getTypeGroups() {
+    if (this._typeGroups) return this._typeGroups;
+    const typeGroups = [ this.get('_type') ];
+    let parentClass = this;
+    while ((parentClass = Object.getPrototypeOf(parentClass))) {
+      if (!parentClass.hasOwnProperty('getTypeGroup')) continue;
+      typeGroups.push(parentClass.getTypeGroup.call(this));
+    }
+    return (this._typeGroups = _.uniq(typeGroups.filter(Boolean).map(s => s.toLowerCase())));
+  }
 
-      this.set({
-        _isComplete: true,
-        _isInteractionComplete: true
+  /**
+   * Searches the model's ancestors to find the first instance of the specified ancestor type
+   * @param {string} [ancestorType] Valid values are 'course', 'pages', 'contentObjects', 'articles' or 'blocks'.
+   * If left blank, the immediate ancestor (if there is one) is returned
+   * @return {object} Reference to the model of the first ancestor of the specified type that's found - or `undefined` if none found
+   */
+  findAncestor(ancestorType) {
+    const parent = this.getParent();
+    if (!parent) return;
+    if (!ancestorType || parent.isTypeGroup(ancestorType)) {
+      return parent;
+    }
+    return parent.findAncestor(ancestorType);
+  }
+
+  /**
+   * Returns all the descendant models of a specific type
+   * @param {string} descendants Valid values are 'contentobject', 'page', 'menu', 'article', 'block', 'component', 'question'
+   * @param {object} options an object that defines the search type and the properties/values to search on. Currently only the `where` search type (equivalent to `Backbone.Collection.where()`) is supported.
+   * @param {object} options.where
+   * @return {array}
+   * @example
+   * //find all available, non-optional components
+   * this.findDescendantModels('component', { where: { _isAvailable: true, _isOptional: false }});
+   */
+  findDescendantModels(descendants, options) {
+    const allDescendantsModels = this.getAllDescendantModels();
+    const returnedDescendants = allDescendantsModels.filter(model => {
+      return model.isTypeGroup(descendants);
+    });
+
+    if (!options) {
+      return returnedDescendants;
+    }
+
+    if (options.where) {
+      return returnedDescendants.filter(descendant => {
+        for (let property in options.where) {
+          const value = options.where[property];
+          if (descendant.get(property) !== value) {
+            return false;
+          }
+        }
+        return true;
       });
     }
+  }
 
-    checkCompletionStatus() {
-      // defer to allow other change:_isComplete handlers to fire before cascading to parent
-      Adapt.checkingCompletion();
-      _.defer(this.checkCompletionStatusFor.bind(this), '_isComplete');
+  /**
+   * Fetches the sub structure of a model as a flattened array
+   *
+   * Such that the tree:
+   *  { a1: { b1: [ c1, c2 ], b2: [ c3, c4 ] }, a2: { b3: [ c5, c6 ] } }
+   *
+   * will become the array (parent first = false):
+   *  [ c1, c2, b1, c3, c4, b2, a1, c5, c6, b3, a2 ]
+   *
+   * or (parent first = true):
+   *  [ a1, b1, c1, c2, b2, c3, c4, a2, b3, c5, c6 ]
+   *
+   * This is useful when sequential operations are performed on the menu/page/article/block/component hierarchy.
+   * @param {boolean} [isParentFirst]
+   * @return {array}
+   */
+  getAllDescendantModels(isParentFirst) {
+
+    const descendants = [];
+
+    if (!this.hasManagedChildren) {
+      return descendants;
     }
 
-    checkInteractionCompletionStatus() {
-      // defer to allow other change:_isInteractionComplete handlers to fire before cascading to parent
-      Adapt.checkingCompletion();
-      _.defer(this.checkCompletionStatusFor.bind(this), '_isInteractionComplete');
-    }
+    const children = this.getChildren();
 
-    /**
-     * Function for checking whether the supplied completion attribute should be set to true or false.
-     * It iterates over our immediate children, checking the same completion attribute on any mandatory child
-     * to see if enough/all of them them have been completed. If enough/all have, we set our attribute to true;
-     * if not, we set it to false.
-     * @param {string} [completionAttribute] Either '_isComplete' or '_isInteractionComplete'. Defaults to '_isComplete' if not supplied.
-     */
+    children.models.forEach(child => {
 
-    checkCompletionStatusFor(completionAttribute = '_isComplete') {
-      let completed = false;
-      const children = this.getAvailableChildModels();
-      const requireCompletionOf = this.get('_requireCompletionOf');
-
-      if (requireCompletionOf === -1) { // a value of -1 indicates that ALL mandatory children must be completed
-        completed = children.every(child => {
-          return child.get(completionAttribute) || child.get('_isOptional');
-        });
-      } else {
-        completed = (children.filter(child => {
-          return child.get(completionAttribute) && !child.get('_isOptional');
-        }).length >= requireCompletionOf);
+      if (!child.hasManagedChildren) {
+        descendants.push(child);
+        return;
       }
 
-      this.set(completionAttribute, completed);
+      const subDescendants = child.getAllDescendantModels(isParentFirst);
+      if (isParentFirst === true) {
+        descendants.push(child);
+      }
 
-      Adapt.checkedCompletion();
+      descendants.push(...subDescendants);
+
+      if (isParentFirst !== true) {
+        descendants.push(child);
+      }
+    });
+
+    return descendants;
+
+  }
+
+  /**
+   * Returns a relative model from the Adapt hierarchy
+   *
+   * Such that in the tree:
+   *  { a1: { b1: [ c1, c2 ], b2: [ c3, c4 ] }, a2: { b3: [ c5, c6 ] } }
+   *
+   *  c1.findRelativeModel('@block +1') = b2;
+   *  c1.findRelativeModel('@component +4') = c5;
+   *
+   * @see Adapt.parseRelativeString for a description of relativeStrings
+   * @param {string} relativeString
+   * @param {object} options Search configuration settings
+   * @param {boolean} options.limitParentId
+   * @param {function} options.filter
+   * @param {boolean} options.loop
+   * @return {array}
+   */
+  findRelativeModel(relativeString, options = {}) {
+    // return a model relative to the specified one if opinionated
+    const rootModel = options.limitParentId ?
+      Adapt.findById(options.limitParentId) :
+      Adapt.course;
+
+    const relativeDescriptor = Adapt.parseRelativeString(relativeString);
+    const searchBackwards = (relativeDescriptor.offset < 0);
+    let moveBy = Math.abs(relativeDescriptor.offset);
+    let movementCount = 0;
+
+    const hasDescendantsOfType = Boolean(this.findDescendantModels(relativeDescriptor.type).length);
+    if (hasDescendantsOfType) {
+      // move by one less as first found is considered next
+      // will find descendants on either side but not inside
+      moveBy--;
     }
 
-    /**
-     * Returns a string describing the type group of this model.
-     * Strings should be lowercase and not plurlaized.
-     * i.e. 'page', 'menu', 'contentobject', 'component', 'article', 'block'
-     * Override in inheritance chain.
-     * @returns {string}
-     */
-    getTypeGroup() {}
+    let pageDescendants;
+    if (searchBackwards) {
+      // parents first [p1,a1,b1,c1,c2,a2,b2,c3,c4,p2,a3,b3,c6,c7,a4,b4,c8,c9]
+      pageDescendants = [rootModel];
+      pageDescendants.push(...rootModel.getAllDescendantModels(true));
 
-    /**
-     * Returns true if this model is of the type group described.
-     * Automatically manages pluralization typeGroup and matches lowercase only.
-     * Pluralized typeGroups and uppercase characters in typeGroups are discouraged.
-     * @param {string} type Type group name i.e. course, contentobject, article, block, component
-     * @returns {boolean}
-     */
-    isTypeGroup(typeGroup) {
-      const hasUpperCase = /[A-Z]+/.test(typeGroup);
-      const isPluralized = typeGroup.slice(-1) === 's';
-      const lowerCased = typeGroup.toLowerCase();
-      const singular = isPluralized && lowerCased.slice(0, -1); // remove pluralization if ending in s
-      const singularLowerCased = (singular || lowerCased).toLowerCase();
-      if (isPluralized || hasUpperCase) {
-        Adapt.log.deprecated(`'${typeGroup}' appears pluralized or contains uppercase characters, suggest using the singular, lowercase type group '${singularLowerCased}'.`);
-      }
-      const pluralizedLowerCaseTypes = [
-        singularLowerCased,
-        !isPluralized && `${lowerCased}s` // pluralize if not ending in s
-      ].filter(Boolean);
-      const typeGroups = this.getTypeGroups();
-      if (_.intersection(pluralizedLowerCaseTypes, typeGroups).length) {
+      // reverse so that we don't need a forward and a backward iterating loop
+      // reversed [c9,c8,b4,a4,c7,c6,b3,a3,p2,c4,c3,b2,a2,c2,c1,b1,a1,p1]
+      pageDescendants.reverse();
+    } else {
+      // children first [c1,c2,b1,a1,c3,c4,b2,a2,p1,c6,c7,b3,a3,c8,c9,b4,a4,p2]
+      pageDescendants = rootModel.getAllDescendantModels(false);
+      pageDescendants.push(rootModel);
+    }
+
+    // filter if opinionated
+    if (typeof options.filter === 'function') {
+      pageDescendants = pageDescendants.filter(options.filter);
+    }
+
+    // find current index in array
+    const modelId = this.get('_id');
+    const modelIndex = pageDescendants.findIndex(pageDescendant => {
+      if (pageDescendant.get('_id') === modelId) {
         return true;
       }
       return false;
+    });
+
+    if (options.loop) {
+      // normalize offset position to allow for overflow looping
+      const totalOfType = pageDescendants.reduce((count, model) => {
+        if (!model.isTypeGroup(relativeDescriptor.type)) return count;
+        return ++count;
+      }, 0);
+      // take the remainder after removing whole units of the type count
+      moveBy = moveBy % totalOfType;
+      // double up entries to allow for overflow looping
+      pageDescendants = pageDescendants.concat(pageDescendants.slice(0));
     }
 
-    /**
-     * Returns an array of strings describing the model type groups.
-     * All strings are lowercase and should not be pluralized.
-     * i.e. ['course', 'menu', 'contentobject'], ['page', 'contentobject'], ['component']
-     * @returns {[string]}
-     */
-    getTypeGroups() {
-      if (this._typeGroups) return this._typeGroups;
-      const typeGroups = [ this.get('_type') ];
-      let parentClass = this;
-      while ((parentClass = Object.getPrototypeOf(parentClass))) {
-        if (!parentClass.hasOwnProperty('getTypeGroup')) continue;
-        typeGroups.push(parentClass.getTypeGroup.call(this));
-      }
-      return (this._typeGroups = _.uniq(typeGroups.filter(Boolean).map(s => s.toLowerCase())));
-    }
-
-    /**
-     * Searches the model's ancestors to find the first instance of the specified ancestor type
-     * @param {string} [ancestorType] Valid values are 'course', 'pages', 'contentObjects', 'articles' or 'blocks'.
-     * If left blank, the immediate ancestor (if there is one) is returned
-     * @return {object} Reference to the model of the first ancestor of the specified type that's found - or `undefined` if none found
-     */
-    findAncestor(ancestorType) {
-      const parent = this.getParent();
-      if (!parent) return;
-      if (!ancestorType || parent.isTypeGroup(ancestorType)) {
-        return parent;
-      }
-      return parent.findAncestor(ancestorType);
-    }
-
-    /**
-     * Returns all the descendant models of a specific type
-     * @param {string} descendants Valid values are 'contentobject', 'page', 'menu', 'article', 'block', 'component', 'question'
-     * @param {object} options an object that defines the search type and the properties/values to search on. Currently only the `where` search type (equivalent to `Backbone.Collection.where()`) is supported.
-     * @param {object} options.where
-     * @return {array}
-     * @example
-     * //find all available, non-optional components
-     * this.findDescendantModels('component', { where: { _isAvailable: true, _isOptional: false }});
-     */
-    findDescendantModels(descendants, options) {
-      const allDescendantsModels = this.getAllDescendantModels();
-      const returnedDescendants = allDescendantsModels.filter(model => {
-        return model.isTypeGroup(descendants);
-      });
-
-      if (!options) {
-        return returnedDescendants;
-      }
-
-      if (options.where) {
-        return returnedDescendants.filter(descendant => {
-          for (let property in options.where) {
-            const value = options.where[property];
-            if (descendant.get(property) !== value) {
-              return false;
-            }
-          }
-          return true;
-        });
-      }
-    }
-
-    /**
-     * Fetches the sub structure of a model as a flattened array
-     *
-     * Such that the tree:
-     *  { a1: { b1: [ c1, c2 ], b2: [ c3, c4 ] }, a2: { b3: [ c5, c6 ] } }
-     *
-     * will become the array (parent first = false):
-     *  [ c1, c2, b1, c3, c4, b2, a1, c5, c6, b3, a2 ]
-     *
-     * or (parent first = true):
-     *  [ a1, b1, c1, c2, b2, c3, c4, a2, b3, c5, c6 ]
-     *
-     * This is useful when sequential operations are performed on the menu/page/article/block/component hierarchy.
-     * @param {boolean} [isParentFirst]
-     * @return {array}
-     */
-    getAllDescendantModels(isParentFirst) {
-
-      const descendants = [];
-
-      if (!this.hasManagedChildren) {
-        return descendants;
-      }
-
-      const children = this.getChildren();
-
-      children.models.forEach(child => {
-
-        if (!child.hasManagedChildren) {
-          descendants.push(child);
-          return;
-        }
-
-        const subDescendants = child.getAllDescendantModels(isParentFirst);
-        if (isParentFirst === true) {
-          descendants.push(child);
-        }
-
-        descendants.push(...subDescendants);
-
-        if (isParentFirst !== true) {
-          descendants.push(child);
-        }
-      });
-
-      return descendants;
-
-    }
-
-    /**
-     * Returns a relative model from the Adapt hierarchy
-     *
-     * Such that in the tree:
-     *  { a1: { b1: [ c1, c2 ], b2: [ c3, c4 ] }, a2: { b3: [ c5, c6 ] } }
-     *
-     *  c1.findRelativeModel('@block +1') = b2;
-     *  c1.findRelativeModel('@component +4') = c5;
-     *
-     * @see Adapt.parseRelativeString for a description of relativeStrings
-     * @param {string} relativeString
-     * @param {object} options Search configuration settings
-     * @param {boolean} options.limitParentId
-     * @param {function} options.filter
-     * @param {boolean} options.loop
-     * @return {array}
-     */
-    findRelativeModel(relativeString, options = {}) {
-      // return a model relative to the specified one if opinionated
-      const rootModel = options.limitParentId ?
-        Adapt.findById(options.limitParentId) :
-        Adapt.course;
-
-      const relativeDescriptor = Adapt.parseRelativeString(relativeString);
-      const searchBackwards = (relativeDescriptor.offset < 0);
-      let moveBy = Math.abs(relativeDescriptor.offset);
-      let movementCount = 0;
-
-      const hasDescendantsOfType = Boolean(this.findDescendantModels(relativeDescriptor.type).length);
-      if (hasDescendantsOfType) {
-        // move by one less as first found is considered next
-        // will find descendants on either side but not inside
-        moveBy--;
-      }
-
-      let pageDescendants;
-      if (searchBackwards) {
-        // parents first [p1,a1,b1,c1,c2,a2,b2,c3,c4,p2,a3,b3,c6,c7,a4,b4,c8,c9]
-        pageDescendants = [rootModel];
-        pageDescendants.push(...rootModel.getAllDescendantModels(true));
-
-        // reverse so that we don't need a forward and a backward iterating loop
-        // reversed [c9,c8,b4,a4,c7,c6,b3,a3,p2,c4,c3,b2,a2,c2,c1,b1,a1,p1]
-        pageDescendants.reverse();
-      } else {
-        // children first [c1,c2,b1,a1,c3,c4,b2,a2,p1,c6,c7,b3,a3,c8,c9,b4,a4,p2]
-        pageDescendants = rootModel.getAllDescendantModels(false);
-        pageDescendants.push(rootModel);
-      }
-
-      // filter if opinionated
-      if (typeof options.filter === 'function') {
-        pageDescendants = pageDescendants.filter(options.filter);
-      }
-
-      // find current index in array
-      const modelId = this.get('_id');
-      const modelIndex = pageDescendants.findIndex(pageDescendant => {
-        if (pageDescendant.get('_id') === modelId) {
-          return true;
-        }
-        return false;
-      });
-
-      if (options.loop) {
-        // normalize offset position to allow for overflow looping
-        const totalOfType = pageDescendants.reduce((count, model) => {
-          if (!model.isTypeGroup(relativeDescriptor.type)) return count;
-          return ++count;
-        }, 0);
-        // take the remainder after removing whole units of the type count
-        moveBy = moveBy % totalOfType;
-        // double up entries to allow for overflow looping
-        pageDescendants = pageDescendants.concat(pageDescendants.slice(0));
-      }
-
-      for (let i = modelIndex, l = pageDescendants.length; i < l; i++) {
-        const descendant = pageDescendants[i];
-        if (descendant.isTypeGroup(relativeDescriptor.type)) {
-          if (movementCount > moveBy) {
-            // there is no descendant which matches this relativeString
-            // probably looking for the descendant 0 in a parent
-            break;
-          }
-          if (movementCount === moveBy) {
-            return Adapt.findById(descendant.get('_id'));
-          }
-          movementCount++;
-        }
-      }
-
-    }
-
-    get hasManagedChildren() {
-      return true;
-    }
-
-    getChildren() {
-      if (this._childrenCollection) {
-        return this._childrenCollection;
-      }
-
-      let childrenCollection;
-
-      if (!this.hasManagedChildren) {
-        childrenCollection = new Backbone.Collection();
-      } else {
-        const id = this.get('_id');
-        // Look up child by _parentId from Adapt.data
-        const children = Adapt.data.filter(model => model.get('_parentId') === id);
-        childrenCollection = new Backbone.Collection(children);
-      }
-
-      if (this.get('_type') === 'block' &&
-        childrenCollection.length === 2 &&
-        childrenCollection.models[0].get('_layout') !== 'left') {
-        // Components may have a 'left' or 'right' _layout,
-        // so ensure they appear in the correct order
-        // Re-order component models to correct it
-        childrenCollection.comparator = '_layout';
-        childrenCollection.sort();
-      }
-
-      this.setChildren(childrenCollection);
-      return this._childrenCollection;
-    }
-
-    setChildren(children) {
-      this._childrenCollection = children;
-      // Setup deprecated reference
-      this.set('_children', children);
-    }
-
-    getAvailableChildModels() {
-      return this.getChildren().where({
-        _isAvailable: true
-      });
-    }
-
-    getParent() {
-      if (this._parentModel) {
-        return this._parentModel;
-      }
-      const parentId = this.get('_parentId');
-      if (!parentId) return;
-      // Look up parent by id from Adapt.data
-      this.setParent(Adapt.findById(parentId));
-      return this._parentModel;
-    }
-
-    setParent(parent) {
-      this._parentModel = parent;
-      this.set('_parentId', this._parentModel.get('_id'));
-      // Set up deprecated reference
-      this.set('_parent', this._parentModel);
-    }
-
-    getAncestorModels(shouldIncludeChild) {
-      const parents = [];
-      let context = this;
-
-      if (shouldIncludeChild) parents.push(context);
-
-      while (context.has('_parentId')) {
-        context = context.getParent();
-        parents.push(context);
-      }
-
-      return parents.length ? parents : null;
-    }
-
-    getSiblings(passSiblingsAndIncludeSelf) {
-      const id = this.get('_id');
-      const parentId = this.get('_parentId');
-      let siblings;
-      if (!passSiblingsAndIncludeSelf) {
-        // returns a collection of siblings excluding self
-        if (this._hasSiblingsAndSelf === false) {
-          return this.get('_siblings');
-        }
-        siblings = Adapt.data.filter(model => {
-          return model.get('_parentId') === parentId &&
-            model.get('_id') !== id;
-        });
-
-        this._hasSiblingsAndSelf = false;
-
-      } else {
-        // returns a collection of siblings including self
-        if (this._hasSiblingsAndSelf) {
-          return this.get('_siblings');
-        }
-
-        siblings = Adapt.data.filter(model => {
-          return model.get('_parentId') === parentId;
-        });
-        this._hasSiblingsAndSelf = true;
-      }
-
-      const siblingsCollection = new Backbone.Collection(siblings);
-      this.set('_siblings', siblingsCollection);
-      return siblingsCollection;
-    }
-
-    /**
-     * @param  {string} key
-     * @param  {any} value
-     * @param  {Object} options
-     */
-    setOnChildren(...args) {
-
-      this.set(...args);
-
-      if (!this.hasManagedChildren) return;
-
-      const children = this.getChildren();
-      children.models.forEach(child => child.setOnChildren(...args));
-
-    }
-
-    /**
-     * @deprecated since v3.2.3 - please use `model.set('_isOptional', value)` instead
-     */
-    setOptional(value) {
-      Adapt.log.deprecated(`Use model.set('_isOptional', value) as setOptional() may be removed in the future`);
-      this.set({ _isOptional: value });
-    }
-
-    checkLocking() {
-      const lockType = this.get('_lockType');
-
-      if (!lockType) return;
-
-      switch (lockType) {
-        case 'sequential':
-          this.setSequentialLocking();
+    for (let i = modelIndex, l = pageDescendants.length; i < l; i++) {
+      const descendant = pageDescendants[i];
+      if (descendant.isTypeGroup(relativeDescriptor.type)) {
+        if (movementCount > moveBy) {
+          // there is no descendant which matches this relativeString
+          // probably looking for the descendant 0 in a parent
           break;
-        case 'unlockFirst':
-          this.setUnlockFirstLocking();
-          break;
-        case 'lockLast':
-          this.setLockLastLocking();
-          break;
-        case 'custom':
-          this.setCustomLocking();
-          break;
-        default:
-          console.warn(`AdaptModel.checkLocking: unknown _lockType '${lockType}' found on ${this.get('_id')}`);
-      }
-    }
-
-    setSequentialLocking() {
-      const children = this.getAvailableChildModels();
-
-      for (let i = 1, j = children.length; i < j; i++) {
-        children[i].set('_isLocked', !children[i - 1].get('_isComplete'));
-      }
-    }
-
-    setUnlockFirstLocking() {
-      const children = this.getAvailableChildModels();
-      const isFirstChildComplete = children[0].get('_isComplete');
-
-      for (let i = 1, j = children.length; i < j; i++) {
-        children[i].set('_isLocked', !isFirstChildComplete);
-      }
-    }
-
-    setLockLastLocking() {
-      const children = this.getAvailableChildModels();
-      const lastIndex = children.length - 1;
-
-      for (let i = lastIndex - 1; i >= 0; i--) {
-        if (!children[i].get('_isComplete')) {
-          return children[lastIndex].set('_isLocked', true);
         }
-      }
-
-      children[lastIndex].set('_isLocked', false);
-    }
-
-    setCustomLocking() {
-      const children = this.getAvailableChildModels();
-      children.forEach(child => {
-        child.set('_isLocked', this.shouldLock(child));
-      });
-    }
-
-    shouldLock(child) {
-      const lockedBy = child.get('_lockedBy');
-
-      if (!lockedBy) return false;
-
-      for (let i = lockedBy.length - 1; i >= 0; i--) {
-        const id = lockedBy[i];
-
-        try {
-          const model = Adapt.findById(id);
-
-          if (!model.get('_isAvailable')) continue;
-          if (!model.get('_isComplete')) return true;
-        } catch (e) {
-          console.warn(`AdaptModel.shouldLock: unknown _lockedBy ID '${id}' found on ${child.get('_id')}`);
+        if (movementCount === moveBy) {
+          return Adapt.findById(descendant.get('_id'));
         }
+        movementCount++;
       }
-
-      return false;
-    }
-
-    onIsComplete() {
-      this.checkCompletionStatus();
-
-      this.checkLocking();
-    }
-
-    /**
-     * Used before a model is rendered to determine if it should be reset to its
-     * default values.
-     */
-    checkIfResetOnRevisit() {
-      const isResetOnRevisit = this.get('_isResetOnRevisit');
-      if (!isResetOnRevisit) {
-        return;
-      }
-      // If reset is enabled set defaults
-      this.reset(isResetOnRevisit);
-    }
-
-    /**
-     * Clones this model and all managed children returning a new branch.
-     * Assign new unique ids to each cloned model.
-     * @param {Function} [modifier] A callback function for each child to allow for custom modifications
-     * @returns {AdaptModel}
-     */
-    deepClone(modifier = null) {
-      // Fetch the class
-      const ModelClass = this.constructor;
-      // Clone the model
-      const clonedModel = new ModelClass(this.toJSON());
-      // Run the custom modifier on the clone
-      if (modifier) {
-        modifier(clonedModel, this);
-      }
-      let clonedId = clonedModel.get('_id');
-      const hasId = Boolean(clonedId);
-      const shouldAssignUniqueId = (this.get('_id') === clonedId);
-      if (hasId && shouldAssignUniqueId) {
-        // Create a unique id if none was set by the modifier
-        const cid = _.uniqueId(ModelClass.prototype.cidPrefix || 'c');
-        clonedId = `${clonedId}_${cid}`;
-        clonedModel.set('_id', clonedId);
-      }
-      // Add the cloned model to Adapt.data for Adapt.findById resolution
-      if (hasId) {
-        Adapt.data.add(clonedModel);
-      }
-      // Clone any children
-      if (this.hasManagedChildren) {
-        this.getChildren().each(child => {
-          if (!child.deepClone) {
-            throw new Error('Cannot deepClone child.');
-          }
-          child.deepClone((clone, child) => {
-            if (hasId) {
-              // Set the cloned child parent id
-              clone.set('_parentId', clonedId);
-            }
-            if (modifier) {
-              // Run the custom modifier function on the cloned child
-              modifier(clone, child);
-            }
-          });
-        });
-      }
-      // Add the cloned model to its parent for model.findDescendants resolution
-      clonedModel.getParent().getChildren().add(clonedModel);
-      // Setup the cloned model after setting the id, the parent and adding any children
-      clonedModel.setupModel();
-      return clonedModel;
-    }
-
-    /**
-     * Internal event handler for all module events. Triggers event bubbling
-     * through the module hierarchy when the event is included in
-     * `this.bubblingEvents`.
-     * @param {string} type Event name / type
-     * @param {Backbone.Model} model Origin backbone model
-     * @param {*} value New property value
-     */
-    onAll(type, model, value) {
-      if (!_.result(this, 'bubblingEvents').includes(type)) return;
-      const event = new ModelEvent(type, model, value);
-      this.bubble(event);
-    }
-
-    /**
-     * Internal event handler for bubbling events.
-     * @param {ModelEvent} event
-     */
-    bubble(event) {
-      if (!event.canBubble) return;
-      event.addPath(this);
-      this.trigger(`bubble:${event.type} bubble`, event);
     }
 
   }
 
-  return AdaptModel;
+  get hasManagedChildren() {
+    return true;
+  }
 
-});
+  getChildren() {
+    if (this._childrenCollection) {
+      return this._childrenCollection;
+    }
+
+    let childrenCollection;
+
+    if (!this.hasManagedChildren) {
+      childrenCollection = new Backbone.Collection();
+    } else {
+      const id = this.get('_id');
+      // Look up child by _parentId from Adapt.data
+      const children = Adapt.data.filter(model => model.get('_parentId') === id);
+      childrenCollection = new Backbone.Collection(children);
+    }
+
+    if (this.get('_type') === 'block' &&
+      childrenCollection.length === 2 &&
+      childrenCollection.models[0].get('_layout') !== 'left') {
+      // Components may have a 'left' or 'right' _layout,
+      // so ensure they appear in the correct order
+      // Re-order component models to correct it
+      childrenCollection.comparator = '_layout';
+      childrenCollection.sort();
+    }
+
+    this.setChildren(childrenCollection);
+    return this._childrenCollection;
+  }
+
+  setChildren(children) {
+    this._childrenCollection = children;
+    // Setup deprecated reference
+    this.set('_children', children);
+  }
+
+  getAvailableChildModels() {
+    return this.getChildren().where({
+      _isAvailable: true
+    });
+  }
+
+  getParent() {
+    if (this._parentModel) {
+      return this._parentModel;
+    }
+    const parentId = this.get('_parentId');
+    if (!parentId) return;
+    // Look up parent by id from Adapt.data
+    this.setParent(Adapt.findById(parentId));
+    return this._parentModel;
+  }
+
+  setParent(parent) {
+    this._parentModel = parent;
+    this.set('_parentId', this._parentModel.get('_id'));
+    // Set up deprecated reference
+    this.set('_parent', this._parentModel);
+  }
+
+  getAncestorModels(shouldIncludeChild) {
+    const parents = [];
+    let context = this;
+
+    if (shouldIncludeChild) parents.push(context);
+
+    while (context.has('_parentId')) {
+      context = context.getParent();
+      parents.push(context);
+    }
+
+    return parents.length ? parents : null;
+  }
+
+  getSiblings(passSiblingsAndIncludeSelf) {
+    const id = this.get('_id');
+    const parentId = this.get('_parentId');
+    let siblings;
+    if (!passSiblingsAndIncludeSelf) {
+      // returns a collection of siblings excluding self
+      if (this._hasSiblingsAndSelf === false) {
+        return this.get('_siblings');
+      }
+      siblings = Adapt.data.filter(model => {
+        return model.get('_parentId') === parentId &&
+          model.get('_id') !== id;
+      });
+
+      this._hasSiblingsAndSelf = false;
+
+    } else {
+      // returns a collection of siblings including self
+      if (this._hasSiblingsAndSelf) {
+        return this.get('_siblings');
+      }
+
+      siblings = Adapt.data.filter(model => {
+        return model.get('_parentId') === parentId;
+      });
+      this._hasSiblingsAndSelf = true;
+    }
+
+    const siblingsCollection = new Backbone.Collection(siblings);
+    this.set('_siblings', siblingsCollection);
+    return siblingsCollection;
+  }
+
+  /**
+   * @param  {string} key
+   * @param  {any} value
+   * @param  {Object} options
+   */
+  setOnChildren(...args) {
+
+    this.set(...args);
+
+    if (!this.hasManagedChildren) return;
+
+    const children = this.getChildren();
+    children.models.forEach(child => child.setOnChildren(...args));
+
+  }
+
+  /**
+   * @deprecated since v3.2.3 - please use `model.set('_isOptional', value)` instead
+   */
+  setOptional(value) {
+    Adapt.log.deprecated(`Use model.set('_isOptional', value) as setOptional() may be removed in the future`);
+    this.set({ _isOptional: value });
+  }
+
+  checkLocking() {
+    const lockType = this.get('_lockType');
+
+    if (!lockType) return;
+
+    switch (lockType) {
+      case 'sequential':
+        this.setSequentialLocking();
+        break;
+      case 'unlockFirst':
+        this.setUnlockFirstLocking();
+        break;
+      case 'lockLast':
+        this.setLockLastLocking();
+        break;
+      case 'custom':
+        this.setCustomLocking();
+        break;
+      default:
+        console.warn(`AdaptModel.checkLocking: unknown _lockType '${lockType}' found on ${this.get('_id')}`);
+    }
+  }
+
+  setSequentialLocking() {
+    const children = this.getAvailableChildModels();
+
+    for (let i = 1, j = children.length; i < j; i++) {
+      children[i].set('_isLocked', !children[i - 1].get('_isComplete'));
+    }
+  }
+
+  setUnlockFirstLocking() {
+    const children = this.getAvailableChildModels();
+    const isFirstChildComplete = children[0].get('_isComplete');
+
+    for (let i = 1, j = children.length; i < j; i++) {
+      children[i].set('_isLocked', !isFirstChildComplete);
+    }
+  }
+
+  setLockLastLocking() {
+    const children = this.getAvailableChildModels();
+    const lastIndex = children.length - 1;
+
+    for (let i = lastIndex - 1; i >= 0; i--) {
+      if (!children[i].get('_isComplete')) {
+        return children[lastIndex].set('_isLocked', true);
+      }
+    }
+
+    children[lastIndex].set('_isLocked', false);
+  }
+
+  setCustomLocking() {
+    const children = this.getAvailableChildModels();
+    children.forEach(child => {
+      child.set('_isLocked', this.shouldLock(child));
+    });
+  }
+
+  shouldLock(child) {
+    const lockedBy = child.get('_lockedBy');
+
+    if (!lockedBy) return false;
+
+    for (let i = lockedBy.length - 1; i >= 0; i--) {
+      const id = lockedBy[i];
+
+      try {
+        const model = Adapt.findById(id);
+
+        if (!model.get('_isAvailable')) continue;
+        if (!model.get('_isComplete')) return true;
+      } catch (e) {
+        console.warn(`AdaptModel.shouldLock: unknown _lockedBy ID '${id}' found on ${child.get('_id')}`);
+      }
+    }
+
+    return false;
+  }
+
+  onIsComplete() {
+    this.checkCompletionStatus();
+
+    this.checkLocking();
+  }
+
+  /**
+   * Used before a model is rendered to determine if it should be reset to its
+   * default values.
+   */
+  checkIfResetOnRevisit() {
+    const isResetOnRevisit = this.get('_isResetOnRevisit');
+    if (!isResetOnRevisit) {
+      return;
+    }
+    // If reset is enabled set defaults
+    this.reset(isResetOnRevisit);
+  }
+
+  /**
+   * Clones this model and all managed children returning a new branch.
+   * Assign new unique ids to each cloned model.
+   * @param {Function} [modifier] A callback function for each child to allow for custom modifications
+   * @returns {AdaptModel}
+   */
+  deepClone(modifier = null) {
+    // Fetch the class
+    const ModelClass = this.constructor;
+    // Clone the model
+    const clonedModel = new ModelClass(this.toJSON());
+    // Run the custom modifier on the clone
+    if (modifier) {
+      modifier(clonedModel, this);
+    }
+    let clonedId = clonedModel.get('_id');
+    const hasId = Boolean(clonedId);
+    const shouldAssignUniqueId = (this.get('_id') === clonedId);
+    if (hasId && shouldAssignUniqueId) {
+      // Create a unique id if none was set by the modifier
+      const cid = _.uniqueId(ModelClass.prototype.cidPrefix || 'c');
+      clonedId = `${clonedId}_${cid}`;
+      clonedModel.set('_id', clonedId);
+    }
+    // Add the cloned model to Adapt.data for Adapt.findById resolution
+    if (hasId) {
+      Adapt.data.add(clonedModel);
+    }
+    // Clone any children
+    if (this.hasManagedChildren) {
+      this.getChildren().each(child => {
+        if (!child.deepClone) {
+          throw new Error('Cannot deepClone child.');
+        }
+        child.deepClone((clone, child) => {
+          if (hasId) {
+            // Set the cloned child parent id
+            clone.set('_parentId', clonedId);
+          }
+          if (modifier) {
+            // Run the custom modifier function on the cloned child
+            modifier(clone, child);
+          }
+        });
+      });
+    }
+    // Add the cloned model to its parent for model.findDescendants resolution
+    clonedModel.getParent().getChildren().add(clonedModel);
+    // Setup the cloned model after setting the id, the parent and adding any children
+    clonedModel.setupModel();
+    return clonedModel;
+  }
+
+  /**
+   * Internal event handler for all module events. Triggers event bubbling
+   * through the module hierarchy when the event is included in
+   * `this.bubblingEvents`.
+   * @param {string} type Event name / type
+   * @param {Backbone.Model} model Origin backbone model
+   * @param {*} value New property value
+   */
+  onAll(type, model, value) {
+    if (!_.result(this, 'bubblingEvents').includes(type)) return;
+    const event = new ModelEvent(type, model, value);
+    this.bubble(event);
+  }
+
+  /**
+   * Internal event handler for bubbling events.
+   * @param {ModelEvent} event
+   */
+  bubble(event) {
+    if (!event.canBubble) return;
+    event.addPath(this);
+    this.trigger(`bubble:${event.type} bubble`, event);
+  }
+
+}

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -6,7 +6,7 @@ export default class AdaptModel extends Backbone.Model {
 
   toJSON() {
     // Perform shallow clone
-    const json = _.clone(this.attributes);
+    const json = { ...this.attributes };
     // Remove deprecated values as they are not true json
     delete json._children;
     delete json._parent;

--- a/src/core/js/models/articleModel.js
+++ b/src/core/js/models/articleModel.js
@@ -1,37 +1,33 @@
-define([
-  'core/js/adapt',
-  'core/js/models/adaptModel'
-], function (Adapt, AdaptModel) {
+import Adapt from 'core/js/adapt';
+import AdaptModel from 'core/js/models/adaptModel';
 
-  class ArticleModel extends AdaptModel {
+class ArticleModel extends AdaptModel {
 
-    get _parent() {
-      Adapt.log.deprecated('articleModel._parent, use articleModel.getParent() instead, parent models are defined by the JSON');
-      return 'contentObjects';
-    }
-
-    get _siblings() {
-      Adapt.log.deprecated('articleModel._siblings, use articleModel.getSiblings() instead, sibling models are defined by the JSON');
-      return 'articles';
-    }
-
-    get _children() {
-      Adapt.log.deprecated('articleModel._children, use articleModel.hasManagedChildren instead, child models are defined by the JSON');
-      return 'blocks';
-    }
-
-    /**
-     * Returns a string of the model type group.
-     * @returns {string}
-     */
-    getTypeGroup() {
-      return 'article';
-    }
-
+  get _parent() {
+    Adapt.log.deprecated('articleModel._parent, use articleModel.getParent() instead, parent models are defined by the JSON');
+    return 'contentObjects';
   }
 
-  Adapt.register('article', { model: ArticleModel });
+  get _siblings() {
+    Adapt.log.deprecated('articleModel._siblings, use articleModel.getSiblings() instead, sibling models are defined by the JSON');
+    return 'articles';
+  }
 
-  return ArticleModel;
+  get _children() {
+    Adapt.log.deprecated('articleModel._children, use articleModel.hasManagedChildren instead, child models are defined by the JSON');
+    return 'blocks';
+  }
 
-});
+  /**
+   * Returns a string of the model type group.
+   * @returns {string}
+   */
+  getTypeGroup() {
+    return 'article';
+  }
+
+}
+
+Adapt.register('article', { model: ArticleModel });
+
+export default ArticleModel;

--- a/src/core/js/models/blockModel.js
+++ b/src/core/js/models/blockModel.js
@@ -1,37 +1,33 @@
-define([
-  'core/js/adapt',
-  'core/js/models/adaptModel'
-], function (Adapt, AdaptModel) {
+import Adapt from 'core/js/adapt';
+import AdaptModel from 'core/js/models/adaptModel';
 
-  class BlockModel extends AdaptModel {
+class BlockModel extends AdaptModel {
 
-    get _parent() {
-      Adapt.log.deprecated('blockModel._parent, use blockModel.getParent() instead, parent models are defined by the JSON');
-      return 'articles';
-    }
-
-    get _siblings() {
-      Adapt.log.deprecated('blockModel._siblings, use blockModel.getSiblings() instead, sibling models are defined by the JSON');
-      return 'blocks';
-    }
-
-    get _children() {
-      Adapt.log.deprecated('blockModel._children, use blockModel.hasManagedChildren instead, child models are defined by the JSON');
-      return 'components';
-    }
-
-    /**
-     * Returns a string of the model type group.
-     * @returns {string}
-     */
-    getTypeGroup() {
-      return 'block';
-    }
-
+  get _parent() {
+    Adapt.log.deprecated('blockModel._parent, use blockModel.getParent() instead, parent models are defined by the JSON');
+    return 'articles';
   }
 
-  Adapt.register('block', { model: BlockModel });
+  get _siblings() {
+    Adapt.log.deprecated('blockModel._siblings, use blockModel.getSiblings() instead, sibling models are defined by the JSON');
+    return 'blocks';
+  }
 
-  return BlockModel;
+  get _children() {
+    Adapt.log.deprecated('blockModel._children, use blockModel.hasManagedChildren instead, child models are defined by the JSON');
+    return 'components';
+  }
 
-});
+  /**
+   * Returns a string of the model type group.
+   * @returns {string}
+   */
+  getTypeGroup() {
+    return 'block';
+  }
+
+}
+
+Adapt.register('block', { model: BlockModel });
+
+export default BlockModel;

--- a/src/core/js/models/buildModel.js
+++ b/src/core/js/models/buildModel.js
@@ -1,7 +1,8 @@
 import Adapt from 'core/js/adapt';
+import LockingModel from 'core/js/models/lockingModel';
 import 'core/js/logging';
 
-export default class BuildModel extends Backbone.Model {
+export default class BuildModel extends LockingModel {
 
   defaults() {
     return {

--- a/src/core/js/models/buildModel.js
+++ b/src/core/js/models/buildModel.js
@@ -1,42 +1,36 @@
-define([
-  'core/js/adapt',
-  'core/js/logging'
-], function (Adapt) {
+import Adapt from 'core/js/adapt';
+import 'core/js/logging';
 
-  class BuildModel extends Backbone.Model {
+export default class BuildModel extends Backbone.Model {
 
-    defaults() {
-      return {
-        jsonext: 'json'
-      };
-    }
-
-    initialize(attrs, options) {
-      this.url = options.url;
-      // Fetch data & if successful trigger event to enable plugins to stop course files loading
-      // Then check if course files can load
-      // 'configModel:loadCourseData' event starts the core content collections and models being fetched
-      this.fetch({
-        success: () => {
-          this.isLoaded = true;
-          Adapt.trigger('buildModel:dataLoaded');
-        },
-        error: () => {
-          console.log('Unable to load adapt/js/build.js');
-          Adapt.trigger('buildModel:dataLoaded');
-        }
-      });
-    }
-
-    whenReady() {
-      if (this.isLoaded) return Promise.resolve();
-      return new Promise(resolve => {
-        Adapt.once('buildModel:dataLoaded', resolve);
-      });
-    }
-
+  defaults() {
+    return {
+      jsonext: 'json'
+    };
   }
 
-  return BuildModel;
+  initialize(attrs, options) {
+    this.url = options.url;
+    // Fetch data & if successful trigger event to enable plugins to stop course files loading
+    // Then check if course files can load
+    // 'configModel:loadCourseData' event starts the core content collections and models being fetched
+    this.fetch({
+      success: () => {
+        this.isLoaded = true;
+        Adapt.trigger('buildModel:dataLoaded');
+      },
+      error: () => {
+        console.log('Unable to load adapt/js/build.js');
+        Adapt.trigger('buildModel:dataLoaded');
+      }
+    });
+  }
 
-});
+  whenReady() {
+    if (this.isLoaded) return Promise.resolve();
+    return new Promise(resolve => {
+      Adapt.once('buildModel:dataLoaded', resolve);
+    });
+  }
+
+}

--- a/src/core/js/models/componentModel.js
+++ b/src/core/js/models/componentModel.js
@@ -1,186 +1,182 @@
-define([
-  'core/js/adapt',
-  'core/js/models/adaptModel'
-], function (Adapt, AdaptModel) {
+import Adapt from 'core/js/adapt';
+import AdaptModel from 'core/js/models/adaptModel';
 
-  class ComponentModel extends AdaptModel {
+class ComponentModel extends AdaptModel {
 
-    get _parent() {
-      Adapt.log.deprecated('componentModel._parent, use componentModel.getParent() instead, parent models are defined by the JSON');
-      return 'blocks';
-    }
-
-    get _siblings() {
-      Adapt.log.deprecated('componentModel._siblings, use componentModel.getSiblings() instead, sibling models are defined by the JSON');
-      return 'components';
-    }
-
-    /**
-     * Returns a string of the model type group.
-     * @returns {string}
-     */
-    getTypeGroup() {
-      return 'component';
-    }
-
-    defaults() {
-      return AdaptModel.resultExtend('defaults', {
-        _isA11yComponentDescriptionEnabled: true,
-        _userAnswer: null,
-        _attemptStates: null
-      });
-    }
-
-    trackable() {
-      return AdaptModel.resultExtend('trackable', [
-        '_userAnswer',
-        '_attemptStates'
-      ]);
-    }
-
-    trackableType() {
-      return AdaptModel.resultExtend('trackableType', [
-        Array,
-        Array
-      ]);
-    }
-
-    get hasManagedChildren() {
-      return false;
-    }
-
-    init() {
-      if (Adapt.get('_isStarted')) {
-        this.onAdaptInitialize();
-        return;
-      }
-      this.listenToOnce(Adapt, 'adapt:initialize', this.onAdaptInitialize);
-    }
-
-    onAdaptInitialize() {
-      this.restoreUserAnswers();
-    }
-
-    /**
-     * Restore the user's answer from the _userAnswer property.
-     * The _userAnswer value must be in the form of arrays containing
-     * numbers, booleans or arrays only.
-     */
-    restoreUserAnswers() {}
-
-    /**
-     * Store the user's answer in the _userAnswer property.
-     * The _userAnswer value must be in the form of arrays containing
-     * numbers, booleans or arrays only.
-     */
-    storeUserAnswer() {}
-
-    resetUserAnswer() {
-      this.set('_userAnswer', null);
-    }
-
-    reset(type, force) {
-      if (!this.get('_canReset') && !force) return;
-      this.resetUserAnswer();
-      super.reset(type, force);
-    }
-
-    /**
-     * Returns the current attempt state raw data or the raw data from the supplied attempt state object.
-     * @param {Object} [object] JSON object representing the component state. Defaults to current JSON.
-     * @returns {Array}
-     */
-    getAttemptState(object = this.toJSON()) {
-      const trackables = this.trackable();
-      const types = this.trackableType();
-      trackables.find((name, index) => {
-        // Exclude _attemptStates as it's trackable but isn't needed here
-        if (name !== '_attemptStates') return;
-        trackables.splice(index, 1);
-        types.splice(index, 1);
-        return true;
-      });
-      const values = trackables.map(n => object[n]);
-      const booleans = values.filter((v, i) => types[i] === Boolean).map(Boolean);
-      const numbers = values.filter((v, i) => types[i] === Number).map(v => Number(v) || 0);
-      const arrays = values.filter((v, i) => types[i] === Array);
-      return [
-        numbers,
-        booleans,
-        arrays
-      ];
-    }
-
-    /**
-     * Returns an attempt object representing the current state or a formatted version of the raw state object supplied.
-     * @param {Array} [state] JSON object representing the component state, defaults to current state returned from getAttemptState().
-     * @returns {Object}
-     */
-    getAttemptObject(state = this.getAttemptState()) {
-      const trackables = this.trackable();
-      const types = this.trackableType();
-      trackables.find((name, index) => {
-        // Exclude _attemptStates as it's trackable but isn't needed here
-        if (name !== '_attemptStates') return;
-        trackables.splice(index, 1);
-        types.splice(index, 1);
-        return true;
-      });
-      const numbers = (state[0] || []).slice(0);
-      const booleans = (state[1] || []).slice(0);
-      const arrays = (state[2] || []).slice(0);
-      const object = {};
-      trackables.forEach((n, i) => {
-        if (n === '_id') return;
-        switch (types[i]) {
-          case Number:
-            object[n] = numbers.shift();
-            break;
-          case Boolean:
-            object[n] = booleans.shift();
-            break;
-          case Array:
-            object[n] = arrays.shift();
-            break;
-        }
-      });
-      return object;
-    }
-
-    /**
-     * Sets the current attempt state from the supplied attempt state object.
-     * @param {Object} object JSON object representing the component state.
-     * @param {boolean} silent Stops change events from triggering
-     */
-    setAttemptObject(object, silent = true) {
-      this.set(object, { silent });
-    }
-
-    /**
-     * Adds the current attempt state object or the supplied state object to the attempts store.
-     * @param {Object} [object] JSON object representing the component state. Defaults to current JSON.
-     */
-    addAttemptObject(object = this.getAttemptObject()) {
-      const attemptStates = this.get('_attemptStates') || [];
-      const state = this.getAttemptState(object);
-      attemptStates.push(state);
-      this.set('_attemptStates', attemptStates);
-    }
-
-    /**
-     * Returns an array of the previous state objects. The most recent state is last in the list.
-     * @returns {Array}
-     */
-    getAttemptObjects() {
-      const states = this.get('_attemptStates') || [];
-      return states.map(state => this.getAttemptObject(state));
-    }
-
+  get _parent() {
+    Adapt.log.deprecated('componentModel._parent, use componentModel.getParent() instead, parent models are defined by the JSON');
+    return 'blocks';
   }
 
-  // This abstract model needs to registered to support deprecated view-only components
-  Adapt.register('component', { model: ComponentModel });
+  get _siblings() {
+    Adapt.log.deprecated('componentModel._siblings, use componentModel.getSiblings() instead, sibling models are defined by the JSON');
+    return 'components';
+  }
 
-  return ComponentModel;
+  /**
+   * Returns a string of the model type group.
+   * @returns {string}
+   */
+  getTypeGroup() {
+    return 'component';
+  }
 
-});
+  defaults() {
+    return AdaptModel.resultExtend('defaults', {
+      _isA11yComponentDescriptionEnabled: true,
+      _userAnswer: null,
+      _attemptStates: null
+    });
+  }
+
+  trackable() {
+    return AdaptModel.resultExtend('trackable', [
+      '_userAnswer',
+      '_attemptStates'
+    ]);
+  }
+
+  trackableType() {
+    return AdaptModel.resultExtend('trackableType', [
+      Array,
+      Array
+    ]);
+  }
+
+  get hasManagedChildren() {
+    return false;
+  }
+
+  init() {
+    if (Adapt.get('_isStarted')) {
+      this.onAdaptInitialize();
+      return;
+    }
+    this.listenToOnce(Adapt, 'adapt:initialize', this.onAdaptInitialize);
+  }
+
+  onAdaptInitialize() {
+    this.restoreUserAnswers();
+  }
+
+  /**
+   * Restore the user's answer from the _userAnswer property.
+   * The _userAnswer value must be in the form of arrays containing
+   * numbers, booleans or arrays only.
+   */
+  restoreUserAnswers() {}
+
+  /**
+   * Store the user's answer in the _userAnswer property.
+   * The _userAnswer value must be in the form of arrays containing
+   * numbers, booleans or arrays only.
+   */
+  storeUserAnswer() {}
+
+  resetUserAnswer() {
+    this.set('_userAnswer', null);
+  }
+
+  reset(type, force) {
+    if (!this.get('_canReset') && !force) return;
+    this.resetUserAnswer();
+    super.reset(type, force);
+  }
+
+  /**
+   * Returns the current attempt state raw data or the raw data from the supplied attempt state object.
+   * @param {Object} [object] JSON object representing the component state. Defaults to current JSON.
+   * @returns {Array}
+   */
+  getAttemptState(object = this.toJSON()) {
+    const trackables = this.trackable();
+    const types = this.trackableType();
+    trackables.find((name, index) => {
+      // Exclude _attemptStates as it's trackable but isn't needed here
+      if (name !== '_attemptStates') return;
+      trackables.splice(index, 1);
+      types.splice(index, 1);
+      return true;
+    });
+    const values = trackables.map(n => object[n]);
+    const booleans = values.filter((v, i) => types[i] === Boolean).map(Boolean);
+    const numbers = values.filter((v, i) => types[i] === Number).map(v => Number(v) || 0);
+    const arrays = values.filter((v, i) => types[i] === Array);
+    return [
+      numbers,
+      booleans,
+      arrays
+    ];
+  }
+
+  /**
+   * Returns an attempt object representing the current state or a formatted version of the raw state object supplied.
+   * @param {Array} [state] JSON object representing the component state, defaults to current state returned from getAttemptState().
+   * @returns {Object}
+   */
+  getAttemptObject(state = this.getAttemptState()) {
+    const trackables = this.trackable();
+    const types = this.trackableType();
+    trackables.find((name, index) => {
+      // Exclude _attemptStates as it's trackable but isn't needed here
+      if (name !== '_attemptStates') return;
+      trackables.splice(index, 1);
+      types.splice(index, 1);
+      return true;
+    });
+    const numbers = (state[0] || []).slice(0);
+    const booleans = (state[1] || []).slice(0);
+    const arrays = (state[2] || []).slice(0);
+    const object = {};
+    trackables.forEach((n, i) => {
+      if (n === '_id') return;
+      switch (types[i]) {
+        case Number:
+          object[n] = numbers.shift();
+          break;
+        case Boolean:
+          object[n] = booleans.shift();
+          break;
+        case Array:
+          object[n] = arrays.shift();
+          break;
+      }
+    });
+    return object;
+  }
+
+  /**
+   * Sets the current attempt state from the supplied attempt state object.
+   * @param {Object} object JSON object representing the component state.
+   * @param {boolean} silent Stops change events from triggering
+   */
+  setAttemptObject(object, silent = true) {
+    this.set(object, { silent });
+  }
+
+  /**
+   * Adds the current attempt state object or the supplied state object to the attempts store.
+   * @param {Object} [object] JSON object representing the component state. Defaults to current JSON.
+   */
+  addAttemptObject(object = this.getAttemptObject()) {
+    const attemptStates = this.get('_attemptStates') || [];
+    const state = this.getAttemptState(object);
+    attemptStates.push(state);
+    this.set('_attemptStates', attemptStates);
+  }
+
+  /**
+   * Returns an array of the previous state objects. The most recent state is last in the list.
+   * @returns {Array}
+   */
+  getAttemptObjects() {
+    const states = this.get('_attemptStates') || [];
+    return states.map(state => this.getAttemptObject(state));
+  }
+
+}
+
+// This abstract model needs to registered to support deprecated view-only components
+Adapt.register('component', { model: ComponentModel });
+
+export default ComponentModel;

--- a/src/core/js/models/configModel.js
+++ b/src/core/js/models/configModel.js
@@ -1,6 +1,7 @@
 import Adapt from 'core/js/adapt';
+import LockingModel from 'core/js/models/lockingModel';
 
-export default class ConfigModel extends Backbone.Model {
+export default class ConfigModel extends LockingModel {
 
   defaults() {
     return {

--- a/src/core/js/models/configModel.js
+++ b/src/core/js/models/configModel.js
@@ -1,44 +1,38 @@
-define([
-  'core/js/adapt'
-], function (Adapt) {
+import Adapt from 'core/js/adapt';
 
-  class ConfigModel extends Backbone.Model {
+export default class ConfigModel extends Backbone.Model {
 
-    defaults() {
-      return {
-        screenSize: {
-          large: 900,
-          medium: 760,
-          small: 520
-        },
-        _forceRouteLocking: false,
-        _canLoadData: true,
-        _disableAnimation: false
-      };
-    }
-
-    initialize(attrs, options) {
-      this.url = options.url;
-      // Fetch data & if successful trigger event to enable plugins to stop course files loading
-      // Then check if course files can load
-      // 'configModel:loadCourseData' event starts the core content collections and models being fetched
-      this.fetch({
-        success: () => {
-          Adapt.trigger('offlineStorage:prepare');
-          Adapt.wait.queue(() => {
-            Adapt.trigger('configModel:dataLoaded');
-            if (!this.get('_canLoadData')) return;
-            Adapt.trigger('configModel:loadCourseData');
-          });
-        },
-        error: () => console.log('Unable to load course/config.json')
-      });
-    }
-
-    loadData() {}
-
+  defaults() {
+    return {
+      screenSize: {
+        large: 900,
+        medium: 760,
+        small: 520
+      },
+      _forceRouteLocking: false,
+      _canLoadData: true,
+      _disableAnimation: false
+    };
   }
 
-  return ConfigModel;
+  initialize(attrs, options) {
+    this.url = options.url;
+    // Fetch data & if successful trigger event to enable plugins to stop course files loading
+    // Then check if course files can load
+    // 'configModel:loadCourseData' event starts the core content collections and models being fetched
+    this.fetch({
+      success: () => {
+        Adapt.trigger('offlineStorage:prepare');
+        Adapt.wait.queue(() => {
+          Adapt.trigger('configModel:dataLoaded');
+          if (!this.get('_canLoadData')) return;
+          Adapt.trigger('configModel:loadCourseData');
+        });
+      },
+      error: () => console.log('Unable to load course/config.json')
+    });
+  }
 
-});
+  loadData() {}
+
+}

--- a/src/core/js/models/contentObjectModel.js
+++ b/src/core/js/models/contentObjectModel.js
@@ -1,39 +1,33 @@
-define([
-  'core/js/adapt',
-  'core/js/models/adaptModel'
-], function (Adapt, AdaptModel) {
+import Adapt from 'core/js/adapt';
+import AdaptModel from 'core/js/models/adaptModel';
 
-  class ContentObjectModel extends AdaptModel {
+export default class ContentObjectModel extends AdaptModel {
 
-    get _parent() {
-      Adapt.log.deprecated('contentObjectModel._parent, use contentObjectModel.getParent() instead, parent models are defined by the JSON');
-      const isParentCourse = (this.get('_parentId') === Adapt.course.get('_id'));
-      if (isParentCourse) {
-        return 'course';
-      }
-      return 'contentObjects';
+  get _parent() {
+    Adapt.log.deprecated('contentObjectModel._parent, use contentObjectModel.getParent() instead, parent models are defined by the JSON');
+    const isParentCourse = (this.get('_parentId') === Adapt.course.get('_id'));
+    if (isParentCourse) {
+      return 'course';
     }
-
-    get _siblings() {
-      Adapt.log.deprecated('contentObjectModel._siblings, use contentObjectModel.getSiblings() instead, sibling models are defined by the JSON');
-      return 'contentObjects';
-    }
-
-    get _children() {
-      Adapt.log.deprecated('contentObjectModel._children, use contentObjectModel.hasManagedChildren instead, child models are defined by the JSON');
-      return null;
-    }
-
-    /**
-     * Returns a string of the model type group.
-     * @returns {string}
-     */
-    getTypeGroup() {
-      return 'contentobject';
-    }
-
+    return 'contentObjects';
   }
 
-  return ContentObjectModel;
+  get _siblings() {
+    Adapt.log.deprecated('contentObjectModel._siblings, use contentObjectModel.getSiblings() instead, sibling models are defined by the JSON');
+    return 'contentObjects';
+  }
 
-});
+  get _children() {
+    Adapt.log.deprecated('contentObjectModel._children, use contentObjectModel.hasManagedChildren instead, child models are defined by the JSON');
+    return null;
+  }
+
+  /**
+   * Returns a string of the model type group.
+   * @returns {string}
+   */
+  getTypeGroup() {
+    return 'contentobject';
+  }
+
+}

--- a/src/core/js/models/courseModel.js
+++ b/src/core/js/models/courseModel.js
@@ -1,24 +1,20 @@
-define([
-  'core/js/adapt',
-  'core/js/models/menuModel'
-], function (Adapt, MenuModel) {
+import Adapt from 'core/js/adapt';
+import MenuModel from 'core/js/models/menuModel';
 
-  class CourseModel extends MenuModel {
+class CourseModel extends MenuModel {
 
-    get _parent() {
-      Adapt.log.deprecated('courseModel._parent, use courseModel.getParent() instead, parent models are defined by the JSON');
-      return null;
-    }
-
-    get _siblings() {
-      Adapt.log.deprecated('courseModel._siblings, use courseModel.getSiblings() instead, sibling models are defined by the JSON');
-      return null;
-    }
-
+  get _parent() {
+    Adapt.log.deprecated('courseModel._parent, use courseModel.getParent() instead, parent models are defined by the JSON');
+    return null;
   }
 
-  Adapt.register('course', { model: CourseModel });
+  get _siblings() {
+    Adapt.log.deprecated('courseModel._siblings, use courseModel.getSiblings() instead, sibling models are defined by the JSON');
+    return null;
+  }
 
-  return CourseModel;
+}
 
-});
+Adapt.register('course', { model: CourseModel });
+
+export default CourseModel;

--- a/src/core/js/models/itemModel.js
+++ b/src/core/js/models/itemModel.js
@@ -1,28 +1,22 @@
-define(function() {
+export default class ItemModel extends Backbone.Model {
 
-  class ItemModel extends Backbone.Model {
-
-    defaults() {
-      return {
-        _isActive: false,
-        _isVisited: false
-      };
-    }
-
-    reset() {
-      this.set({ _isActive: false, _isVisited: false });
-    }
-
-    toggleActive(isActive = !this.get('_isActive')) {
-      this.set('_isActive', isActive);
-    }
-
-    toggleVisited(isVisited = !this.get('_isVisited')) {
-      this.set('_isVisited', isVisited);
-    }
-
+  defaults() {
+    return {
+      _isActive: false,
+      _isVisited: false
+    };
   }
 
-  return ItemModel;
+  reset() {
+    this.set({ _isActive: false, _isVisited: false });
+  }
 
-});
+  toggleActive(isActive = !this.get('_isActive')) {
+    this.set('_isActive', isActive);
+  }
+
+  toggleVisited(isVisited = !this.get('_isVisited')) {
+    this.set('_isVisited', isVisited);
+  }
+
+}

--- a/src/core/js/models/itemModel.js
+++ b/src/core/js/models/itemModel.js
@@ -1,4 +1,6 @@
-export default class ItemModel extends Backbone.Model {
+import LockingModel from 'core/js/models/lockingModel';
+
+export default class ItemModel extends LockingModel {
 
   defaults() {
     return {

--- a/src/core/js/models/itemsComponentModel.js
+++ b/src/core/js/models/itemsComponentModel.js
@@ -1,90 +1,84 @@
-define([
-  'core/js/models/componentModel',
-  'core/js/models/itemModel'
-], function(ComponentModel, ItemModel) {
+import ComponentModel from 'core/js/models/componentModel';
+import ItemModel from 'core/js/models/itemModel';
 
-  class ItemsComponentModel extends ComponentModel {
+export default class ItemsComponentModel extends ComponentModel {
 
-    toJSON() {
-      const json = super.toJSON();
-      // Make sure _items is updated from child collection
-      json._items = this.getChildren().toJSON();
-      return json;
-    }
-
-    init() {
-      this.setUpItems();
-      this.listenTo(this.getChildren(), {
-        'all': this.onAll,
-        'change:_isVisited': this.checkCompletionStatus
-      });
-      super.init();
-    }
-
-    restoreUserAnswers() {
-      const booleanArray = this.get('_userAnswer');
-      if (!booleanArray) return;
-      this.getChildren().forEach((child, index) => child.set('_isVisited', booleanArray[index]));
-    }
-
-    storeUserAnswer() {
-      const booleanArray = this.getChildren().map(child => child.get('_isVisited'));
-      this.set('_userAnswer', booleanArray);
-    }
-
-    setUpItems() {
-      // see https://github.com/adaptlearning/adapt_framework/issues/2480
-      const items = this.get('_items') || [];
-      items.forEach((item, index) => (item._index = index));
-      this.setChildren(new Backbone.Collection(items, { model: ItemModel }));
-    }
-
-    getItem(index) {
-      return this.getChildren().findWhere({ _index: index });
-    }
-
-    getVisitedItems() {
-      return this.getChildren().where({ _isVisited: true });
-    }
-
-    getActiveItems() {
-      return this.getChildren().where({ _isActive: true });
-    }
-
-    getActiveItem() {
-      return this.getChildren().findWhere({ _isActive: true });
-    }
-
-    areAllItemsCompleted() {
-      return this.getVisitedItems().length === this.getChildren().length;
-    }
-
-    checkCompletionStatus() {
-      this.storeUserAnswer();
-      if (!this.areAllItemsCompleted()) return;
-      this.setCompletionStatus();
-    }
-
-    reset(type, force) {
-      this.getChildren().each(item => item.reset());
-      super.reset(type, force);
-    }
-
-    resetActiveItems() {
-      this.getChildren().each(item => item.toggleActive(false));
-    }
-
-    setActiveItem(index) {
-      const item = this.getItem(index);
-      if (!item) return;
-
-      const activeItem = this.getActiveItem();
-      if (activeItem) activeItem.toggleActive(false);
-      item.toggleActive(true);
-    }
-
+  toJSON() {
+    const json = super.toJSON();
+    // Make sure _items is updated from child collection
+    json._items = this.getChildren().toJSON();
+    return json;
   }
 
-  return ItemsComponentModel;
+  init() {
+    this.setUpItems();
+    this.listenTo(this.getChildren(), {
+      'all': this.onAll,
+      'change:_isVisited': this.checkCompletionStatus
+    });
+    super.init();
+  }
 
-});
+  restoreUserAnswers() {
+    const booleanArray = this.get('_userAnswer');
+    if (!booleanArray) return;
+    this.getChildren().forEach((child, index) => child.set('_isVisited', booleanArray[index]));
+  }
+
+  storeUserAnswer() {
+    const booleanArray = this.getChildren().map(child => child.get('_isVisited'));
+    this.set('_userAnswer', booleanArray);
+  }
+
+  setUpItems() {
+    // see https://github.com/adaptlearning/adapt_framework/issues/2480
+    const items = this.get('_items') || [];
+    items.forEach((item, index) => (item._index = index));
+    this.setChildren(new Backbone.Collection(items, { model: ItemModel }));
+  }
+
+  getItem(index) {
+    return this.getChildren().findWhere({ _index: index });
+  }
+
+  getVisitedItems() {
+    return this.getChildren().where({ _isVisited: true });
+  }
+
+  getActiveItems() {
+    return this.getChildren().where({ _isActive: true });
+  }
+
+  getActiveItem() {
+    return this.getChildren().findWhere({ _isActive: true });
+  }
+
+  areAllItemsCompleted() {
+    return this.getVisitedItems().length === this.getChildren().length;
+  }
+
+  checkCompletionStatus() {
+    this.storeUserAnswer();
+    if (!this.areAllItemsCompleted()) return;
+    this.setCompletionStatus();
+  }
+
+  reset(type, force) {
+    this.getChildren().each(item => item.reset());
+    super.reset(type, force);
+  }
+
+  resetActiveItems() {
+    this.getChildren().each(item => item.toggleActive(false));
+  }
+
+  setActiveItem(index) {
+    const item = this.getItem(index);
+    if (!item) return;
+
+    const activeItem = this.getActiveItem();
+    if (activeItem) activeItem.toggleActive(false);
+    item.toggleActive(true);
+  }
+
+}

--- a/src/core/js/models/itemsQuestionModel.js
+++ b/src/core/js/models/itemsQuestionModel.js
@@ -1,225 +1,218 @@
-define([
-  'core/js/adapt',
-  'core/js/models/questionModel',
-  'core/js/models/itemsComponentModel'
-], function(Adapt, QuestionModel, ItemsComponentModel) {
+import QuestionModel from 'core/js/models/questionModel';
+import ItemsComponentModel from 'core/js/models/itemsComponentModel';
 
-  class BlendedItemsComponentQuestionModel extends QuestionModel {
+class BlendedItemsComponentQuestionModel extends QuestionModel {
 
-    init() {
-      ItemsComponentModel.prototype.init.call(this);
-      super.init();
-    }
-
-    reset(type, force) {
-      ItemsComponentModel.prototype.reset.call(this, type, force);
-      super.reset(type, force);
-    }
-
+  init() {
+    ItemsComponentModel.prototype.init.call(this);
+    super.init();
   }
-  // extend BlendedItemsComponentQuestionModel with ItemsComponentModel
-  Object.getOwnPropertyNames(ItemsComponentModel.prototype).forEach(name => {
-    if (name === 'constructor' || name === 'init' || name === 'reset') return;
-    Object.defineProperty(BlendedItemsComponentQuestionModel.prototype, name, {
-      value: ItemsComponentModel.prototype[name]
-    });
+
+  reset(type, force) {
+    ItemsComponentModel.prototype.reset.call(this, type, force);
+    super.reset(type, force);
+  }
+
+}
+// extend BlendedItemsComponentQuestionModel with ItemsComponentModel
+Object.getOwnPropertyNames(ItemsComponentModel.prototype).forEach(name => {
+  if (name === 'constructor' || name === 'init' || name === 'reset') return;
+  Object.defineProperty(BlendedItemsComponentQuestionModel.prototype, name, {
+    value: ItemsComponentModel.prototype[name]
   });
+});
 
-  class ItemsQuestionModel extends BlendedItemsComponentQuestionModel {
+export default class ItemsQuestionModel extends BlendedItemsComponentQuestionModel {
 
-    init() {
-      super.init();
-      this.set('_isRadio', this.isSingleSelect());
-      this.listenTo(this.getChildren(), 'change:_isActive', this.checkCanSubmit);
-      this.checkCanSubmit();
-    }
-
-    restoreUserAnswers() {
-      if (!this.get('_isSubmitted')) return;
-
-      const itemModels = this.getChildren();
-      const userAnswer = this.get('_userAnswer');
-      itemModels.each(item => {
-        item.toggleActive(userAnswer[item.get('_index')]);
-      });
-
-      this.setQuestionAsSubmitted();
-      this.markQuestion();
-      this.setScore();
-      this.setupFeedback();
-    }
-
-    setupRandomisation() {
-      if (!this.get('_isRandom') || !this.get('_isEnabled')) return;
-      const children = this.getChildren();
-      children.set(children.shuffle());
-    }
-
-    // check if the user is allowed to submit the question
-    canSubmit() {
-      const activeItems = this.getActiveItems();
-      return activeItems.length > 0;
-    }
-
-    // This is important for returning or showing the users answer
-    // This should preserve the state of the users answers
-    storeUserAnswer() {
-      const items = this.getChildren().slice(0);
-      items.sort((a, b) => a.get('_index') - b.get('_index'));
-      const userAnswer = items.map(itemModel => itemModel.get('_isActive'));
-      this.set('_userAnswer', userAnswer);
-    }
-
-    isCorrect() {
-
-      const props = {
-        _numberOfRequiredAnswers: 0,
-        _numberOfIncorrectAnswers: 0,
-        _isAtLeastOneCorrectSelection: false,
-        _numberOfCorrectAnswers: 0
-      };
-
-      this.getChildren().each(itemModel => {
-        const itemShouldBeActive = itemModel.get('_shouldBeSelected');
-        if (itemShouldBeActive) {
-          props._numberOfRequiredAnswers++;
-        }
-
-        if (!itemModel.get('_isActive')) return;
-
-        if (!itemShouldBeActive) {
-          props._numberOfIncorrectAnswers++;
-          return;
-        }
-
-        props._isAtLeastOneCorrectSelection = true;
-        props._numberOfCorrectAnswers++;
-        itemModel.set('_isCorrect', true);
-      });
-
-      this.set(props);
-
-      const hasRightNumberOfCorrectAnswers = (props._numberOfCorrectAnswers === props._numberOfRequiredAnswers);
-      const hasNoIncorrectAnswers = !props._numberOfIncorrectAnswers;
-
-      return hasRightNumberOfCorrectAnswers && hasNoIncorrectAnswers;
-    }
-
-    // Sets the score based upon the questionWeight
-    // Can be overwritten if the question needs to set the score in a different way
-    setScore() {
-      const questionWeight = this.get('_questionWeight');
-      const answeredCorrectly = this.get('_isCorrect');
-      const score = answeredCorrectly ? questionWeight : 0;
-      this.set('_score', score);
-    }
-
-    setupFeedback() {
-      if (!this.has('_feedback')) return;
-
-      if (this.get('_isCorrect')) {
-        this.setupCorrectFeedback();
-        return;
-      }
-
-      if (this.isPartlyCorrect()) {
-        this.setupPartlyCorrectFeedback();
-        return;
-      }
-
-      // apply individual item feedback
-      const activeItem = this.getActiveItem();
-      if (this.isSingleSelect() && activeItem.get('feedback')) {
-        this.setupIndividualFeedback(activeItem);
-        return;
-      }
-
-      this.setupIncorrectFeedback();
-    }
-
-    setupIndividualFeedback(selectedItem) {
-      this.set({
-        feedbackTitle: this.getFeedbackTitle(this.get('_feedback')),
-        feedbackMessage: selectedItem.get('feedback')
-      });
-    }
-
-    isPartlyCorrect() {
-      return this.get('_isAtLeastOneCorrectSelection');
-    }
-
-    resetUserAnswer() {
-      this.set('_userAnswer', []);
-    }
-
-    isAtActiveLimit() {
-      const selectedItems = this.getActiveItems();
-      return (selectedItems.length === this.get('_selectable'));
-    }
-
-    isSingleSelect() {
-      return (this.get('_selectable') === 1);
-    }
-
-    getLastActiveItem() {
-      const selectedItems = this.getActiveItems();
-      return selectedItems[selectedItems.length - 1];
-    }
-
-    resetItems() {
-      this.resetActiveItems();
-      this.set('_isAtLeastOneCorrectSelection', false);
-    }
-
-    getInteractionObject() {
-      const interactions = {
-        correctResponsesPattern: [],
-        choices: []
-      };
-
-      interactions.choices = this.getChildren().map(itemModel => {
-        return {
-          id: (itemModel.get('_index') + 1).toString(),
-          description: itemModel.get('text')
-        };
-      });
-
-      const correctItems = this.getChildren().filter(itemModel => {
-        return itemModel.get('_shouldBeSelected');
-      });
-
-      interactions.correctResponsesPattern = [
-        correctItems.map(itemModel => {
-          // indexes are 0-based, we need them to be 1-based for cmi.interactions
-          return String(itemModel.get('_index') + 1);
-        }).join('[,]')
-      ];
-
-      return interactions;
-    }
-
-    /**
-    * used by adapt-contrib-spoor to get the user's answers in the format required by the cmi.interactions.n.student_response data field
-    * returns the user's answers as a string in the format '1,5,2'
-    */
-    getResponse() {
-      const activeItems = this.getActiveItems();
-      const activeIndexes = activeItems.map(itemModel => {
-        // indexes are 0-based, we need them to be 1-based for cmi.interactions
-        return itemModel.get('_index') + 1;
-      });
-      return activeIndexes.join(',');
-    }
-
-    /**
-    * used by adapt-contrib-spoor to get the type of this question in the format required by the cmi.interactions.n.type data field
-    */
-    getResponseType() {
-      return 'choice';
-    }
-
+  init() {
+    super.init();
+    this.set('_isRadio', this.isSingleSelect());
+    this.listenTo(this.getChildren(), 'change:_isActive', this.checkCanSubmit);
+    this.checkCanSubmit();
   }
 
-  return ItemsQuestionModel;
+  restoreUserAnswers() {
+    if (!this.get('_isSubmitted')) return;
 
-});
+    const itemModels = this.getChildren();
+    const userAnswer = this.get('_userAnswer');
+    itemModels.each(item => {
+      item.toggleActive(userAnswer[item.get('_index')]);
+    });
+
+    this.setQuestionAsSubmitted();
+    this.markQuestion();
+    this.setScore();
+    this.setupFeedback();
+  }
+
+  setupRandomisation() {
+    if (!this.get('_isRandom') || !this.get('_isEnabled')) return;
+    const children = this.getChildren();
+    children.set(children.shuffle());
+  }
+
+  // check if the user is allowed to submit the question
+  canSubmit() {
+    const activeItems = this.getActiveItems();
+    return activeItems.length > 0;
+  }
+
+  // This is important for returning or showing the users answer
+  // This should preserve the state of the users answers
+  storeUserAnswer() {
+    const items = this.getChildren().slice(0);
+    items.sort((a, b) => a.get('_index') - b.get('_index'));
+    const userAnswer = items.map(itemModel => itemModel.get('_isActive'));
+    this.set('_userAnswer', userAnswer);
+  }
+
+  isCorrect() {
+
+    const props = {
+      _numberOfRequiredAnswers: 0,
+      _numberOfIncorrectAnswers: 0,
+      _isAtLeastOneCorrectSelection: false,
+      _numberOfCorrectAnswers: 0
+    };
+
+    this.getChildren().each(itemModel => {
+      const itemShouldBeActive = itemModel.get('_shouldBeSelected');
+      if (itemShouldBeActive) {
+        props._numberOfRequiredAnswers++;
+      }
+
+      if (!itemModel.get('_isActive')) return;
+
+      if (!itemShouldBeActive) {
+        props._numberOfIncorrectAnswers++;
+        return;
+      }
+
+      props._isAtLeastOneCorrectSelection = true;
+      props._numberOfCorrectAnswers++;
+      itemModel.set('_isCorrect', true);
+    });
+
+    this.set(props);
+
+    const hasRightNumberOfCorrectAnswers = (props._numberOfCorrectAnswers === props._numberOfRequiredAnswers);
+    const hasNoIncorrectAnswers = !props._numberOfIncorrectAnswers;
+
+    return hasRightNumberOfCorrectAnswers && hasNoIncorrectAnswers;
+  }
+
+  // Sets the score based upon the questionWeight
+  // Can be overwritten if the question needs to set the score in a different way
+  setScore() {
+    const questionWeight = this.get('_questionWeight');
+    const answeredCorrectly = this.get('_isCorrect');
+    const score = answeredCorrectly ? questionWeight : 0;
+    this.set('_score', score);
+  }
+
+  setupFeedback() {
+    if (!this.has('_feedback')) return;
+
+    if (this.get('_isCorrect')) {
+      this.setupCorrectFeedback();
+      return;
+    }
+
+    if (this.isPartlyCorrect()) {
+      this.setupPartlyCorrectFeedback();
+      return;
+    }
+
+    // apply individual item feedback
+    const activeItem = this.getActiveItem();
+    if (this.isSingleSelect() && activeItem.get('feedback')) {
+      this.setupIndividualFeedback(activeItem);
+      return;
+    }
+
+    this.setupIncorrectFeedback();
+  }
+
+  setupIndividualFeedback(selectedItem) {
+    this.set({
+      feedbackTitle: this.getFeedbackTitle(this.get('_feedback')),
+      feedbackMessage: selectedItem.get('feedback')
+    });
+  }
+
+  isPartlyCorrect() {
+    return this.get('_isAtLeastOneCorrectSelection');
+  }
+
+  resetUserAnswer() {
+    this.set('_userAnswer', []);
+  }
+
+  isAtActiveLimit() {
+    const selectedItems = this.getActiveItems();
+    return (selectedItems.length === this.get('_selectable'));
+  }
+
+  isSingleSelect() {
+    return (this.get('_selectable') === 1);
+  }
+
+  getLastActiveItem() {
+    const selectedItems = this.getActiveItems();
+    return selectedItems[selectedItems.length - 1];
+  }
+
+  resetItems() {
+    this.resetActiveItems();
+    this.set('_isAtLeastOneCorrectSelection', false);
+  }
+
+  getInteractionObject() {
+    const interactions = {
+      correctResponsesPattern: [],
+      choices: []
+    };
+
+    interactions.choices = this.getChildren().map(itemModel => {
+      return {
+        id: (itemModel.get('_index') + 1).toString(),
+        description: itemModel.get('text')
+      };
+    });
+
+    const correctItems = this.getChildren().filter(itemModel => {
+      return itemModel.get('_shouldBeSelected');
+    });
+
+    interactions.correctResponsesPattern = [
+      correctItems.map(itemModel => {
+        // indexes are 0-based, we need them to be 1-based for cmi.interactions
+        return String(itemModel.get('_index') + 1);
+      }).join('[,]')
+    ];
+
+    return interactions;
+  }
+
+  /**
+  * used by adapt-contrib-spoor to get the user's answers in the format required by the cmi.interactions.n.student_response data field
+  * returns the user's answers as a string in the format '1,5,2'
+  */
+  getResponse() {
+    const activeItems = this.getActiveItems();
+    const activeIndexes = activeItems.map(itemModel => {
+      // indexes are 0-based, we need them to be 1-based for cmi.interactions
+      return itemModel.get('_index') + 1;
+    });
+    return activeIndexes.join(',');
+  }
+
+  /**
+  * used by adapt-contrib-spoor to get the type of this question in the format required by the cmi.interactions.n.type data field
+  */
+  getResponseType() {
+    return 'choice';
+  }
+
+}

--- a/src/core/js/models/lockingModel.js
+++ b/src/core/js/models/lockingModel.js
@@ -1,138 +1,134 @@
-define(function() {
+const set = Backbone.Model.prototype.set;
 
-  const set = Backbone.Model.prototype.set;
+Object.assign(Backbone.Model.prototype, {
 
-  Object.assign(Backbone.Model.prototype, {
+  set: function(attrName, attrVal, options = {}) {
+    const stopProcessing = (typeof attrName === 'object' || typeof attrVal !== 'boolean' || !this.isLocking(attrName));
+    if (stopProcessing) return set.apply(this, arguments);
 
-    set: function(attrName, attrVal, options = {}) {
-      const stopProcessing = (typeof attrName === 'object' || typeof attrVal !== 'boolean' || !this.isLocking(attrName));
-      if (stopProcessing) return set.apply(this, arguments);
-
-      const isSettingValueForSpecificPlugin = options && options.pluginName;
-      if (!isSettingValueForSpecificPlugin) {
-        console.error('Must supply a pluginName to change a locked attribute');
-        options.pluginName = 'compatibility';
-      }
-
-      const pluginName = options.pluginName;
-      if (this.defaults[attrName] !== undefined) {
-        this._lockedAttributes[attrName] = !this.defaults[attrName];
-      }
-      const lockingValue = this._lockedAttributes[attrName];
-      const isAttemptingToLock = (lockingValue === attrVal);
-
-      if (isAttemptingToLock) {
-        this.setLockState(attrName, true, { pluginName: pluginName, skipcheck: true });
-        return set.call(this, attrName, lockingValue);
-      }
-
-      this.setLockState(attrName, false, { pluginName: pluginName, skipcheck: true });
-
-      const totalLockValue = this.getLockCount(attrName, { skipcheck: true });
-      if (totalLockValue === 0) {
-        return set.call(this, attrName, !lockingValue);
-      }
-
-      return this;
-
-    },
-
-    setLocking: function(attrName, defaultLockValue) {
-      if (this.isLocking(attrName)) return;
-      if (!this._lockedAttributes) this._lockedAttributes = {};
-      this._lockedAttributes[attrName] = defaultLockValue;
-    },
-
-    unsetLocking: function(attrName) {
-      if (!this.isLocking(attrName)) return;
-      if (!this._lockedAttributes) return;
-      delete this._lockedAttributes[attrName];
-      delete this._lockedAttributesValues[attrName];
-      if (Object.keys(this._lockedAttributes).length === 0) {
-        delete this._lockedAttributes;
-        delete this._lockedAttributesValues;
-      }
-    },
-
-    isLocking: function(attrName) {
-      const isCheckingGeneralLockingState = (attrName === undefined);
-      const isUsingLockedAttributes = Boolean(this.lockedAttributes || this._lockedAttributes);
-
-      if (isCheckingGeneralLockingState) {
-        return isUsingLockedAttributes;
-      }
-
-      if (!isUsingLockedAttributes) return false;
-
-      if (!this._lockedAttributes) {
-        this._lockedAttributes = _.result(this, 'lockedAttributes');
-      }
-
-      const isAttributeALockingAttribute = this._lockedAttributes.hasOwnProperty(attrName);
-      if (!isAttributeALockingAttribute) return false;
-
-      if (!this._lockedAttributesValues) {
-        this._lockedAttributesValues = {};
-      }
-
-      if (!this._lockedAttributesValues[attrName]) {
-        this._lockedAttributesValues[attrName] = {};
-      }
-
-      return true;
-    },
-
-    isLocked: function(attrName, options) {
-      const shouldSkipCheck = (options && options.skipcheck);
-      if (!shouldSkipCheck) {
-        const stopProcessing = !this.isLocking(attrName);
-        if (stopProcessing) return;
-      }
-
-      return this.getLockCount(attrName) > 0;
-    },
-
-    getLockCount: function(attrName, options) {
-      const shouldSkipCheck = (options && options.skipcheck);
-      if (!shouldSkipCheck) {
-        const stopProcessing = !this.isLocking(attrName);
-        if (stopProcessing) return;
-      }
-
-      const isGettingValueForSpecificPlugin = options && options.pluginName;
-      if (isGettingValueForSpecificPlugin) {
-        return this._lockedAttributesValues[attrName][options.pluginName] ? 1 : 0;
-      }
-
-      const lockingAttributeValues = Object.values(this._lockedAttributesValues[attrName]);
-      const lockingAttributeValuesSum = lockingAttributeValues.reduce((sum, value) => sum + (value ? 1 : 0), 0);
-
-      return lockingAttributeValuesSum;
-    },
-
-    setLockState: function(attrName, value, options) {
-      const shouldSkipCheck = (options && options.skipcheck);
-      if (!shouldSkipCheck) {
-        const stopProcessing = !this.isLocking(attrName);
-        if (stopProcessing) return this;
-      }
-
-      const isSettingValueForSpecificPlugin = options && options.pluginName;
-      if (!isSettingValueForSpecificPlugin) {
-        console.error('Must supply a pluginName to set a locked attribute lock value');
-        options.pluginName = 'compatibility';
-      }
-
-      if (value) {
-        this._lockedAttributesValues[attrName][options.pluginName] = value;
-      } else {
-        delete this._lockedAttributesValues[attrName][options.pluginName];
-      }
-
-      return this;
-
+    const isSettingValueForSpecificPlugin = options && options.pluginName;
+    if (!isSettingValueForSpecificPlugin) {
+      console.error('Must supply a pluginName to change a locked attribute');
+      options.pluginName = 'compatibility';
     }
 
-  });
+    const pluginName = options.pluginName;
+    if (this.defaults[attrName] !== undefined) {
+      this._lockedAttributes[attrName] = !this.defaults[attrName];
+    }
+    const lockingValue = this._lockedAttributes[attrName];
+    const isAttemptingToLock = (lockingValue === attrVal);
+
+    if (isAttemptingToLock) {
+      this.setLockState(attrName, true, { pluginName: pluginName, skipcheck: true });
+      return set.call(this, attrName, lockingValue);
+    }
+
+    this.setLockState(attrName, false, { pluginName: pluginName, skipcheck: true });
+
+    const totalLockValue = this.getLockCount(attrName, { skipcheck: true });
+    if (totalLockValue === 0) {
+      return set.call(this, attrName, !lockingValue);
+    }
+
+    return this;
+
+  },
+
+  setLocking: function(attrName, defaultLockValue) {
+    if (this.isLocking(attrName)) return;
+    if (!this._lockedAttributes) this._lockedAttributes = {};
+    this._lockedAttributes[attrName] = defaultLockValue;
+  },
+
+  unsetLocking: function(attrName) {
+    if (!this.isLocking(attrName)) return;
+    if (!this._lockedAttributes) return;
+    delete this._lockedAttributes[attrName];
+    delete this._lockedAttributesValues[attrName];
+    if (Object.keys(this._lockedAttributes).length === 0) {
+      delete this._lockedAttributes;
+      delete this._lockedAttributesValues;
+    }
+  },
+
+  isLocking: function(attrName) {
+    const isCheckingGeneralLockingState = (attrName === undefined);
+    const isUsingLockedAttributes = Boolean(this.lockedAttributes || this._lockedAttributes);
+
+    if (isCheckingGeneralLockingState) {
+      return isUsingLockedAttributes;
+    }
+
+    if (!isUsingLockedAttributes) return false;
+
+    if (!this._lockedAttributes) {
+      this._lockedAttributes = _.result(this, 'lockedAttributes');
+    }
+
+    const isAttributeALockingAttribute = this._lockedAttributes.hasOwnProperty(attrName);
+    if (!isAttributeALockingAttribute) return false;
+
+    if (!this._lockedAttributesValues) {
+      this._lockedAttributesValues = {};
+    }
+
+    if (!this._lockedAttributesValues[attrName]) {
+      this._lockedAttributesValues[attrName] = {};
+    }
+
+    return true;
+  },
+
+  isLocked: function(attrName, options) {
+    const shouldSkipCheck = (options && options.skipcheck);
+    if (!shouldSkipCheck) {
+      const stopProcessing = !this.isLocking(attrName);
+      if (stopProcessing) return;
+    }
+
+    return this.getLockCount(attrName) > 0;
+  },
+
+  getLockCount: function(attrName, options) {
+    const shouldSkipCheck = (options && options.skipcheck);
+    if (!shouldSkipCheck) {
+      const stopProcessing = !this.isLocking(attrName);
+      if (stopProcessing) return;
+    }
+
+    const isGettingValueForSpecificPlugin = options && options.pluginName;
+    if (isGettingValueForSpecificPlugin) {
+      return this._lockedAttributesValues[attrName][options.pluginName] ? 1 : 0;
+    }
+
+    const lockingAttributeValues = Object.values(this._lockedAttributesValues[attrName]);
+    const lockingAttributeValuesSum = lockingAttributeValues.reduce((sum, value) => sum + (value ? 1 : 0), 0);
+
+    return lockingAttributeValuesSum;
+  },
+
+  setLockState: function(attrName, value, options) {
+    const shouldSkipCheck = (options && options.skipcheck);
+    if (!shouldSkipCheck) {
+      const stopProcessing = !this.isLocking(attrName);
+      if (stopProcessing) return this;
+    }
+
+    const isSettingValueForSpecificPlugin = options && options.pluginName;
+    if (!isSettingValueForSpecificPlugin) {
+      console.error('Must supply a pluginName to set a locked attribute lock value');
+      options.pluginName = 'compatibility';
+    }
+
+    if (value) {
+      this._lockedAttributesValues[attrName][options.pluginName] = value;
+    } else {
+      delete this._lockedAttributesValues[attrName][options.pluginName];
+    }
+
+    return this;
+
+  }
 
 });

--- a/src/core/js/models/lockingModel.js
+++ b/src/core/js/models/lockingModel.js
@@ -1,10 +1,8 @@
-const set = Backbone.Model.prototype.set;
+class LockingModel extends Backbone.Model {
 
-Object.assign(Backbone.Model.prototype, {
-
-  set: function(attrName, attrVal, options = {}) {
+  set(attrName, attrVal, options = {}) {
     const stopProcessing = (typeof attrName === 'object' || typeof attrVal !== 'boolean' || !this.isLocking(attrName));
-    if (stopProcessing) return set.apply(this, arguments);
+    if (stopProcessing) return super.set(...arguments);
 
     const isSettingValueForSpecificPlugin = options && options.pluginName;
     if (!isSettingValueForSpecificPlugin) {
@@ -21,27 +19,27 @@ Object.assign(Backbone.Model.prototype, {
 
     if (isAttemptingToLock) {
       this.setLockState(attrName, true, { pluginName: pluginName, skipcheck: true });
-      return set.call(this, attrName, lockingValue);
+      return super.set(attrName, lockingValue);
     }
 
     this.setLockState(attrName, false, { pluginName: pluginName, skipcheck: true });
 
     const totalLockValue = this.getLockCount(attrName, { skipcheck: true });
     if (totalLockValue === 0) {
-      return set.call(this, attrName, !lockingValue);
+      return super.set(attrName, !lockingValue);
     }
 
     return this;
 
-  },
+  }
 
-  setLocking: function(attrName, defaultLockValue) {
+  setLocking(attrName, defaultLockValue) {
     if (this.isLocking(attrName)) return;
     if (!this._lockedAttributes) this._lockedAttributes = {};
     this._lockedAttributes[attrName] = defaultLockValue;
-  },
+  }
 
-  unsetLocking: function(attrName) {
+  unsetLocking(attrName) {
     if (!this.isLocking(attrName)) return;
     if (!this._lockedAttributes) return;
     delete this._lockedAttributes[attrName];
@@ -50,9 +48,9 @@ Object.assign(Backbone.Model.prototype, {
       delete this._lockedAttributes;
       delete this._lockedAttributesValues;
     }
-  },
+  }
 
-  isLocking: function(attrName) {
+  isLocking(attrName) {
     const isCheckingGeneralLockingState = (attrName === undefined);
     const isUsingLockedAttributes = Boolean(this.lockedAttributes || this._lockedAttributes);
 
@@ -78,9 +76,9 @@ Object.assign(Backbone.Model.prototype, {
     }
 
     return true;
-  },
+  }
 
-  isLocked: function(attrName, options) {
+  isLocked(attrName, options) {
     const shouldSkipCheck = (options && options.skipcheck);
     if (!shouldSkipCheck) {
       const stopProcessing = !this.isLocking(attrName);
@@ -88,9 +86,9 @@ Object.assign(Backbone.Model.prototype, {
     }
 
     return this.getLockCount(attrName) > 0;
-  },
+  }
 
-  getLockCount: function(attrName, options) {
+  getLockCount(attrName, options) {
     const shouldSkipCheck = (options && options.skipcheck);
     if (!shouldSkipCheck) {
       const stopProcessing = !this.isLocking(attrName);
@@ -106,9 +104,9 @@ Object.assign(Backbone.Model.prototype, {
     const lockingAttributeValuesSum = lockingAttributeValues.reduce((sum, value) => sum + (value ? 1 : 0), 0);
 
     return lockingAttributeValuesSum;
-  },
+  }
 
-  setLockState: function(attrName, value, options) {
+  setLockState(attrName, value, options) {
     const shouldSkipCheck = (options && options.skipcheck);
     if (!shouldSkipCheck) {
       const stopProcessing = !this.isLocking(attrName);
@@ -131,4 +129,6 @@ Object.assign(Backbone.Model.prototype, {
 
   }
 
-});
+}
+
+export default LockingModel;

--- a/src/core/js/models/lockingModel.js
+++ b/src/core/js/models/lockingModel.js
@@ -1,4 +1,4 @@
-class LockingModel extends Backbone.Model {
+export default class LockingModel extends Backbone.Model {
 
   set(attrName, attrVal, options = {}) {
     const stopProcessing = (typeof attrName === 'object' || typeof attrVal !== 'boolean' || !this.isLocking(attrName));
@@ -130,5 +130,3 @@ class LockingModel extends Backbone.Model {
   }
 
 }
-
-export default LockingModel;

--- a/src/core/js/models/menuModel.js
+++ b/src/core/js/models/menuModel.js
@@ -1,36 +1,32 @@
-define([
-  'core/js/adapt',
-  'core/js/models/contentObjectModel'
-], function (Adapt, ContentObjectModel) {
+import Adapt from 'core/js/adapt';
+import ContentObjectModel from 'core/js/models/contentObjectModel';
 
-  class MenuModel extends ContentObjectModel {
+class MenuModel extends ContentObjectModel {
 
-    get _children() {
-      Adapt.log.deprecated('menuModel._children, use menuModel.hasManagedChildren instead, child models are defined by the JSON');
-      return 'contentObjects';
-    }
-
-    /**
-     * Returns a string of the model type group.
-     * @returns {string}
-     */
-    getTypeGroup() {
-      return 'menu';
-    }
-
-    setCustomLocking() {
-      const children = this.getAvailableChildModels();
-      children.forEach(child => {
-        child.set('_isLocked', this.shouldLock(child));
-        if (!(child instanceof MenuModel)) return;
-        child.checkLocking();
-      });
-    }
-
+  get _children() {
+    Adapt.log.deprecated('menuModel._children, use menuModel.hasManagedChildren instead, child models are defined by the JSON');
+    return 'contentObjects';
   }
 
-  Adapt.register('menu', { model: MenuModel });
+  /**
+   * Returns a string of the model type group.
+   * @returns {string}
+   */
+  getTypeGroup() {
+    return 'menu';
+  }
 
-  return MenuModel;
+  setCustomLocking() {
+    const children = this.getAvailableChildModels();
+    children.forEach(child => {
+      child.set('_isLocked', this.shouldLock(child));
+      if (!(child instanceof MenuModel)) return;
+      child.checkLocking();
+    });
+  }
 
-});
+}
+
+Adapt.register('menu', { model: MenuModel });
+
+export default MenuModel;

--- a/src/core/js/models/notifyModel.js
+++ b/src/core/js/models/notifyModel.js
@@ -1,4 +1,6 @@
-export default class NotifyModel extends Backbone.Model {
+import LockingModel from 'core/js/models/lockingModel';
+
+export default class NotifyModel extends LockingModel {
 
   defaults() {
     return {

--- a/src/core/js/models/notifyModel.js
+++ b/src/core/js/models/notifyModel.js
@@ -1,13 +1,11 @@
-define(function() {
+export default class NotifyModel extends Backbone.Model {
 
-  var NotifyModel = Backbone.Model.extend({
-    defaults: {
+  defaults() {
+    return {
       _isActive: false,
       _showIcon: false,
       _timeout: 3000
-    }
-  });
+    };
+  }
 
-  return NotifyModel;
-
-});
+}

--- a/src/core/js/models/pageModel.js
+++ b/src/core/js/models/pageModel.js
@@ -1,27 +1,23 @@
-define([
-  'core/js/adapt',
-  'core/js/models/contentObjectModel'
-], function (Adapt, ContentObjectModel) {
+import Adapt from 'core/js/adapt';
+import ContentObjectModel from 'core/js/models/contentObjectModel';
 
-  class PageModel extends ContentObjectModel {
+class PageModel extends ContentObjectModel {
 
-    get _children() {
-      Adapt.log.deprecated('pageModel._children, use menuModel.hasManagedChildren instead, child models are defined by the JSON');
-      return 'articles';
-    }
-
-    /**
-     * Returns a string of the model type group.
-     * @returns {string}
-     */
-    getTypeGroup() {
-      return 'page';
-    }
-
+  get _children() {
+    Adapt.log.deprecated('pageModel._children, use menuModel.hasManagedChildren instead, child models are defined by the JSON');
+    return 'articles';
   }
 
-  Adapt.register('page', { model: PageModel });
+  /**
+   * Returns a string of the model type group.
+   * @returns {string}
+   */
+  getTypeGroup() {
+    return 'page';
+  }
 
-  return PageModel;
+}
 
-});
+Adapt.register('page', { model: PageModel });
+
+export default PageModel;

--- a/src/core/js/models/questionModel.js
+++ b/src/core/js/models/questionModel.js
@@ -1,343 +1,339 @@
-define([
-  'core/js/adapt',
-  'core/js/models/componentModel',
-  'core/js/enums/buttonStateEnum'
-], function(Adapt, ComponentModel, BUTTON_STATE) {
+import Adapt from 'core/js/adapt';
+import ComponentModel from 'core/js/models/componentModel';
+import BUTTON_STATE from 'core/js/enums/buttonStateEnum';
 
-  class QuestionModel extends ComponentModel {
+class QuestionModel extends ComponentModel {
 
-    /// ///
-    // Setup question types
-    /// /
+  /// ///
+  // Setup question types
+  /// /
 
-    // Used to set model defaults
-    defaults() {
-      // Extend from the ComponentModel defaults
-      return ComponentModel.resultExtend('defaults', {
-        _isQuestionType: true,
-        _shouldDisplayAttempts: false,
-        _canShowModelAnswer: true,
-        _canShowFeedback: true,
-        _canShowMarking: true,
-        _canSubmit: true,
-        _isSubmitted: false,
-        _questionWeight: Adapt.config.get('_questionWeight'),
-        _items: []
-      });
-    }
+  // Used to set model defaults
+  defaults() {
+    // Extend from the ComponentModel defaults
+    return ComponentModel.resultExtend('defaults', {
+      _isQuestionType: true,
+      _shouldDisplayAttempts: false,
+      _canShowModelAnswer: true,
+      _canShowFeedback: true,
+      _canShowMarking: true,
+      _canSubmit: true,
+      _isSubmitted: false,
+      _questionWeight: Adapt.config.get('_questionWeight'),
+      _items: []
+    });
+  }
 
-    // Extend from the ComponentModel trackable
-    trackable() {
-      return ComponentModel.resultExtend('trackable', [
-        '_isSubmitted',
-        '_score',
-        '_isCorrect',
-        '_attemptsLeft'
-      ]);
-    }
+  // Extend from the ComponentModel trackable
+  trackable() {
+    return ComponentModel.resultExtend('trackable', [
+      '_isSubmitted',
+      '_score',
+      '_isCorrect',
+      '_attemptsLeft'
+    ]);
+  }
 
-    trackableType() {
-      return ComponentModel.resultExtend('trackableType', [
-        Boolean,
-        Number,
-        Boolean,
-        Number
-      ]);
-    }
+  trackableType() {
+    return ComponentModel.resultExtend('trackableType', [
+      Boolean,
+      Number,
+      Boolean,
+      Number
+    ]);
+  }
 
-    /**
-     * Returns a string of the model type group.
-     * @returns {string}
-     */
-    getTypeGroup() {
-      return 'question';
-    }
+  /**
+   * Returns a string of the model type group.
+   * @returns {string}
+   */
+  getTypeGroup() {
+    return 'question';
+  }
 
-    init() {
-      this.setupDefaultSettings();
-      this.setLocking('_canSubmit', true);
-      super.init();
-    }
+  init() {
+    this.setupDefaultSettings();
+    this.setLocking('_canSubmit', true);
+    super.init();
+  }
 
-    // Calls default methods to setup on questions
-    setupDefaultSettings() {
-      // Not sure this is needed anymore, keeping to maintain API
-      this.setupWeightSettings();
-      this.setupButtonSettings();
-    }
+  // Calls default methods to setup on questions
+  setupDefaultSettings() {
+    // Not sure this is needed anymore, keeping to maintain API
+    this.setupWeightSettings();
+    this.setupButtonSettings();
+  }
 
-    // Used to setup either global or local button text
-    setupButtonSettings() {
-      const globalButtons = Adapt.course.get('_buttons');
+  // Used to setup either global or local button text
+  setupButtonSettings() {
+    const globalButtons = Adapt.course.get('_buttons');
 
-      // Check if  '_buttons' attribute exists and if not use the globally defined buttons.
-      if (!this.has('_buttons')) {
-        this.set('_buttons', globalButtons);
-      } else {
-        // Check all the components buttons.
-        // If they are empty use the global defaults.
-        const componentButtons = this.get('_buttons');
+    // Check if  '_buttons' attribute exists and if not use the globally defined buttons.
+    if (!this.has('_buttons')) {
+      this.set('_buttons', globalButtons);
+    } else {
+      // Check all the components buttons.
+      // If they are empty use the global defaults.
+      const componentButtons = this.get('_buttons');
 
-        for (let key in componentButtons) {
-          if (typeof componentButtons[key] === 'object') {
-            // Button text.
-            if (!componentButtons[key].buttonText && globalButtons[key].buttonText) {
-              componentButtons[key].buttonText = globalButtons[key].buttonText;
-            }
-
-            // ARIA labels.
-            if (!componentButtons[key].ariaLabel && globalButtons[key].ariaLabel) {
-              componentButtons[key].ariaLabel = globalButtons[key].ariaLabel;
-            }
+      for (let key in componentButtons) {
+        if (typeof componentButtons[key] === 'object') {
+          // Button text.
+          if (!componentButtons[key].buttonText && globalButtons[key].buttonText) {
+            componentButtons[key].buttonText = globalButtons[key].buttonText;
           }
 
-          if (!componentButtons[key] && globalButtons[key]) {
-            componentButtons[key] = globalButtons[key];
+          // ARIA labels.
+          if (!componentButtons[key].ariaLabel && globalButtons[key].ariaLabel) {
+            componentButtons[key].ariaLabel = globalButtons[key].ariaLabel;
           }
+        }
+
+        if (!componentButtons[key] && globalButtons[key]) {
+          componentButtons[key] = globalButtons[key];
         }
       }
     }
+  }
 
-    // Used to setup either global or local question weight/score
-    setupWeightSettings() {
-      // Not needed as handled by model defaults, keeping to maintain API
+  // Used to setup either global or local question weight/score
+  setupWeightSettings() {
+    // Not needed as handled by model defaults, keeping to maintain API
+  }
+
+  /// ///
+  // Submit process
+  /// /
+
+  // Use to check if the user is allowed to submit the question
+  // Maybe the user has to select an item?
+  canSubmit() {}
+
+  checkCanSubmit() {
+    this.set('_canSubmit', this.canSubmit(), { pluginName: 'adapt' });
+  }
+
+  // Used to update the amount of attempts the user has left
+  updateAttempts() {
+    if (!this.get('_attemptsLeft')) {
+      this.set('_attemptsLeft', this.get('_attempts'));
     }
+    this.set('_attemptsLeft', this.get('_attemptsLeft') - 1);
+  }
 
-    /// ///
-    // Submit process
-    /// /
+  // Used to set _isEnabled and _isSubmitted on the model
+  setQuestionAsSubmitted() {
+    this.set({
+      _isEnabled: false,
+      _isSubmitted: true
+    });
+  }
 
-    // Use to check if the user is allowed to submit the question
-    // Maybe the user has to select an item?
-    canSubmit() {}
+  // Sets _isCorrect:true/false based upon isCorrect method below
+  markQuestion() {
 
-    checkCanSubmit() {
-      this.set('_canSubmit', this.canSubmit(), { pluginName: 'adapt' });
-    }
-
-    // Used to update the amount of attempts the user has left
-    updateAttempts() {
-      if (!this.get('_attemptsLeft')) {
-        this.set('_attemptsLeft', this.get('_attempts'));
-      }
-      this.set('_attemptsLeft', this.get('_attemptsLeft') - 1);
-    }
-
-    // Used to set _isEnabled and _isSubmitted on the model
-    setQuestionAsSubmitted() {
-      this.set({
-        _isEnabled: false,
-        _isSubmitted: true
-      });
-    }
-
-    // Sets _isCorrect:true/false based upon isCorrect method below
-    markQuestion() {
-
-      if (this.isCorrect()) {
-        this.set('_isCorrect', true);
-      } else {
-        this.set('_isCorrect', false);
-      }
-
-    }
-
-    // Should return a boolean based upon whether to question is correct or not
-    isCorrect() {}
-
-    // Used to set the score based upon the _questionWeight
-    setScore() {}
-
-    // Checks if the question should be set to complete
-    // Calls setCompletionStatus and adds complete classes
-    checkQuestionCompletion() {
-
-      const isComplete = (this.get('_isCorrect') || this.get('_attemptsLeft') === 0);
-
-      if (isComplete) {
-        this.setCompletionStatus();
-      }
-
-      return isComplete;
-
-    }
-
-    // Updates buttons based upon question state by setting
-    // _buttonState on the model which buttonsView listens to
-    updateButtons() {
-
-      const isInteractionComplete = this.get('_isInteractionComplete');
-      const isCorrect = this.get('_isCorrect');
-      const isEnabled = this.get('_isEnabled');
-      const buttonState = this.get('_buttonState');
-      const canShowModelAnswer = this.get('_canShowModelAnswer');
-
-      if (isInteractionComplete) {
-
-        if (isCorrect || !canShowModelAnswer) {
-          // Use correct instead of complete to signify button state
-          this.set('_buttonState', BUTTON_STATE.CORRECT);
-
-        } else {
-
-          switch (buttonState) {
-            case BUTTON_STATE.SUBMIT:
-            case BUTTON_STATE.HIDE_CORRECT_ANSWER:
-              this.set('_buttonState', BUTTON_STATE.SHOW_CORRECT_ANSWER);
-              break;
-            default:
-              this.set('_buttonState', BUTTON_STATE.HIDE_CORRECT_ANSWER);
-          }
-
-        }
-
-      } else {
-
-        if (isEnabled) {
-          this.set('_buttonState', BUTTON_STATE.SUBMIT);
-        } else {
-          this.set('_buttonState', BUTTON_STATE.RESET);
-        }
-      }
-
-    }
-
-    // Used to setup the correct, incorrect and partly correct feedback
-    setupFeedback() {
-      if (!this.has('_feedback')) return;
-
-      if (this.get('_isCorrect')) {
-        this.setupCorrectFeedback();
-      } else if (this.isPartlyCorrect()) {
-        this.setupPartlyCorrectFeedback();
-      } else {
-        this.setupIncorrectFeedback();
-      }
-    }
-
-    // Used by the question to determine if the question is incorrect or partly correct
-    // Should return a boolean
-    isPartlyCorrect() {}
-
-    setupCorrectFeedback() {
-      this.set({
-        feedbackTitle: this.getFeedbackTitle(),
-        feedbackMessage: this.get('_feedback').correct
-      });
-    }
-
-    setupPartlyCorrectFeedback() {
-      const feedback = this.get('_feedback')._partlyCorrect;
-
-      if (feedback && feedback.final) {
-        this.setAttemptSpecificFeedback(feedback);
-      } else {
-        this.setupIncorrectFeedback();
-      }
-    }
-
-    setupIncorrectFeedback() {
-      this.setAttemptSpecificFeedback(this.get('_feedback')._incorrect);
-    }
-
-    setAttemptSpecificFeedback(feedback) {
-      const body = (this.get('_attemptsLeft') && feedback.notFinal) || feedback.final;
-
-      this.set({
-        feedbackTitle: this.getFeedbackTitle(),
-        feedbackMessage: body
-      });
-    }
-
-    getFeedbackTitle() {
-      return this.get('_feedback').title || this.get('displayTitle') || this.get('title') || '';
-    }
-
-    /**
-     * Used to determine whether the learner is allowed to interact with the question component or not.
-     * @return {Boolean}
-     */
-    isInteractive() {
-      return !this.get('_isComplete') || (this.get('_isEnabled') && !this.get('_isSubmitted'));
-    }
-
-    // Reset the model to let the user have another go (not the same as attempts)
-    reset(type, force) {
-      if (!this.get('_canReset') && !force) return;
-
-      type = type || true; // hard reset by default, can be "soft", "hard"/true
-
-      super.reset(type, force);
-
-      const attempts = this.get('_attempts');
-      this.set({
-        _attemptsLeft: attempts,
-        _isCorrect: undefined,
-        _isSubmitted: false,
-        _buttonState: BUTTON_STATE.SUBMIT
-      });
-    }
-
-    // Reset question for subsequent attempts
-    setQuestionAsReset() {
-      this.set({
-        _isEnabled: true,
-        _isSubmitted: false
-      });
-    }
-
-    refresh() {
-      this.trigger('question:refresh');
-    }
-
-    getButtonState() {
-      if (this.get('_isCorrect')) {
-        return BUTTON_STATE.CORRECT;
-      }
-
-      if (this.get('_attemptsLeft') === 0) {
-        return this.get('_canShowModelAnswer') ? BUTTON_STATE.SHOW_CORRECT_ANSWER : BUTTON_STATE.INCORRECT;
-      }
-
-      return this.get('_isSubmitted') ? BUTTON_STATE.RESET : BUTTON_STATE.SUBMIT;
-    }
-
-    // Returns an object specific to the question type, e.g. if the question
-    // is a 'choice' this should contain an object with:
-    // - correctResponsesPattern[]
-    // - choices[]
-    getInteractionObject() {
-      return {};
-    }
-
-    // Returns a string detailing how the user answered the question.
-    getResponse() {}
-
-    // Returns a string describing the type of interaction: "choice" and "matching" supported (see scorm wrapper)
-    getResponseType() {}
-
-    /**
-     * Called at the end of the onSubmitClicked view function.
-     */
-    onSubmitted() {
-      // Stores the current attempt state
-      this.addAttemptObject();
-    }
-
-    /** @type {boolean} */
-    get shouldShowMarking() {
-      if (!this.get('_canShowMarking')) {
-        return false;
-      }
-
-      return this.get('_isInteractionComplete');
+    if (this.isCorrect()) {
+      this.set('_isCorrect', true);
+    } else {
+      this.set('_isCorrect', false);
     }
 
   }
 
-  // This abstract model needs to registered to support deprecated view-only questions
-  Adapt.register('question', { model: QuestionModel });
+  // Should return a boolean based upon whether to question is correct or not
+  isCorrect() {}
 
-  return QuestionModel;
+  // Used to set the score based upon the _questionWeight
+  setScore() {}
 
-});
+  // Checks if the question should be set to complete
+  // Calls setCompletionStatus and adds complete classes
+  checkQuestionCompletion() {
+
+    const isComplete = (this.get('_isCorrect') || this.get('_attemptsLeft') === 0);
+
+    if (isComplete) {
+      this.setCompletionStatus();
+    }
+
+    return isComplete;
+
+  }
+
+  // Updates buttons based upon question state by setting
+  // _buttonState on the model which buttonsView listens to
+  updateButtons() {
+
+    const isInteractionComplete = this.get('_isInteractionComplete');
+    const isCorrect = this.get('_isCorrect');
+    const isEnabled = this.get('_isEnabled');
+    const buttonState = this.get('_buttonState');
+    const canShowModelAnswer = this.get('_canShowModelAnswer');
+
+    if (isInteractionComplete) {
+
+      if (isCorrect || !canShowModelAnswer) {
+        // Use correct instead of complete to signify button state
+        this.set('_buttonState', BUTTON_STATE.CORRECT);
+
+      } else {
+
+        switch (buttonState) {
+          case BUTTON_STATE.SUBMIT:
+          case BUTTON_STATE.HIDE_CORRECT_ANSWER:
+            this.set('_buttonState', BUTTON_STATE.SHOW_CORRECT_ANSWER);
+            break;
+          default:
+            this.set('_buttonState', BUTTON_STATE.HIDE_CORRECT_ANSWER);
+        }
+
+      }
+
+    } else {
+
+      if (isEnabled) {
+        this.set('_buttonState', BUTTON_STATE.SUBMIT);
+      } else {
+        this.set('_buttonState', BUTTON_STATE.RESET);
+      }
+    }
+
+  }
+
+  // Used to setup the correct, incorrect and partly correct feedback
+  setupFeedback() {
+    if (!this.has('_feedback')) return;
+
+    if (this.get('_isCorrect')) {
+      this.setupCorrectFeedback();
+    } else if (this.isPartlyCorrect()) {
+      this.setupPartlyCorrectFeedback();
+    } else {
+      this.setupIncorrectFeedback();
+    }
+  }
+
+  // Used by the question to determine if the question is incorrect or partly correct
+  // Should return a boolean
+  isPartlyCorrect() {}
+
+  setupCorrectFeedback() {
+    this.set({
+      feedbackTitle: this.getFeedbackTitle(),
+      feedbackMessage: this.get('_feedback').correct
+    });
+  }
+
+  setupPartlyCorrectFeedback() {
+    const feedback = this.get('_feedback')._partlyCorrect;
+
+    if (feedback && feedback.final) {
+      this.setAttemptSpecificFeedback(feedback);
+    } else {
+      this.setupIncorrectFeedback();
+    }
+  }
+
+  setupIncorrectFeedback() {
+    this.setAttemptSpecificFeedback(this.get('_feedback')._incorrect);
+  }
+
+  setAttemptSpecificFeedback(feedback) {
+    const body = (this.get('_attemptsLeft') && feedback.notFinal) || feedback.final;
+
+    this.set({
+      feedbackTitle: this.getFeedbackTitle(),
+      feedbackMessage: body
+    });
+  }
+
+  getFeedbackTitle() {
+    return this.get('_feedback').title || this.get('displayTitle') || this.get('title') || '';
+  }
+
+  /**
+   * Used to determine whether the learner is allowed to interact with the question component or not.
+   * @return {Boolean}
+   */
+  isInteractive() {
+    return !this.get('_isComplete') || (this.get('_isEnabled') && !this.get('_isSubmitted'));
+  }
+
+  // Reset the model to let the user have another go (not the same as attempts)
+  reset(type, force) {
+    if (!this.get('_canReset') && !force) return;
+
+    type = type || true; // hard reset by default, can be "soft", "hard"/true
+
+    super.reset(type, force);
+
+    const attempts = this.get('_attempts');
+    this.set({
+      _attemptsLeft: attempts,
+      _isCorrect: undefined,
+      _isSubmitted: false,
+      _buttonState: BUTTON_STATE.SUBMIT
+    });
+  }
+
+  // Reset question for subsequent attempts
+  setQuestionAsReset() {
+    this.set({
+      _isEnabled: true,
+      _isSubmitted: false
+    });
+  }
+
+  refresh() {
+    this.trigger('question:refresh');
+  }
+
+  getButtonState() {
+    if (this.get('_isCorrect')) {
+      return BUTTON_STATE.CORRECT;
+    }
+
+    if (this.get('_attemptsLeft') === 0) {
+      return this.get('_canShowModelAnswer') ? BUTTON_STATE.SHOW_CORRECT_ANSWER : BUTTON_STATE.INCORRECT;
+    }
+
+    return this.get('_isSubmitted') ? BUTTON_STATE.RESET : BUTTON_STATE.SUBMIT;
+  }
+
+  // Returns an object specific to the question type, e.g. if the question
+  // is a 'choice' this should contain an object with:
+  // - correctResponsesPattern[]
+  // - choices[]
+  getInteractionObject() {
+    return {};
+  }
+
+  // Returns a string detailing how the user answered the question.
+  getResponse() {}
+
+  // Returns a string describing the type of interaction: "choice" and "matching" supported (see scorm wrapper)
+  getResponseType() {}
+
+  /**
+   * Called at the end of the onSubmitClicked view function.
+   */
+  onSubmitted() {
+    // Stores the current attempt state
+    this.addAttemptObject();
+  }
+
+  /** @type {boolean} */
+  get shouldShowMarking() {
+    if (!this.get('_canShowMarking')) {
+      return false;
+    }
+
+    return this.get('_isInteractionComplete');
+  }
+
+}
+
+// This abstract model needs to registered to support deprecated view-only questions
+Adapt.register('question', { model: QuestionModel });
+
+export default QuestionModel;

--- a/src/core/js/models/routerModel.js
+++ b/src/core/js/models/routerModel.js
@@ -1,4 +1,6 @@
-export default class RouterModel extends Backbone.Model {
+import LockingModel from 'core/js/models/lockingModel';
+
+export default class RouterModel extends LockingModel {
 
   defaults() {
     return {

--- a/src/core/js/models/routerModel.js
+++ b/src/core/js/models/routerModel.js
@@ -1,25 +1,17 @@
-define([
-  'core/js/adapt'
-], function(Adapt) {
+export default class RouterModel extends Backbone.Model {
 
-  class RouterModel extends Backbone.Model {
-
-    defaults() {
-      return {
-        _canNavigate: true,
-        _shouldNavigateFocus: true
-      };
-    }
-
-    lockedAttributes() {
-      return {
-        _canNavigate: false,
-        _shouldNavigateFocus: false
-      };
-    }
-
+  defaults() {
+    return {
+      _canNavigate: true,
+      _shouldNavigateFocus: true
+    };
   }
 
-  return RouterModel;
+  lockedAttributes() {
+    return {
+      _canNavigate: false,
+      _shouldNavigateFocus: false
+    };
+  }
 
-});
+}

--- a/src/core/js/mpabc.js
+++ b/src/core/js/mpabc.js
@@ -1,49 +1,46 @@
-define([
-  'core/js/adapt',
-  'core/js/data',
-  'core/js/collections/adaptSubsetCollection',
-  'core/js/models/courseModel',
-  'core/js/models/contentObjectModel',
-  'core/js/models/menuModel',
-  'core/js/models/pageModel',
-  'core/js/models/articleModel',
-  'core/js/models/blockModel',
-  'core/js/models/componentModel',
-  'core/js/views/pageView',
-  'core/js/views/articleView',
-  'core/js/views/blockView'
-], function(Adapt, Data, AdaptSubsetCollection, CourseModel, ContentObjectModel, MenuModel, PageModel, ArticleModel, BlockModel, ComponentModel, PageView, ArticleView, BlockView) {
+import Adapt from 'core/js/adapt';
+import Data from 'core/js/data';
+import AdaptSubsetCollection from 'core/js/collections/adaptSubsetCollection';
+import ContentObjectModel from 'core/js/models/contentObjectModel';
+import ArticleModel from 'core/js/models/articleModel';
+import BlockModel from 'core/js/models/blockModel';
+import ComponentModel from 'core/js/models/componentModel';
 
-  class MPABC extends Backbone.Controller {
+import 'core/js/models/courseModel';
+import 'core/js/models/menuModel';
+import 'core/js/models/pageModel';
+import 'core/js/views/pageView';
+import 'core/js/views/articleView';
+import 'core/js/views/blockView';
 
-    initialize() {
-      // Example of how to cause the data loader to wait for another module to setup
-      this.listenTo(Data, {
-        loading: this.waitForDataLoaded,
-        loaded: this.onDataLoaded
-      });
-      this.setupSubsetCollections();
-    }
+class MPABC extends Backbone.Controller {
 
-    waitForDataLoaded() {
-      // Tell the data loader to wait
-      Adapt.wait.begin();
-    }
-
-    onDataLoaded() {
-      // Tell the data loader that we have finished
-      Adapt.wait.end();
-    }
-
-    setupSubsetCollections() {
-      Adapt.contentObjects = new AdaptSubsetCollection(null, { parent: Data, model: ContentObjectModel });
-      Adapt.articles = new AdaptSubsetCollection(null, { parent: Data, model: ArticleModel });
-      Adapt.blocks = new AdaptSubsetCollection(null, { parent: Data, model: BlockModel });
-      Adapt.components = new AdaptSubsetCollection(null, { parent: Data, model: ComponentModel });
-    }
-
+  initialize() {
+    // Example of how to cause the data loader to wait for another module to setup
+    this.listenTo(Data, {
+      loading: this.waitForDataLoaded,
+      loaded: this.onDataLoaded
+    });
+    this.setupSubsetCollections();
   }
 
-  return (Adapt.mpabc = new MPABC());
+  waitForDataLoaded() {
+    // Tell the data loader to wait
+    Adapt.wait.begin();
+  }
 
-});
+  onDataLoaded() {
+    // Tell the data loader that we have finished
+    Adapt.wait.end();
+  }
+
+  setupSubsetCollections() {
+    Adapt.contentObjects = new AdaptSubsetCollection(null, { parent: Data, model: ContentObjectModel });
+    Adapt.articles = new AdaptSubsetCollection(null, { parent: Data, model: ArticleModel });
+    Adapt.blocks = new AdaptSubsetCollection(null, { parent: Data, model: BlockModel });
+    Adapt.components = new AdaptSubsetCollection(null, { parent: Data, model: ComponentModel });
+  }
+
+}
+
+export default (Adapt.mpabc = new MPABC());

--- a/src/core/js/navigation.js
+++ b/src/core/js/navigation.js
@@ -8,7 +8,7 @@ class NavigationController extends Backbone.Controller {
   }
 
   addNavigationBar() {
-    var adaptConfig = Adapt.course.get('_navigation');
+    const adaptConfig = Adapt.course.get('_navigation');
 
     if (adaptConfig && adaptConfig._isDefaultNavigationDisabled) {
       Adapt.trigger('navigation:initialize');

--- a/src/core/js/navigation.js
+++ b/src/core/js/navigation.js
@@ -1,27 +1,23 @@
-define([
-  'core/js/adapt',
-  'core/js/views/navigationView'
-], function(Adapt, NavigationView) {
+import Adapt from 'core/js/adapt';
+import NavigationView from 'core/js/views/navigationView';
 
-  var NavigationController = Backbone.Controller.extend({
+class NavigationController extends Backbone.Controller {
 
-    initialize: function() {
-      this.listenTo(Adapt, 'adapt:preInitialize', this.addNavigationBar);
-    },
+  initialize() {
+    this.listenTo(Adapt, 'adapt:preInitialize', this.addNavigationBar);
+  }
 
-    addNavigationBar: function() {
-      var adaptConfig = Adapt.course.get('_navigation');
+  addNavigationBar() {
+    var adaptConfig = Adapt.course.get('_navigation');
 
-      if (adaptConfig && adaptConfig._isDefaultNavigationDisabled) {
-        Adapt.trigger('navigation:initialize');
-        return;
-      }
-
-      Adapt.navigation = new NavigationView();// This should be triggered after 'app:dataReady' as plugins might want to manipulate the navigation
+    if (adaptConfig && adaptConfig._isDefaultNavigationDisabled) {
+      Adapt.trigger('navigation:initialize');
+      return;
     }
 
-  });
+    Adapt.navigation = new NavigationView();// This should be triggered after 'app:dataReady' as plugins might want to manipulate the navigation
+  }
 
-  return new NavigationController();
+}
 
-});
+export default new NavigationController();

--- a/src/core/js/notify.js
+++ b/src/core/js/notify.js
@@ -1,113 +1,109 @@
-define([
-  'core/js/adapt',
-  'core/js/collections/notifyPushCollection',
-  'core/js/views/notifyView',
-  'core/js/models/notifyModel'
-], function(Adapt, NotifyPushCollection, NotifyView, NotifyModel) {
+import Adapt from 'core/js/adapt';
+import NotifyPushCollection from 'core/js/collections/notifyPushCollection';
+import NotifyView from 'core/js/views/notifyView';
+import NotifyModel from 'core/js/models/notifyModel';
 
-  class Notify extends Backbone.Controller {
+class Notify extends Backbone.Controller {
 
-    initialize() {
-      this._stack = [];
-      this.notifyPushes = new NotifyPushCollection();
-      this.listenTo(Adapt, {
-        'notify:popup': this._deprecated.bind(this, 'popup'),
-        'notify:alert': this._deprecated.bind(this, 'alert'),
-        'notify:prompt': this._deprecated.bind(this, 'prompt'),
-        'notify:push': this._deprecated.bind(this, 'push')
-      });
-    }
-
-    get stack() {
-      return this._stack;
-    }
-
-    _deprecated(type, notifyObject) {
-      Adapt.log.deprecated(`NOTIFY DEPRECATED: Adapt.trigger('notify:${type}', notifyObject); is no longer supported, please use Adapt.notify.${type}(notifyObject);`);
-      return this.create(notifyObject, { _type: type });
-    }
-
-    create(notifyObject, defaults) {
-      notifyObject = _.defaults({}, notifyObject, defaults, {
-        _type: 'popup',
-        _isCancellable: true,
-        _showCloseButton: true,
-        _closeOnShadowClick: true
-      });
-
-      if (notifyObject._type === 'push') {
-        this.notifyPushes.push(notifyObject);
-        return;
-      }
-
-      return new NotifyView({
-        model: new NotifyModel(notifyObject)
-      });
-    }
-
-    /**
-     * Creates a 'popup' notify
-     * @param {Object} notifyObject An object containing all the settings for the popup
-     * @param {string} notifyObject.title Title of the popup
-     * @param {string} notifyObject.body Body of the popup
-     * @param {Boolean} [notifyObject._showCloseButton=true] If set to `false` the popup will not have a close button. The learner will still be able to dismiss the popup by clicking outside of it or by pressing the Esc key. This setting is typically used mainly for popups that have a subview (where the subview contains the close button)
-     * @param {Boolean} [notifyObject._isCancellable=true] If set to `false` the learner will not be able to close the popup - use with caution!
-     * @param {string} [notifyObject._classes] A class name or (space separated) list of class names you'd like to be applied to the popup's `<div>`
-     * @param {Backbone.View} [notifyObject._view] Subview to display in the popup instead of the standard view
-     */
-    popup(notifyObject) {
-      return this.create(notifyObject, { _type: 'popup' });
-    }
-
-    /**
-     * Creates an 'alert' notify popup
-     * @param {Object} notifyObject An object containing all the settings for the alert popup
-     * @param {string} notifyObject.title Title of the alert popup
-     * @param {string} notifyObject.body Body of the alert popup
-     * @param {string} notifyObject.confirmText Label for the popup confirm button
-     * @param {Boolean} [notifyObject._isCancellable=true] If set to `false` only the confirm button can be used to dismiss/close the popup
-     * @param {Boolean} [notifyObject._showIcon=false] If set to `true` an 'alert' icon will be displayed in the popup
-     * @param {string} [notifyObject._callbackEvent] Event to trigger when the confirm button is clicked
-     * @param {string} [notifyObject._classes] A class name or (space separated) list of class names you'd like to be applied to the popup's `<div>`
-     * @param {Backbone.View} [notifyObject._view] Subview to display in the popup instead of the standard view
-     */
-    alert(notifyObject) {
-      return this.create(notifyObject, { _type: 'alert' });
-    }
-
-    /**
-     * Creates a 'prompt dialog' notify popup
-     * @param {Object} notifyObject An object containing all the settings for the prompt dialog
-     * @param {string} notifyObject.title Title of the prompt
-     * @param {string} notifyObject.body Body of the prompt
-     * @param {Object[]} notifyObject._prompts Array of objects that each define a button (and associated callback event) that you want shown in the prompt
-     * @param {string} notifyObject._prompts[].promptText Label for this button
-     * @param {string} notifyObject._prompts[]._callbackEvent Event to be triggered when this button is clicked
-     * @param {Boolean} [notifyObject._isCancellable=true] If set to `false` only the confirm button can be used to dismiss/close the prompt
-     * @param {Boolean} [notifyObject._showIcon=true] If set to `true` a 'query' icon will be displayed in the popup
-     * @param {string} [notifyObject._callbackEvent] Event to trigger when the confirm button is clicked
-     * @param {string} [notifyObject._classes] A class name or (space separated) list of class names you'd like to be applied to the popup's `<div>`
-     * @param {Backbone.View} [notifyObject._view] Subview to display in the popup instead of the standard view
-     */
-    prompt(notifyObject) {
-      return this.create(notifyObject, { _type: 'prompt' });
-    }
-
-    /**
-     * Creates a 'push notification'
-     * @param {Object} notifyObject An object containing all the settings for the push notification
-     * @param {string} notifyObject.title Title of the push notification
-     * @param {string} notifyObject.body Body of the push notification
-     * @param {Number} [notifyObject._timeout=3000] Length of time (in milliseconds) the notification should left on-screen before automatically fading away
-     * @param {string} notifyObject._callbackEvent Event to be triggered if the learner clicks on the push notification (not triggered if they use the close button)
-     * @param {string} [notifyObject._classes] A class name or (space separated) list of class names you'd like to be applied to the popup's `<div>`
-     */
-    push(notifyObject) {
-      return this.create(notifyObject, { _type: 'push' });
-    }
-
+  initialize() {
+    this._stack = [];
+    this.notifyPushes = new NotifyPushCollection();
+    this.listenTo(Adapt, {
+      'notify:popup': this._deprecated.bind(this, 'popup'),
+      'notify:alert': this._deprecated.bind(this, 'alert'),
+      'notify:prompt': this._deprecated.bind(this, 'prompt'),
+      'notify:push': this._deprecated.bind(this, 'push')
+    });
   }
 
-  return (Adapt.notify = new Notify());
+  get stack() {
+    return this._stack;
+  }
 
-});
+  _deprecated(type, notifyObject) {
+    Adapt.log.deprecated(`NOTIFY DEPRECATED: Adapt.trigger('notify:${type}', notifyObject); is no longer supported, please use Adapt.notify.${type}(notifyObject);`);
+    return this.create(notifyObject, { _type: type });
+  }
+
+  create(notifyObject, defaults) {
+    notifyObject = _.defaults({}, notifyObject, defaults, {
+      _type: 'popup',
+      _isCancellable: true,
+      _showCloseButton: true,
+      _closeOnShadowClick: true
+    });
+
+    if (notifyObject._type === 'push') {
+      this.notifyPushes.push(notifyObject);
+      return;
+    }
+
+    return new NotifyView({
+      model: new NotifyModel(notifyObject)
+    });
+  }
+
+  /**
+   * Creates a 'popup' notify
+   * @param {Object} notifyObject An object containing all the settings for the popup
+   * @param {string} notifyObject.title Title of the popup
+   * @param {string} notifyObject.body Body of the popup
+   * @param {Boolean} [notifyObject._showCloseButton=true] If set to `false` the popup will not have a close button. The learner will still be able to dismiss the popup by clicking outside of it or by pressing the Esc key. This setting is typically used mainly for popups that have a subview (where the subview contains the close button)
+   * @param {Boolean} [notifyObject._isCancellable=true] If set to `false` the learner will not be able to close the popup - use with caution!
+   * @param {string} [notifyObject._classes] A class name or (space separated) list of class names you'd like to be applied to the popup's `<div>`
+   * @param {Backbone.View} [notifyObject._view] Subview to display in the popup instead of the standard view
+   */
+  popup(notifyObject) {
+    return this.create(notifyObject, { _type: 'popup' });
+  }
+
+  /**
+   * Creates an 'alert' notify popup
+   * @param {Object} notifyObject An object containing all the settings for the alert popup
+   * @param {string} notifyObject.title Title of the alert popup
+   * @param {string} notifyObject.body Body of the alert popup
+   * @param {string} notifyObject.confirmText Label for the popup confirm button
+   * @param {Boolean} [notifyObject._isCancellable=true] If set to `false` only the confirm button can be used to dismiss/close the popup
+   * @param {Boolean} [notifyObject._showIcon=false] If set to `true` an 'alert' icon will be displayed in the popup
+   * @param {string} [notifyObject._callbackEvent] Event to trigger when the confirm button is clicked
+   * @param {string} [notifyObject._classes] A class name or (space separated) list of class names you'd like to be applied to the popup's `<div>`
+   * @param {Backbone.View} [notifyObject._view] Subview to display in the popup instead of the standard view
+   */
+  alert(notifyObject) {
+    return this.create(notifyObject, { _type: 'alert' });
+  }
+
+  /**
+   * Creates a 'prompt dialog' notify popup
+   * @param {Object} notifyObject An object containing all the settings for the prompt dialog
+   * @param {string} notifyObject.title Title of the prompt
+   * @param {string} notifyObject.body Body of the prompt
+   * @param {Object[]} notifyObject._prompts Array of objects that each define a button (and associated callback event) that you want shown in the prompt
+   * @param {string} notifyObject._prompts[].promptText Label for this button
+   * @param {string} notifyObject._prompts[]._callbackEvent Event to be triggered when this button is clicked
+   * @param {Boolean} [notifyObject._isCancellable=true] If set to `false` only the confirm button can be used to dismiss/close the prompt
+   * @param {Boolean} [notifyObject._showIcon=true] If set to `true` a 'query' icon will be displayed in the popup
+   * @param {string} [notifyObject._callbackEvent] Event to trigger when the confirm button is clicked
+   * @param {string} [notifyObject._classes] A class name or (space separated) list of class names you'd like to be applied to the popup's `<div>`
+   * @param {Backbone.View} [notifyObject._view] Subview to display in the popup instead of the standard view
+   */
+  prompt(notifyObject) {
+    return this.create(notifyObject, { _type: 'prompt' });
+  }
+
+  /**
+   * Creates a 'push notification'
+   * @param {Object} notifyObject An object containing all the settings for the push notification
+   * @param {string} notifyObject.title Title of the push notification
+   * @param {string} notifyObject.body Body of the push notification
+   * @param {Number} [notifyObject._timeout=3000] Length of time (in milliseconds) the notification should left on-screen before automatically fading away
+   * @param {string} notifyObject._callbackEvent Event to be triggered if the learner clicks on the push notification (not triggered if they use the close button)
+   * @param {string} [notifyObject._classes] A class name or (space separated) list of class names you'd like to be applied to the popup's `<div>`
+   */
+  push(notifyObject) {
+    return this.create(notifyObject, { _type: 'push' });
+  }
+
+}
+
+export default (Adapt.notify = new Notify());

--- a/src/core/js/offlineStorage.js
+++ b/src/core/js/offlineStorage.js
@@ -1,102 +1,98 @@
-define([
-  'core/js/adapt'
-], function(Adapt) {
+import Adapt from 'core/js/adapt';
 
-  // Basic API for setting and getting name+value pairs
-  // Allows registration of a single handler.
+// Basic API for setting and getting name+value pairs
+// Allows registration of a single handler.
 
-  var OfflineStorage = Backbone.Controller.extend({
+class OfflineStorage extends Backbone.Controller {
 
+  /**
+   * set .ready to false if an offlineStorage handler is being attached - we'll need to wait until the handler lets us know
+   * it's ready before we can safely use offlineStorage
+   */
+  initialize(handler) {
     /**
      * set to true initially so that if there are no offlineStorage handlers (i.e. if contrib-spoor is not installed)
      * this can still be accessed OK
      */
-    ready: true,
-    _handler: undefined,
+    this.ready = true;
+    this._handler = undefined;
 
-    /**
-     * set .ready to false if an offlineStorage handler is being attached - we'll need to wait until the handler lets us know
-     * it's ready before we can safely use offlineStorage
-     */
-    initialize: function(handler) {
-      if (!handler) {
-        return;
-      }
-
-      this.ready = false;
-      this._handler = handler;
-    },
-
-    /**
-     * Flag to indicate if an offlineStorage handler has been defined.
-     * @returns {boolean} true if an offlineStorage handler has been defined, false otherwise
-     */
-    hasHandler: function() {
-      return this._handler !== undefined;
-    },
-
-    /**
-     * Causes state to be serialized and saved.
-     */
-    save: function() {
-      Adapt.trigger('tracking:save');
-      if (this._handler && this._handler.save) {
-        return this._handler.save.apply(this._handler, arguments);
-      }
-    },
-
-    /**
-     * Serializes nested arrays, booleans and numbers into an encoded string.
-     * @param {Array|boolean|number} value
-     * @returns {string}
-     */
-    serialize: function(value) {
-      if (this._handler && this._handler.serialize) {
-        return this._handler.serialize.apply(this._handler, arguments);
-      }
-      return JSON.stringify(value);
-    },
-
-    /**
-     * Deserializes encoded strings back into nested arrays, booleans and numbers.
-     * @param {string} value
-     * @returns {Array|boolean|number}
-     */
-    deserialize: function(value) {
-      if (this._handler && this._handler.deserialize) {
-        return this._handler.deserialize.apply(this._handler, arguments);
-      }
-      return JSON.parse(value);
-    },
-
-    set: function(name, value) {
-      if (this._handler && this._handler.set) {
-        return this._handler.set.apply(this._handler, arguments);
-      }
-      // if no handler has been defined, just store the data locally
-      this[name] = value;
-    },
-
-    get: function(name) {
-      if (this._handler && this._handler.get) {
-        return this._handler.get.apply(this._handler, arguments);
-      }
-      // if no handler has been defined, check local data store
-      return this[name];
-    },
-
-    /**
-     * Some forms of offlineStorage could take time to initialise, this allows us to let plugins know when it's ready to be used
-     */
-    setReadyStatus: function() {
-      this.ready = true;
-      Adapt.trigger('offlineStorage:ready');
+    if (!handler) {
+      return;
     }
 
-  });
+    this.ready = false;
+    this._handler = handler;
+  }
 
-  Adapt.offlineStorage = new OfflineStorage();
+  /**
+   * Flag to indicate if an offlineStorage handler has been defined.
+   * @returns {boolean} true if an offlineStorage handler has been defined, false otherwise
+   */
+  hasHandler() {
+    return this._handler !== undefined;
+  }
 
-  return Adapt.offlineStorage;
+  /**
+   * Causes state to be serialized and saved.
+   */
+  save() {
+    Adapt.trigger('tracking:save');
+    if (this._handler && this._handler.save) {
+      return this._handler.save.apply(this._handler, arguments);
+    }
+  }
 
-});
+  /**
+   * Serializes nested arrays, booleans and numbers into an encoded string.
+   * @param {Array|boolean|number} value
+   * @returns {string}
+   */
+  serialize(value) {
+    if (this._handler && this._handler.serialize) {
+      return this._handler.serialize.apply(this._handler, arguments);
+    }
+    return JSON.stringify(value);
+  }
+
+  /**
+   * Deserializes encoded strings back into nested arrays, booleans and numbers.
+   * @param {string} value
+   * @returns {Array|boolean|number}
+   */
+  deserialize(value) {
+    if (this._handler && this._handler.deserialize) {
+      return this._handler.deserialize.apply(this._handler, arguments);
+    }
+    return JSON.parse(value);
+  }
+
+  set(name, value) {
+    if (this._handler && this._handler.set) {
+      return this._handler.set.apply(this._handler, arguments);
+    }
+    // if no handler has been defined, just store the data locally
+    this[name] = value;
+  }
+
+  get(name) {
+    if (this._handler && this._handler.get) {
+      return this._handler.get.apply(this._handler, arguments);
+    }
+    // if no handler has been defined, check local data store
+    return this[name];
+  }
+
+  /**
+   * Some forms of offlineStorage could take time to initialise, this allows us to let plugins know when it's ready to be used
+   */
+  setReadyStatus() {
+    this.ready = true;
+    Adapt.trigger('offlineStorage:ready');
+  }
+
+}
+
+Adapt.offlineStorage = new OfflineStorage();
+
+export default Adapt.offlineStorage;

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -1,423 +1,419 @@
-define([
-  'core/js/adapt',
-  'core/js/models/routerModel',
-  'core/js/models/courseModel',
-  'core/js/models/contentObjectModel',
-  'core/js/models/menuModel',
-  'core/js/startController'
-], function(Adapt, RouterModel, CourseModel, ContentObjectModel, MenuModel) {
+import Adapt from 'core/js/adapt';
+import RouterModel from 'core/js/models/routerModel';
+import CourseModel from 'core/js/models/courseModel';
+import ContentObjectModel from 'core/js/models/contentObjectModel';
+import MenuModel from 'core/js/models/menuModel';
+import 'core/js/startController';
 
-  class Router extends Backbone.Router {
+class Router extends Backbone.Router {
 
-    routes() {
-      return {
-        '': 'handleRoute',
-        'id/:id': 'handleRoute',
-        ':pluginName(/*location)(/*action)': 'handleRoute'
-      };
+  routes() {
+    return {
+      '': 'handleRoute',
+      'id/:id': 'handleRoute',
+      ':pluginName(/*location)(/*action)': 'handleRoute'
+    };
+  }
+
+  initialize({ model }) {
+    this.model = model;
+    this._navigationRoot = null;
+    // Flag to indicate if the router has tried to redirect to the current location.
+    this._isCircularNavigationInProgress = false;
+    this.showLoading();
+    // Store #wrapper element and html to cache for later use.
+    this.$wrapper = $('#wrapper');
+    this.$html = $('html');
+    this.listenToOnce(Adapt, 'app:dataReady', this.setDocumentTitle);
+    this.listenTo(Adapt, 'router:navigateTo', this.navigateToArguments);
+  }
+
+  get rootModel() {
+    return this._navigationRoot || Adapt.course;
+  }
+
+  set rootModel(model) {
+    this._navigationRoot = model;
+  }
+
+  showLoading() {
+    $('.js-loading').show();
+  }
+
+  hideLoading() {
+    $('.js-loading').hide();
+  }
+
+  setDocumentTitle() {
+    const currentModel = Adapt.location._currentModel;
+    const hasSubTitle = (currentModel && currentModel !== Adapt.router.rootModel && currentModel.get('title'));
+    const title = [
+      this.rootModel.get('title'),
+      hasSubTitle && currentModel.get('title')
+    ].filter(Boolean).join(' | ');
+    this.listenToOnce(Adapt, 'contentObjectView:preRender', () => {
+      const escapedTitle = $(`<div>${title}</div>`).text();
+      document.title = escapedTitle;
+    });
+  }
+
+  navigateToArguments(args) {
+    args = args.filter(v => v !== null);
+    const options = { trigger: false, replace: false };
+    if (args.length === 1 && Adapt.findById(args[0])) {
+      this.navigate('#/id/' + args[0], options);
+      return;
     }
+    if (args.length <= 3) {
+      this.navigate('#/' + args.join('/'), options);
+      return;
+    }
+    Adapt.log.deprecated(`Use Backbone.history.navigate or window.location.href instead of Adapt.trigger('router:navigateTo')`);
+    this.handleRoute(...args);
+  }
 
-    initialize({ model }) {
-      this.model = model;
-      this._navigationRoot = null;
-      // Flag to indicate if the router has tried to redirect to the current location.
+  handleRoute(...args) {
+    args = args.filter(v => v !== null);
+
+    if (this.model.get('_canNavigate')) {
+      // Reset _isCircularNavigationInProgress protection as code is allowed to navigate away.
       this._isCircularNavigationInProgress = false;
-      this.showLoading();
-      // Store #wrapper element and html to cache for later use.
-      this.$wrapper = $('#wrapper');
-      this.$html = $('html');
-      this.listenToOnce(Adapt, 'app:dataReady', this.setDocumentTitle);
-      this.listenTo(Adapt, 'router:navigateTo', this.navigateToArguments);
     }
 
-    get rootModel() {
-      return this._navigationRoot || Adapt.course;
+    // Check if the current page is in the process of navigating to itself.
+    // It will redirect to itself if the URL was changed and _canNavigate is false.
+    if (this._isCircularNavigationInProgress === false) {
+      // Trigger an event pre 'router:location' to allow extensions to stop routing.
+      Adapt.trigger('router:navigate', args);
     }
 
-    set rootModel(model) {
-      this._navigationRoot = model;
-    }
-
-    showLoading() {
-      $('.js-loading').show();
-    }
-
-    hideLoading() {
-      $('.js-loading').hide();
-    }
-
-    setDocumentTitle() {
-      const currentModel = Adapt.location._currentModel;
-      const hasSubTitle = (currentModel && currentModel !== Adapt.router.rootModel && currentModel.get('title'));
-      const title = [
-        this.rootModel.get('title'),
-        hasSubTitle && currentModel.get('title')
-      ].filter(Boolean).join(' | ');
-      this.listenToOnce(Adapt, 'contentObjectView:preRender', () => {
-        const escapedTitle = $(`<div>${title}</div>`).text();
-        document.title = escapedTitle;
-      });
-    }
-
-    navigateToArguments(args) {
-      args = args.filter(v => v !== null);
-      const options = { trigger: false, replace: false };
-      if (args.length === 1 && Adapt.findById(args[0])) {
-        this.navigate('#/id/' + args[0], options);
-        return;
+    // Re-check as _canNavigate can be set to false on 'router:navigate' event.
+    if (this.model.get('_canNavigate')) {
+      // Disable navigation whilst rendering.
+      this.model.set('_canNavigate', false, { pluginName: 'adapt' });
+      if (args.length <= 1) {
+        return this.handleId(...args);
       }
-      if (args.length <= 3) {
-        this.navigate('#/' + args.join('/'), options);
-        return;
-      }
-      Adapt.log.deprecated(`Use Backbone.history.navigate or window.location.href instead of Adapt.trigger('router:navigateTo')`);
-      this.handleRoute(...args);
+      return this.handlePluginRouter(...args);
     }
 
-    handleRoute(...args) {
-      args = args.filter(v => v !== null);
-
-      if (this.model.get('_canNavigate')) {
-        // Reset _isCircularNavigationInProgress protection as code is allowed to navigate away.
-        this._isCircularNavigationInProgress = false;
-      }
-
-      // Check if the current page is in the process of navigating to itself.
-      // It will redirect to itself if the URL was changed and _canNavigate is false.
-      if (this._isCircularNavigationInProgress === false) {
-        // Trigger an event pre 'router:location' to allow extensions to stop routing.
-        Adapt.trigger('router:navigate', args);
-      }
-
-      // Re-check as _canNavigate can be set to false on 'router:navigate' event.
-      if (this.model.get('_canNavigate')) {
-        // Disable navigation whilst rendering.
-        this.model.set('_canNavigate', false, { pluginName: 'adapt' });
-        if (args.length <= 1) {
-          return this.handleId(...args);
-        }
-        return this.handlePluginRouter(...args);
-      }
-
-      if (this._isCircularNavigationInProgress) {
-        // Navigation correction finished.
-        // Router has successfully re-navigated to the current _id as the URL was changed
-        // while _canNavigate: false
-        this._isCircularNavigationInProgress = false;
-        return;
-      }
-
-      // Cancel navigation to stay at the current location.
-      this._isCircularNavigationInProgress = true;
-      Adapt.trigger('router:navigationCancelled', args);
-
-      // Reset URL to the current one.
-      this.navigateToCurrentRoute(true);
+    if (this._isCircularNavigationInProgress) {
+      // Navigation correction finished.
+      // Router has successfully re-navigated to the current _id as the URL was changed
+      // while _canNavigate: false
+      this._isCircularNavigationInProgress = false;
+      return;
     }
 
-    async handlePluginRouter(pluginName, location, action) {
-      const pluginLocation = [
-        pluginName,
-        location && `-${location}`,
-        action && `-${action}`
-      ].filter(Boolean).join('');
-      await this.updateLocation(pluginLocation, null, null, null);
+    // Cancel navigation to stay at the current location.
+    this._isCircularNavigationInProgress = true;
+    Adapt.trigger('router:navigationCancelled', args);
 
-      Adapt.trigger('router:plugin:' + pluginName, pluginName, location, action);
-      Adapt.trigger('router:plugin', pluginName, location, action);
+    // Reset URL to the current one.
+    this.navigateToCurrentRoute(true);
+  }
+
+  async handlePluginRouter(pluginName, location, action) {
+    const pluginLocation = [
+      pluginName,
+      location && `-${location}`,
+      action && `-${action}`
+    ].filter(Boolean).join('');
+    await this.updateLocation(pluginLocation, null, null, null);
+
+    Adapt.trigger('router:plugin:' + pluginName, pluginName, location, action);
+    Adapt.trigger('router:plugin', pluginName, location, action);
+    this.model.set('_canNavigate', true, { pluginName: 'adapt' });
+  }
+
+  async handleId(id) {
+    const rootModel = Adapt.router.rootModel;
+    let model = (!id) ? rootModel : Adapt.findById(id);
+
+    if (!model) {
+      // Bad id
       this.model.set('_canNavigate', true, { pluginName: 'adapt' });
+      return;
     }
 
-    async handleId(id) {
-      const rootModel = Adapt.router.rootModel;
-      let model = (!id) ? rootModel : Adapt.findById(id);
+    // Keep the routed id incase it needs to be scrolled to later
+    const isContentObject = (model instanceof ContentObjectModel);
+    const navigateToId = model.get('_id');
 
-      if (!model) {
-        // Bad id
-        this.model.set('_canNavigate', true, { pluginName: 'adapt' });
+    // Ensure that the router is rendering a contentobject
+    model = isContentObject ? model : model.findAncestor('contentobject');
+    id = model.get('_id');
+
+    const isRoot = (model === rootModel);
+    if (isRoot && Adapt.course.has('_start')) {
+      // Do not allow access to the menu when the start controller is enabled.
+      var startController = Adapt.course.get('_start');
+      if (startController._isEnabled === true && startController._isMenuDisabled === true) {
         return;
       }
-
-      // Keep the routed id incase it needs to be scrolled to later
-      const isContentObject = (model instanceof ContentObjectModel);
-      const navigateToId = model.get('_id');
-
-      // Ensure that the router is rendering a contentobject
-      model = isContentObject ? model : model.findAncestor('contentobject');
-      id = model.get('_id');
-
-      const isRoot = (model === rootModel);
-      if (isRoot && Adapt.course.has('_start')) {
-        // Do not allow access to the menu when the start controller is enabled.
-        var startController = Adapt.course.get('_start');
-        if (startController._isEnabled === true && startController._isMenuDisabled === true) {
-          return;
-        }
-      }
-
-      if (model.get('_isLocked') && Adapt.config.get('_forceRouteLocking')) {
-        // Locked id
-        Adapt.log.warn('Unable to navigate to locked id: ' + id);
-        this.model.set('_canNavigate', true, { pluginName: 'adapt' });
-        if (Adapt.location._previousId === undefined) {
-          return this.navigate('#/', { trigger: true, replace: true });
-        }
-        return this.navigateBack();
-      }
-
-      // Move to a content object
-      this.showLoading();
-      await Adapt.remove();
-
-      /**
-       * TODO:
-       * As the course object has separate location and type rules,
-       * it makes it more difficult to update the Adapt.location object
-       * should stop doing this.
-       */
-      const isCourse = (model instanceof CourseModel);
-      const type = isCourse ? 'menu' : model.get('_type');
-      const location = isCourse ? 'course' : `${type}-${id}`;
-
-      model.set('_isVisited', true);
-      await this.updateLocation(location, type, id, model);
-
-      Adapt.once('contentObjectView:ready', () => {
-        // Allow navigation.
-        this.model.set('_canNavigate', true, { pluginName: 'adapt' });
-        this.handleNavigationFocus();
-      });
-      Adapt.trigger(`router:${type} router:contentObject`, model);
-
-      const ViewClass = Adapt.getViewClass(model);
-      const isMenu = (model instanceof MenuModel);
-      if (!ViewClass && isMenu) {
-        Adapt.log.deprecated(`Using event based menu view instantiation for '${Adapt.getViewName(model)}'`);
-        return;
-      }
-      this.$wrapper.append(new ViewClass({ model }).$el);
-
-      if (!isContentObject && !this.isScrolling) {
-        // Scroll to element if not a content object or not already trying to
-        await Adapt.navigateToElement('.' + navigateToId, { replace: true, duration: 400 });
-      }
-
     }
 
-    async updateLocation(currentLocation, type, id, currentModel) {
-      // Handles updating the location.
-      Adapt.location._previousModel = Adapt.location._currentModel;
-      Adapt.location._previousId = Adapt.location._currentId;
-      Adapt.location._previousContentType = Adapt.location._contentType;
-
-      Adapt.location._currentModel = currentModel;
-      Adapt.location._currentId = id;
-      Adapt.location._contentType = type;
-      Adapt.location._currentLocation = currentLocation;
-
-      /**
-       * TODO:
-       * this if block should be removed,
-       * these properties are unused in the framework
-       */
-      if (type === 'menu') {
-        Adapt.location._lastVisitedType = 'menu';
-        Adapt.location._lastVisitedMenu = id;
-      } else if (type === 'page') {
-        Adapt.location._lastVisitedType = 'page';
-        Adapt.location._lastVisitedPage = id;
+    if (model.get('_isLocked') && Adapt.config.get('_forceRouteLocking')) {
+      // Locked id
+      Adapt.log.warn('Unable to navigate to locked id: ' + id);
+      this.model.set('_canNavigate', true, { pluginName: 'adapt' });
+      if (Adapt.location._previousId === undefined) {
+        return this.navigate('#/', { trigger: true, replace: true });
       }
-
-      this.setDocumentTitle();
-      this.setGlobalClasses();
-
-      // Trigger event when location changes.
-      Adapt.trigger('router:location', Adapt.location);
-
-      await Adapt.wait.queue();
+      return this.navigateBack();
     }
 
-    setGlobalClasses() {
-      const currentModel = Adapt.location._currentModel;
-
-      const htmlClasses = (currentModel && currentModel.get('_htmlClasses')) || '';
-      const classes = (Adapt.location._currentId) ?
-        `location-${Adapt.location._contentType} location-id-${Adapt.location._currentId}` :
-        `location-${Adapt.location._currentLocation}`;
-      const currentClasses = `${classes} ${htmlClasses}`;
-
-      this.$html
-        .removeClass(Adapt.location._previousClasses)
-        .addClass(currentClasses)
-        .attr('data-location', Adapt.location._currentLocation);
-
-      this.$wrapper
-        .removeClass()
-        .addClass(classes)
-        .attr('data-location', Adapt.location._currentLocation);
-
-      Adapt.location._previousClasses = currentClasses;
-    }
-
-    handleNavigationFocus() {
-      if (!this.model.get('_shouldNavigateFocus')) return;
-      // Body will be forced to accept focus to start the
-      // screen reader reading the page.
-      Adapt.a11y.focus('body');
-    }
-
-    navigateBack() {
-      Backbone.history.history.back();
-    }
-
-    navigateToCurrentRoute(force) {
-      if (!this.model.get('_canNavigate') && !force) {
-        return;
-      }
-      if (!Adapt.location._currentId) {
-        return;
-      }
-      const currentId = Adapt.location._currentModel.get('_id');
-      const isRoot = (Adapt.location._currentModel === this.rootModel);
-      const route = isRoot ? '#/' : '#/id/' + currentId;
-      this.navigate(route, { trigger: true, replace: true });
-    }
-
-    navigateToPreviousRoute(force) {
-      // Sometimes a plugin might want to stop the default navigation.
-      // Check whether default navigation has changed.
-      if (!this.model.get('_canNavigate') && !force) {
-        return;
-      }
-      const currentModel = Adapt.location._currentModel;
-      const previousModel = Adapt.location._previousModel;
-      if (!currentModel) {
-        return this.navigateBack();
-      }
-      if (Adapt.location._currentModel instanceof MenuModel) {
-        return this.navigateToParent();
-      }
-      if (previousModel) {
-        return this.navigateBack();
-      }
-      this.navigateToParent();
-    }
-
-    navigateToParent(force) {
-      if (!this.model.get('_canNavigate') && !force) {
-        return;
-      }
-      const parentId = Adapt.location._currentModel.get('_parentId');
-      const parentModel = Adapt.findById(parentId);
-      const isRoot = (parentModel === this.rootModel);
-      const route = isRoot ? '#/' : '#/id/' + parentId;
-      this.navigate(route, { trigger: true });
-    }
-
-    navigateToHomeRoute(force) {
-      if (!this.model.get('_canNavigate') && !force) {
-        return;
-      }
-      this.navigate('#/', { trigger: true });
-    }
+    // Move to a content object
+    this.showLoading();
+    await Adapt.remove();
 
     /**
-     * Allows a selector or id to be passed in and Adapt will navigate to this element. Resolves
-     * asynchronously when the element has been navigated to.
-     * Backend for Adapt.navigateToElement
-     * @param {string} selector CSS selector or id of the Adapt element you want to navigate to e.g. `".co-05"` or `"co-05"`
-     * @param {Object} [settings] The settings for the `$.scrollTo` function (See https://github.com/flesler/jquery.scrollTo#settings).
-     * @param {Object} [settings.replace=false] Set to `true` if you want to update the URL without creating an entry in the browser's history.
+     * TODO:
+     * As the course object has separate location and type rules,
+     * it makes it more difficult to update the Adapt.location object
+     * should stop doing this.
      */
-    async navigateToElement(selector, settings = {}) {
-      const currentModelId = selector.replace(/\./g, '').split(' ')[0];
-      const currentModel = Adapt.findById(currentModelId);
+    const isCourse = (model instanceof CourseModel);
+    const type = isCourse ? 'menu' : model.get('_type');
+    const location = isCourse ? 'course' : `${type}-${id}`;
 
-      if (currentModel && (!currentModel.get('_isRendered') || !currentModel.get('_isReady'))) {
-        const shouldReplace = settings.replace || false;
-        const contentObject = (currentModel instanceof ContentObjectModel) ? currentModel : currentModel.findAncestor('contentobject');
-        const contentObjectId = contentObject.get('_id');
-        const isInCurrentContentObject = (contentObjectId !== Adapt.location._currentId);
-        if (isInCurrentContentObject) {
-          this.isScrolling = true;
-          this.navigate(`#/id/${currentModelId}`, { trigger: true, replace: shouldReplace });
-          this.model.set('_shouldNavigateFocus', false, { pluginName: 'adapt' });
-          await new Promise(resolve => Adapt.once('contentObjectView:ready', _.debounce(() => {
-            this.model.set('_shouldNavigateFocus', true, { pluginName: 'adapt' });
-            resolve();
-          }, 1)));
-          this.isScrolling = false;
-        }
-        await Adapt.parentView.renderTo(currentModelId);
-      }
+    model.set('_isVisited', true);
+    await this.updateLocation(location, type, id, model);
 
-      // Correct selector when passed a pure id
-      if (currentModel && selector === currentModel.get('_id')) {
-        selector = `.${selector}`;
-      }
+    Adapt.once('contentObjectView:ready', () => {
+      // Allow navigation.
+      this.model.set('_canNavigate', true, { pluginName: 'adapt' });
+      this.handleNavigationFocus();
+    });
+    Adapt.trigger(`router:${type} router:contentObject`, model);
 
-      // Get the current location - this is set in the router
-      const location = (Adapt.location._contentType) ?
-        Adapt.location._contentType : Adapt.location._currentLocation;
-      // Trigger initial scrollTo event
-      Adapt.trigger(`${location}:scrollTo`, selector);
-      // Setup duration variable
-      const disableScrollToAnimation = Adapt.config.has('_disableAnimation') ? Adapt.config.get('_disableAnimation') : false;
-      if (disableScrollToAnimation) {
-        settings.duration = 0;
-      } else if (!settings.duration) {
-        settings.duration = $.scrollTo.defaults.duration;
-      }
-
-      let offsetTop = 0;
-      if (Adapt.scrolling.isLegacyScrolling) {
-        offsetTop = -$('.nav').outerHeight();
-        // prevent scroll issue when component description aria-label coincident with top of component
-        if ($(selector).hasClass('component')) {
-          offsetTop -= $(selector).find('.aria-label').height() || 0;
-        }
-      }
-
-      if (!settings.offset) settings.offset = { top: offsetTop, left: 0 };
-      if (settings.offset.top === undefined) settings.offset.top = offsetTop;
-      if (settings.offset.left === undefined) settings.offset.left = 0;
-
-      if (settings.offset.left === 0) settings.axis = 'y';
-
-      if (Adapt.get('_canScroll') !== false) {
-        // Trigger scrollTo plugin
-        $.scrollTo(selector, settings);
-      }
-
-      // Trigger an event after animation
-      // 300 milliseconds added to make sure queue has finished
-      await new Promise(resolve => {
-        _.delay(() => {
-          Adapt.a11y.focusNext(selector);
-          Adapt.trigger(`${location}:scrolledTo`, selector);
-          resolve();
-        }, settings.duration + 300);
-      });
+    const ViewClass = Adapt.getViewClass(model);
+    const isMenu = (model instanceof MenuModel);
+    if (!ViewClass && isMenu) {
+      Adapt.log.deprecated(`Using event based menu view instantiation for '${Adapt.getViewName(model)}'`);
+      return;
     }
+    this.$wrapper.append(new ViewClass({ model }).$el);
 
-    get(...args) {
-      Adapt.log.deprecated('Adapt.router.get, please use Adapt.router.model.get');
-      return this.model.get(...args);
-    }
-
-    set(...args) {
-      Adapt.log.deprecated('Adapt.router.set, please use Adapt.router.model.set');
-      return this.model.set(...args);
+    if (!isContentObject && !this.isScrolling) {
+      // Scroll to element if not a content object or not already trying to
+      await Adapt.navigateToElement('.' + navigateToId, { replace: true, duration: 400 });
     }
 
   }
 
-  Adapt.router = new Router({
-    model: new RouterModel(null, { reset: true })
-  });
+  async updateLocation(currentLocation, type, id, currentModel) {
+    // Handles updating the location.
+    Adapt.location._previousModel = Adapt.location._currentModel;
+    Adapt.location._previousId = Adapt.location._currentId;
+    Adapt.location._previousContentType = Adapt.location._contentType;
 
-  Adapt.navigateToElement = Adapt.router.navigateToElement.bind(Adapt.router);
+    Adapt.location._currentModel = currentModel;
+    Adapt.location._currentId = id;
+    Adapt.location._contentType = type;
+    Adapt.location._currentLocation = currentLocation;
 
-  return Adapt.router;
+    /**
+     * TODO:
+     * this if block should be removed,
+     * these properties are unused in the framework
+     */
+    if (type === 'menu') {
+      Adapt.location._lastVisitedType = 'menu';
+      Adapt.location._lastVisitedMenu = id;
+    } else if (type === 'page') {
+      Adapt.location._lastVisitedType = 'page';
+      Adapt.location._lastVisitedPage = id;
+    }
 
+    this.setDocumentTitle();
+    this.setGlobalClasses();
+
+    // Trigger event when location changes.
+    Adapt.trigger('router:location', Adapt.location);
+
+    await Adapt.wait.queue();
+  }
+
+  setGlobalClasses() {
+    const currentModel = Adapt.location._currentModel;
+
+    const htmlClasses = (currentModel && currentModel.get('_htmlClasses')) || '';
+    const classes = (Adapt.location._currentId) ?
+      `location-${Adapt.location._contentType} location-id-${Adapt.location._currentId}` :
+      `location-${Adapt.location._currentLocation}`;
+    const currentClasses = `${classes} ${htmlClasses}`;
+
+    this.$html
+      .removeClass(Adapt.location._previousClasses)
+      .addClass(currentClasses)
+      .attr('data-location', Adapt.location._currentLocation);
+
+    this.$wrapper
+      .removeClass()
+      .addClass(classes)
+      .attr('data-location', Adapt.location._currentLocation);
+
+    Adapt.location._previousClasses = currentClasses;
+  }
+
+  handleNavigationFocus() {
+    if (!this.model.get('_shouldNavigateFocus')) return;
+    // Body will be forced to accept focus to start the
+    // screen reader reading the page.
+    Adapt.a11y.focus('body');
+  }
+
+  navigateBack() {
+    Backbone.history.history.back();
+  }
+
+  navigateToCurrentRoute(force) {
+    if (!this.model.get('_canNavigate') && !force) {
+      return;
+    }
+    if (!Adapt.location._currentId) {
+      return;
+    }
+    const currentId = Adapt.location._currentModel.get('_id');
+    const isRoot = (Adapt.location._currentModel === this.rootModel);
+    const route = isRoot ? '#/' : '#/id/' + currentId;
+    this.navigate(route, { trigger: true, replace: true });
+  }
+
+  navigateToPreviousRoute(force) {
+    // Sometimes a plugin might want to stop the default navigation.
+    // Check whether default navigation has changed.
+    if (!this.model.get('_canNavigate') && !force) {
+      return;
+    }
+    const currentModel = Adapt.location._currentModel;
+    const previousModel = Adapt.location._previousModel;
+    if (!currentModel) {
+      return this.navigateBack();
+    }
+    if (Adapt.location._currentModel instanceof MenuModel) {
+      return this.navigateToParent();
+    }
+    if (previousModel) {
+      return this.navigateBack();
+    }
+    this.navigateToParent();
+  }
+
+  navigateToParent(force) {
+    if (!this.model.get('_canNavigate') && !force) {
+      return;
+    }
+    const parentId = Adapt.location._currentModel.get('_parentId');
+    const parentModel = Adapt.findById(parentId);
+    const isRoot = (parentModel === this.rootModel);
+    const route = isRoot ? '#/' : '#/id/' + parentId;
+    this.navigate(route, { trigger: true });
+  }
+
+  navigateToHomeRoute(force) {
+    if (!this.model.get('_canNavigate') && !force) {
+      return;
+    }
+    this.navigate('#/', { trigger: true });
+  }
+
+  /**
+   * Allows a selector or id to be passed in and Adapt will navigate to this element. Resolves
+   * asynchronously when the element has been navigated to.
+   * Backend for Adapt.navigateToElement
+   * @param {string} selector CSS selector or id of the Adapt element you want to navigate to e.g. `".co-05"` or `"co-05"`
+   * @param {Object} [settings] The settings for the `$.scrollTo` function (See https://github.com/flesler/jquery.scrollTo#settings).
+   * @param {Object} [settings.replace=false] Set to `true` if you want to update the URL without creating an entry in the browser's history.
+   */
+  async navigateToElement(selector, settings = {}) {
+    const currentModelId = selector.replace(/\./g, '').split(' ')[0];
+    const currentModel = Adapt.findById(currentModelId);
+
+    if (currentModel && (!currentModel.get('_isRendered') || !currentModel.get('_isReady'))) {
+      const shouldReplace = settings.replace || false;
+      const contentObject = (currentModel instanceof ContentObjectModel) ? currentModel : currentModel.findAncestor('contentobject');
+      const contentObjectId = contentObject.get('_id');
+      const isInCurrentContentObject = (contentObjectId !== Adapt.location._currentId);
+      if (isInCurrentContentObject) {
+        this.isScrolling = true;
+        this.navigate(`#/id/${currentModelId}`, { trigger: true, replace: shouldReplace });
+        this.model.set('_shouldNavigateFocus', false, { pluginName: 'adapt' });
+        await new Promise(resolve => Adapt.once('contentObjectView:ready', _.debounce(() => {
+          this.model.set('_shouldNavigateFocus', true, { pluginName: 'adapt' });
+          resolve();
+        }, 1)));
+        this.isScrolling = false;
+      }
+      await Adapt.parentView.renderTo(currentModelId);
+    }
+
+    // Correct selector when passed a pure id
+    if (currentModel && selector === currentModel.get('_id')) {
+      selector = `.${selector}`;
+    }
+
+    // Get the current location - this is set in the router
+    const location = (Adapt.location._contentType) ?
+      Adapt.location._contentType : Adapt.location._currentLocation;
+    // Trigger initial scrollTo event
+    Adapt.trigger(`${location}:scrollTo`, selector);
+    // Setup duration variable
+    const disableScrollToAnimation = Adapt.config.has('_disableAnimation') ? Adapt.config.get('_disableAnimation') : false;
+    if (disableScrollToAnimation) {
+      settings.duration = 0;
+    } else if (!settings.duration) {
+      settings.duration = $.scrollTo.defaults.duration;
+    }
+
+    let offsetTop = 0;
+    if (Adapt.scrolling.isLegacyScrolling) {
+      offsetTop = -$('.nav').outerHeight();
+      // prevent scroll issue when component description aria-label coincident with top of component
+      if ($(selector).hasClass('component')) {
+        offsetTop -= $(selector).find('.aria-label').height() || 0;
+      }
+    }
+
+    if (!settings.offset) settings.offset = { top: offsetTop, left: 0 };
+    if (settings.offset.top === undefined) settings.offset.top = offsetTop;
+    if (settings.offset.left === undefined) settings.offset.left = 0;
+
+    if (settings.offset.left === 0) settings.axis = 'y';
+
+    if (Adapt.get('_canScroll') !== false) {
+      // Trigger scrollTo plugin
+      $.scrollTo(selector, settings);
+    }
+
+    // Trigger an event after animation
+    // 300 milliseconds added to make sure queue has finished
+    await new Promise(resolve => {
+      _.delay(() => {
+        Adapt.a11y.focusNext(selector);
+        Adapt.trigger(`${location}:scrolledTo`, selector);
+        resolve();
+      }, settings.duration + 300);
+    });
+  }
+
+  get(...args) {
+    Adapt.log.deprecated('Adapt.router.get, please use Adapt.router.model.get');
+    return this.model.get(...args);
+  }
+
+  set(...args) {
+    Adapt.log.deprecated('Adapt.router.set, please use Adapt.router.model.set');
+    return this.model.set(...args);
+  }
+
+}
+
+Adapt.router = new Router({
+  model: new RouterModel(null, { reset: true })
 });
+
+Adapt.navigateToElement = Adapt.router.navigateToElement.bind(Adapt.router);
+
+export default Adapt.router;

--- a/src/core/js/router.js
+++ b/src/core/js/router.js
@@ -147,7 +147,7 @@ class Router extends Backbone.Router {
     const isRoot = (model === rootModel);
     if (isRoot && Adapt.course.has('_start')) {
       // Do not allow access to the menu when the start controller is enabled.
-      var startController = Adapt.course.get('_start');
+      const startController = Adapt.course.get('_start');
       if (startController._isEnabled === true && startController._isMenuDisabled === true) {
         return;
       }

--- a/src/core/js/scrolling.js
+++ b/src/core/js/scrolling.js
@@ -1,124 +1,120 @@
-define([
-  'core/js/adapt'
-], function(Adapt) {
+import Adapt from 'core/js/adapt';
 
-  class Scrolling extends Backbone.Controller {
+class Scrolling extends Backbone.Controller {
 
-    initialize() {
-      this.$html = null;
-      this.$app = null;
-      this.isLegacyScrolling = true;
-      this._checkApp();
-      Adapt.once('configModel:dataLoaded', this._loadConfig.bind(this));
-    }
-
-    _checkApp() {
-      this.$html = $('html');
-      this.$app = $('#app');
-      if (this.$app.length) return;
-      this.$app = $('<div id="app">');
-      $('body').append(this.$app);
-      this.$app.append($('#wrapper'));
-      Adapt.log.warn('UPDATE - Your html file needs to have #app adding. See https://github.com/adaptlearning/adapt_framework/issues/2168');
-    }
-
-    _loadConfig() {
-      const config = Adapt.config.get('_scrollingContainer');
-      if (!config || !config._isEnabled) return;
-      const limitTo = config._limitToSelector;
-      const isIncluded = !limitTo || (this.$html.is(limitTo) || this.$html.hasClass(limitTo));
-      if (!isIncluded) return;
-      this.isLegacyScrolling = false;
-      this._addStyling();
-      this._fixJQuery();
-      this._fixScrollTo();
-      this._fixBrowser();
-    }
-
-    _addStyling() {
-      this.$html.addClass('adapt-scrolling');
-    }
-
-    _fixJQuery() {
-      const selectorScrollTop = $.fn.scrollTop;
-      const $app = Adapt.scrolling.$app;
-      $.fn.scrollTop = function() {
-        if (this[0] === window || this[0] === document.body) {
-          return selectorScrollTop.apply($app, arguments);
-        }
-        return selectorScrollTop.apply(this, arguments);
-      };
-      const selectorOffset = $.fn.offset;
-      $.fn.offset = function(coordinates) {
-        if (coordinates) {
-          return selectorOffset.apply(this, arguments);
-        }
-        const $app = Adapt.scrolling.$app;
-        const $element = this;
-        const elementOffset = selectorOffset.call($element);
-        const isCorrectedContainer = $element.is('html, body, #app') ||
-          $element.parents().is('#app');
-        if (!isCorrectedContainer) {
-          // Do not adjust the offset measurement as not in $app container and isn't html or body
-          return elementOffset;
-        }
-        // Adjust measurement by scrolling and offset of $app container
-        const scrollTop = parseInt($app.scrollTop());
-        const scrollLeft = parseInt($app.scrollLeft());
-        const appOffset = selectorOffset.call($app);
-        elementOffset.top += (scrollTop - appOffset.top);
-        elementOffset.left += (scrollLeft - appOffset.left);
-        return elementOffset;
-      };
-    }
-
-    _fixScrollTo() {
-      const selectorScrollTo = $.fn.scrollTo;
-      const scrollTo = $.scrollTo;
-      const $app = Adapt.scrolling.$app;
-      $.fn.scrollTo = function(target, duration, settings) {
-        if (this[0] === window || this[0] === document.body) {
-          return selectorScrollTo.apply($app, arguments);
-        }
-        return selectorScrollTo.apply(this, arguments);
-      };
-      $.scrollTo = function(target, duration, settings) {
-        return selectorScrollTo.apply($app, arguments);
-      };
-      Object.assign($.scrollTo, scrollTo);
-    }
-
-    _fixBrowser() {
-      const app = Adapt.scrolling.$app[0];
-      window.scrollTo = function(x, y) {
-        app.scrollTop = y || 0;
-        app.scrollLeft = x || 0;
-      };
-      const $window = $(window);
-      this.$app.on('scroll', () => {
-        $window.scroll();
-      });
-    }
-
-    /**
-     * Allows a selector to be passed in and Adapt will scroll to this element. Resolves
-     * asynchronously when the element has been navigated/scrolled to.
-     * Backend for Adapt.scrollTo
-     * @param {string} selector CSS selector of the Adapt element you want to navigate to e.g. `".co-05"`
-     * @param {Object} [settings={}] The settings for the `$.scrollTo` function (See https://github.com/flesler/jquery.scrollTo#settings).
-     * @param {Object} [settings.replace=false] Set to `true` if you want to update the URL without creating an entry in the browser's history.
-     */
-    async scrollTo(selector, settings = {}) {
-      Adapt.log.deprecated('Adapt.scrollTo and Adapt.scrolling.scrollTo, use Adapt.navigateToElement instead.');
-      return Adapt.router.navigateToElement(selector, settings);
-    }
-
+  initialize() {
+    this.$html = null;
+    this.$app = null;
+    this.isLegacyScrolling = true;
+    this._checkApp();
+    Adapt.once('configModel:dataLoaded', this._loadConfig.bind(this));
   }
 
-  Adapt.scrolling = new Scrolling();
+  _checkApp() {
+    this.$html = $('html');
+    this.$app = $('#app');
+    if (this.$app.length) return;
+    this.$app = $('<div id="app">');
+    $('body').append(this.$app);
+    this.$app.append($('#wrapper'));
+    Adapt.log.warn('UPDATE - Your html file needs to have #app adding. See https://github.com/adaptlearning/adapt_framework/issues/2168');
+  }
 
-  Adapt.scrollTo = Adapt.scrolling.scrollTo.bind(Adapt.scrolling);
+  _loadConfig() {
+    const config = Adapt.config.get('_scrollingContainer');
+    if (!config || !config._isEnabled) return;
+    const limitTo = config._limitToSelector;
+    const isIncluded = !limitTo || (this.$html.is(limitTo) || this.$html.hasClass(limitTo));
+    if (!isIncluded) return;
+    this.isLegacyScrolling = false;
+    this._addStyling();
+    this._fixJQuery();
+    this._fixScrollTo();
+    this._fixBrowser();
+  }
 
-  return Adapt.scrolling;
+  _addStyling() {
+    this.$html.addClass('adapt-scrolling');
+  }
 
-});
+  _fixJQuery() {
+    const selectorScrollTop = $.fn.scrollTop;
+    const $app = Adapt.scrolling.$app;
+    $.fn.scrollTop = function() {
+      if (this[0] === window || this[0] === document.body) {
+        return selectorScrollTop.apply($app, arguments);
+      }
+      return selectorScrollTop.apply(this, arguments);
+    };
+    const selectorOffset = $.fn.offset;
+    $.fn.offset = function(coordinates) {
+      if (coordinates) {
+        return selectorOffset.apply(this, arguments);
+      }
+      const $app = Adapt.scrolling.$app;
+      const $element = this;
+      const elementOffset = selectorOffset.call($element);
+      const isCorrectedContainer = $element.is('html, body, #app') ||
+        $element.parents().is('#app');
+      if (!isCorrectedContainer) {
+        // Do not adjust the offset measurement as not in $app container and isn't html or body
+        return elementOffset;
+      }
+      // Adjust measurement by scrolling and offset of $app container
+      const scrollTop = parseInt($app.scrollTop());
+      const scrollLeft = parseInt($app.scrollLeft());
+      const appOffset = selectorOffset.call($app);
+      elementOffset.top += (scrollTop - appOffset.top);
+      elementOffset.left += (scrollLeft - appOffset.left);
+      return elementOffset;
+    };
+  }
+
+  _fixScrollTo() {
+    const selectorScrollTo = $.fn.scrollTo;
+    const scrollTo = $.scrollTo;
+    const $app = Adapt.scrolling.$app;
+    $.fn.scrollTo = function(target, duration, settings) {
+      if (this[0] === window || this[0] === document.body) {
+        return selectorScrollTo.apply($app, arguments);
+      }
+      return selectorScrollTo.apply(this, arguments);
+    };
+    $.scrollTo = function(target, duration, settings) {
+      return selectorScrollTo.apply($app, arguments);
+    };
+    Object.assign($.scrollTo, scrollTo);
+  }
+
+  _fixBrowser() {
+    const app = Adapt.scrolling.$app[0];
+    window.scrollTo = function(x, y) {
+      app.scrollTop = y || 0;
+      app.scrollLeft = x || 0;
+    };
+    const $window = $(window);
+    this.$app.on('scroll', () => {
+      $window.scroll();
+    });
+  }
+
+  /**
+   * Allows a selector to be passed in and Adapt will scroll to this element. Resolves
+   * asynchronously when the element has been navigated/scrolled to.
+   * Backend for Adapt.scrollTo
+   * @param {string} selector CSS selector of the Adapt element you want to navigate to e.g. `".co-05"`
+   * @param {Object} [settings={}] The settings for the `$.scrollTo` function (See https://github.com/flesler/jquery.scrollTo#settings).
+   * @param {Object} [settings.replace=false] Set to `true` if you want to update the URL without creating an entry in the browser's history.
+   */
+  async scrollTo(selector, settings = {}) {
+    Adapt.log.deprecated('Adapt.scrollTo and Adapt.scrolling.scrollTo, use Adapt.navigateToElement instead.');
+    return Adapt.router.navigateToElement(selector, settings);
+  }
+
+}
+
+Adapt.scrolling = new Scrolling();
+
+Adapt.scrollTo = Adapt.scrolling.scrollTo.bind(Adapt.scrolling);
+
+export default Adapt.scrolling;

--- a/src/core/js/startController.js
+++ b/src/core/js/startController.js
@@ -17,7 +17,7 @@ class StartController extends Backbone.Controller {
   }
 
   returnToStartLocation() {
-    var startIds = this.model.get('_startIds');
+    const startIds = this.model.get('_startIds');
     if (startIds) {
       // ensure we can return to the start page even if it is completed
       startIds.forEach(function(startId) {
@@ -33,10 +33,10 @@ class StartController extends Backbone.Controller {
    * @return {string}
    */
   getStartHash(alwaysForce) {
-    var startId = this.getStartId();
-    var isRouteSpecified = window.location.href.indexOf('#') > -1;
-    var shouldForceStartId = alwaysForce || this.model.get('_force');
-    var shouldNavigateToStartId = startId && (!isRouteSpecified || shouldForceStartId);
+    const startId = this.getStartId();
+    const isRouteSpecified = window.location.href.indexOf('#') > -1;
+    const shouldForceStartId = alwaysForce || this.model.get('_force');
+    const shouldNavigateToStartId = startId && (!isRouteSpecified || shouldForceStartId);
 
     if (shouldNavigateToStartId && startId !== Adapt.course.get('_id')) {
       return '#/id/' + startId;
@@ -52,18 +52,18 @@ class StartController extends Backbone.Controller {
   }
 
   getStartId() {
-    var startId = this.model.get('_id');
-    var startIds = this.model.get('_startIds');
+    let startId = this.model.get('_id');
+    const startIds = this.model.get('_startIds');
 
     if (!startIds || !startIds.length) return startId;
 
-    var $html = $('html');
-    for (var i = 0, l = startIds.length; i < l; i++) {
-      var item = startIds[i];
-      var className = item._className;
-      var skipIfComplete = item._skipIfComplete;
+    const $html = $('html');
+    for (let i = 0, l = startIds.length; i < l; i++) {
+      const item = startIds[i];
+      const className = item._className;
+      const skipIfComplete = item._skipIfComplete;
 
-      var model = Adapt.findById(item._id);
+      const model = Adapt.findById(item._id);
 
       if (!model) {
         console.log('startController: cannot find id', item._id);

--- a/src/core/js/startController.js
+++ b/src/core/js/startController.js
@@ -1,103 +1,102 @@
-define([
-  'core/js/adapt'
-], function(Adapt) {
+import Adapt from 'core/js/adapt';
 
-  var StartController = Backbone.Controller.extend({
+class StartController extends Backbone.Controller {
 
-    model: null,
+  initialize(...args) {
+    super.initialize(...args);
+    this.model = null;
+  }
 
-    loadCourseData: function() {
-      this.model = new Backbone.Model(Adapt.course.get('_start'));
-    },
+  loadCourseData() {
+    this.model = new Backbone.Model(Adapt.course.get('_start'));
+  }
 
-    setStartLocation: function() {
-      if (!this.isEnabled()) return;
-      window.history.replaceState('', '', this.getStartHash());
-    },
+  setStartLocation() {
+    if (!this.isEnabled()) return;
+    window.history.replaceState('', '', this.getStartHash());
+  }
 
-    returnToStartLocation: function() {
-      var startIds = this.model.get('_startIds');
-      if (startIds) {
-        // ensure we can return to the start page even if it is completed
-        startIds.forEach(function(startId) {
-          startId._skipIfComplete = false;
-        });
-      }
-      window.location.hash = this.getStartHash(true);
-    },
+  returnToStartLocation() {
+    var startIds = this.model.get('_startIds');
+    if (startIds) {
+      // ensure we can return to the start page even if it is completed
+      startIds.forEach(function(startId) {
+        startId._skipIfComplete = false;
+      });
+    }
+    window.location.hash = this.getStartHash(true);
+  }
 
-    /**
-     * Returns a string in URL.hash format representing the route that the course should be sent to
-     * @param {boolean} [alwaysForce] Ignore any route specified in location.hash and force use of the start page instead
-     * @return {string}
-     */
-    getStartHash: function(alwaysForce) {
-      var startId = this.getStartId();
-      var isRouteSpecified = window.location.href.indexOf('#') > -1;
-      var shouldForceStartId = alwaysForce || this.model.get('_force');
-      var shouldNavigateToStartId = startId && (!isRouteSpecified || shouldForceStartId);
+  /**
+   * Returns a string in URL.hash format representing the route that the course should be sent to
+   * @param {boolean} [alwaysForce] Ignore any route specified in location.hash and force use of the start page instead
+   * @return {string}
+   */
+  getStartHash(alwaysForce) {
+    var startId = this.getStartId();
+    var isRouteSpecified = window.location.href.indexOf('#') > -1;
+    var shouldForceStartId = alwaysForce || this.model.get('_force');
+    var shouldNavigateToStartId = startId && (!isRouteSpecified || shouldForceStartId);
 
-      if (shouldNavigateToStartId && startId !== Adapt.course.get('_id')) {
-        return '#/id/' + startId;
-      }
-
-      // If there's a route specified in location.hash, use that - otherwise go to main menu
-      return window.location.hash || '#/';
-    },
-
-    isEnabled: function() {
-      if (!this.model || !this.model.get('_isEnabled')) return false;
-      return true;
-    },
-
-    getStartId: function() {
-      var startId = this.model.get('_id');
-      var startIds = this.model.get('_startIds');
-
-      if (!startIds || !startIds.length) return startId;
-
-      var $html = $('html');
-      for (var i = 0, l = startIds.length; i < l; i++) {
-        var item = startIds[i];
-        var className = item._className;
-        var skipIfComplete = item._skipIfComplete;
-
-        var model = Adapt.findById(item._id);
-
-        if (!model) {
-          console.log('startController: cannot find id', item._id);
-          continue;
-        }
-
-        if (skipIfComplete) {
-          if (model.get('_isComplete')) continue;
-        }
-
-        if (!className || $html.is(className) || $html.hasClass(className)) {
-          // See https://github.com/adaptlearning/adapt_framework/issues/1843
-          startId = item._id;
-          break;
-        }
-      }
-
-      return startId;
+    if (shouldNavigateToStartId && startId !== Adapt.course.get('_id')) {
+      return '#/id/' + startId;
     }
 
-  });
+    // If there's a route specified in location.hash, use that - otherwise go to main menu
+    return window.location.hash || '#/';
+  }
 
-  Adapt.once('adapt:start', function() {
-    Adapt.startController.loadCourseData();
-    Adapt.startController.setStartLocation();
-  });
+  isEnabled() {
+    if (!this.model || !this.model.get('_isEnabled')) return false;
+    return true;
+  }
 
-  /*
-  * allows you to call returnToStartLocation either by calling `Adapt.trigger('navigation:returnToStart')`
-  * or by including in the top navigation bar a button that has the attribute `data-event="returnToStart"`
-  */
-  Adapt.on('navigation:returnToStart', function() {
-    Adapt.startController.returnToStartLocation();
-  });
+  getStartId() {
+    var startId = this.model.get('_id');
+    var startIds = this.model.get('_startIds');
 
-  return (Adapt.startController = new StartController());
+    if (!startIds || !startIds.length) return startId;
 
+    var $html = $('html');
+    for (var i = 0, l = startIds.length; i < l; i++) {
+      var item = startIds[i];
+      var className = item._className;
+      var skipIfComplete = item._skipIfComplete;
+
+      var model = Adapt.findById(item._id);
+
+      if (!model) {
+        console.log('startController: cannot find id', item._id);
+        continue;
+      }
+
+      if (skipIfComplete) {
+        if (model.get('_isComplete')) continue;
+      }
+
+      if (!className || $html.is(className) || $html.hasClass(className)) {
+        // See https://github.com/adaptlearning/adapt_framework/issues/1843
+        startId = item._id;
+        break;
+      }
+    }
+
+    return startId;
+  }
+
+}
+
+Adapt.once('adapt:start', function() {
+  Adapt.startController.loadCourseData();
+  Adapt.startController.setStartLocation();
 });
+
+/*
+* allows you to call returnToStartLocation either by calling `Adapt.trigger('navigation:returnToStart')`
+* or by including in the top navigation bar a button that has the attribute `data-event="returnToStart"`
+*/
+Adapt.on('navigation:returnToStart', function() {
+  Adapt.startController.returnToStartLocation();
+});
+
+export default (Adapt.startController = new StartController());

--- a/src/core/js/startController.js
+++ b/src/core/js/startController.js
@@ -1,4 +1,5 @@
 import Adapt from 'core/js/adapt';
+import LockingModel from 'core/js/models/lockingModel';
 
 class StartController extends Backbone.Controller {
 
@@ -8,7 +9,7 @@ class StartController extends Backbone.Controller {
   }
 
   loadCourseData() {
-    this.model = new Backbone.Model(Adapt.course.get('_start'));
+    this.model = new LockingModel(Adapt.course.get('_start'));
   }
 
   setStartLocation() {

--- a/src/core/js/startController.js
+++ b/src/core/js/startController.js
@@ -21,9 +21,7 @@ class StartController extends Backbone.Controller {
     const startIds = this.model.get('_startIds');
     if (startIds) {
       // ensure we can return to the start page even if it is completed
-      startIds.forEach(function(startId) {
-        startId._skipIfComplete = false;
-      });
+      startIds.forEach(startId => (startId._skipIfComplete = false));
     }
     window.location.hash = this.getStartHash(true);
   }
@@ -87,7 +85,7 @@ class StartController extends Backbone.Controller {
 
 }
 
-Adapt.once('adapt:start', function() {
+Adapt.once('adapt:start', () => {
   Adapt.startController.loadCourseData();
   Adapt.startController.setStartLocation();
 });
@@ -96,7 +94,7 @@ Adapt.once('adapt:start', function() {
 * allows you to call returnToStartLocation either by calling `Adapt.trigger('navigation:returnToStart')`
 * or by including in the top navigation bar a button that has the attribute `data-event="returnToStart"`
 */
-Adapt.on('navigation:returnToStart', function() {
+Adapt.on('navigation:returnToStart', () => {
   Adapt.startController.returnToStartLocation();
 });
 

--- a/src/core/js/templateRenderEvent.js
+++ b/src/core/js/templateRenderEvent.js
@@ -1,30 +1,24 @@
-define(function() {
+export default class TemplateRenderEvent extends Backbone.Controller {
 
-  class TemplateRenderEvent extends Backbone.Controller {
-
-    /**
-     * Template render event
-     * @param {string} type Event type
-     * @param {string} name Template name
-     * @param {string} mode "template" / "partial"
-     * @param {string} value Rendered template string
-     * @param {[*]} args Arguments passed to template for render
-     */
-    initialize(type, name, mode, value, args) {
-      /** @type {string} Event type */
-      this.type = type;
-      /** @type {string} Template name */
-      this.name = name;
-      /** @type {string} "template" / "partial" */
-      this.mode = mode;
-      /** @type {string} Rendered template string */
-      this.value = value;
-      /** @type {[*]} Arguments passed to template for render */
-      this.args = args;
-    }
-
+  /**
+   * Template render event
+   * @param {string} type Event type
+   * @param {string} name Template name
+   * @param {string} mode "template" / "partial"
+   * @param {string} value Rendered template string
+   * @param {[*]} args Arguments passed to template for render
+   */
+  initialize(type, name, mode, value, args) {
+    /** @type {string} Event type */
+    this.type = type;
+    /** @type {string} Template name */
+    this.name = name;
+    /** @type {string} "template" / "partial" */
+    this.mode = mode;
+    /** @type {string} Rendered template string */
+    this.value = value;
+    /** @type {[*]} Arguments passed to template for render */
+    this.args = args;
   }
 
-  return TemplateRenderEvent;
-
-});
+}

--- a/src/core/js/templates.js
+++ b/src/core/js/templates.js
@@ -1,39 +1,34 @@
-define([
-  'core/js/adapt',
-  'handlebars',
-  './templateRenderEvent'
-], function(Adapt, Handlebars, TemplateRenderEvent) {
+import Adapt from 'core/js/adapt';
+import TemplateRenderEvent from 'core/js/templateRenderEvent';
 
-  /**
-   * Adds template and partial, preRender and postRender events to Adapt
-   */
+/**
+ * Adds template and partial, preRender and postRender events to Adapt
+ */
 
-  function onRender(cb) {
-    const intercept = (object, name, mode, cb) => {
-      return (object[name] = cb.bind(object, object[name], name, mode));
-    };
-    Object.keys(Handlebars.templates).forEach(name => {
-      intercept(Handlebars.templates, name, 'template', cb);
-    });
-    Object.keys(Handlebars.partials).forEach(name => {
-      intercept(Handlebars.partials, name, 'partial', cb);
-    });
-  }
-
-  onRender((template, name, mode, ...args) => {
-    // Send preRender event to allow modification of args
-    const preRenderEvent = new TemplateRenderEvent(`${mode}:preRender`, name, mode, null, args);
-    Adapt.trigger(preRenderEvent.type, preRenderEvent);
-
-    // Execute template
-    const value = template(...preRenderEvent.args);
-
-    // Send postRender event to allow modification of rendered template
-    const postRenderEvent = new TemplateRenderEvent(`${mode}:postRender`, name, mode, value, preRenderEvent.args);
-    Adapt.trigger(postRenderEvent.type, postRenderEvent);
-
-    // Return rendered, modified template
-    return postRenderEvent.value;
+function onRender(cb) {
+  const intercept = (object, name, mode, cb) => {
+    return (object[name] = cb.bind(object, object[name], name, mode));
+  };
+  Object.keys(Handlebars.templates).forEach(name => {
+    intercept(Handlebars.templates, name, 'template', cb);
   });
+  Object.keys(Handlebars.partials).forEach(name => {
+    intercept(Handlebars.partials, name, 'partial', cb);
+  });
+}
 
+onRender((template, name, mode, ...args) => {
+  // Send preRender event to allow modification of args
+  const preRenderEvent = new TemplateRenderEvent(`${mode}:preRender`, name, mode, null, args);
+  Adapt.trigger(preRenderEvent.type, preRenderEvent);
+
+  // Execute template
+  const value = template(...preRenderEvent.args);
+
+  // Send postRender event to allow modification of rendered template
+  const postRenderEvent = new TemplateRenderEvent(`${mode}:postRender`, name, mode, value, preRenderEvent.args);
+  Adapt.trigger(postRenderEvent.type, postRenderEvent);
+
+  // Return rendered, modified template
+  return postRenderEvent.value;
 });

--- a/src/core/js/tracking.js
+++ b/src/core/js/tracking.js
@@ -1,118 +1,113 @@
-define([
-  'core/js/adapt',
-  'core/js/enums/completionStateEnum'
-], function(Adapt, COMPLETION_STATE) {
+import Adapt from 'core/js/adapt';
+import COMPLETION_STATE from 'core/js/enums/completionStateEnum';
 
-  var Tracking = Backbone.Controller.extend({
+class Tracking extends Backbone.Controller {
 
-    _config: {
+  initialize() {
+    this._config = {
       _requireContentCompleted: true,
       _requireAssessmentCompleted: false
-    },
+    };
+    this._assessmentState = null;
 
-    _assessmentState: null,
+    Adapt.once('configModel:dataLoaded', this.loadConfig.bind(this));
+    Adapt.on('app:dataReady', this.setupEventListeners.bind(this));
+  }
 
-    initialize: function() {
-      Adapt.once('configModel:dataLoaded', this.loadConfig.bind(this));
-      Adapt.on('app:dataReady', this.setupEventListeners.bind(this));
-    },
-
-    setupEventListeners: function() {
-      // Check if completion requires passing an assessment.
-      if (this._config._requireAssessmentCompleted) {
-        this.listenTo(Adapt, {
-          'assessment:complete': this.onAssessmentComplete,
-          'assessment:restored': this.onAssessmentRestored
-        });
-      }
-
-      // Check if completion requires completing all content.
-      if (this._config._requireContentCompleted) {
-        this.listenTo(Adapt.course, 'change:_isComplete', this.checkCompletion);
-      }
-    },
-
-    /**
-     * Store the assessment state.
-     * @param {object} assessmentState - The object returned by Adapt.assessment.getState()
-     */
-    onAssessmentComplete: function(assessmentState) {
-      this._assessmentState = assessmentState;
-
-      this.checkCompletion();
-    },
-
-    /**
-     * Restores the _assessmentState object when an assessment is registered.
-     * @param {object} assessmentState - An object representing the overall assessment state
-     */
-    onAssessmentRestored: function(assessmentState) {
-      this._assessmentState = assessmentState;
-    },
-
-    /**
-     * Evaluate the course and assessment completion.
-     */
-    checkCompletion: function() {
-      var completionData = this.getCompletionData();
-
-      if (completionData.status === COMPLETION_STATE.INCOMPLETE) {
-        return;
-      }
-
-      Adapt.trigger('tracking:complete', completionData);
-      Adapt.log.debug('tracking:complete', completionData);
-    },
-
-    /**
-     * The return value of this function should be passed to the trigger of 'tracking:complete'.
-     * @returns An object representing the user's course completion.
-     */
-    getCompletionData: function() {
-      var completionData = {
-        status: COMPLETION_STATE.INCOMPLETE,
-        assessment: null
-      };
-
-      // Course complete is required.
-      if (this._config._requireContentCompleted && !Adapt.course.get('_isComplete')) {
-        // INCOMPLETE: course not complete.
-        return completionData;
-      }
-
-      // Assessment completed required.
-      if (this._config._requireAssessmentCompleted) {
-        if (!this._assessmentState) {
-          // INCOMPLETE: assessment is not complete.
-          return completionData;
-        }
-
-        // PASSED/FAILED: assessment completed.
-        completionData.status = this._assessmentState.isPass ? COMPLETION_STATE.PASSED : COMPLETION_STATE.FAILED;
-        completionData.assessment = this._assessmentState;
-
-        return completionData;
-      }
-
-      // COMPLETED: criteria met, no assessment requirements.
-      completionData.status = COMPLETION_STATE.COMPLETED;
-
-      return completionData;
-    },
-
-    /**
-     * Set the _config object to the values retrieved from config.json.
-     */
-    loadConfig: function() {
-      if (Adapt.config.has('_completionCriteria')) {
-        this._config = Adapt.config.get('_completionCriteria');
-      }
+  setupEventListeners() {
+    // Check if completion requires passing an assessment.
+    if (this._config._requireAssessmentCompleted) {
+      this.listenTo(Adapt, {
+        'assessment:complete': this.onAssessmentComplete,
+        'assessment:restored': this.onAssessmentRestored
+      });
     }
 
-  });
+    // Check if completion requires completing all content.
+    if (this._config._requireContentCompleted) {
+      this.listenTo(Adapt.course, 'change:_isComplete', this.checkCompletion);
+    }
+  }
 
-  Adapt.tracking = new Tracking();
+  /**
+   * Store the assessment state.
+   * @param {object} assessmentState - The object returned by Adapt.assessment.getState()
+   */
+  onAssessmentComplete(assessmentState) {
+    this._assessmentState = assessmentState;
 
-  return Adapt.tracking;
+    this.checkCompletion();
+  }
 
-});
+  /**
+   * Restores the _assessmentState object when an assessment is registered.
+   * @param {object} assessmentState - An object representing the overall assessment state
+   */
+  onAssessmentRestored(assessmentState) {
+    this._assessmentState = assessmentState;
+  }
+
+  /**
+   * Evaluate the course and assessment completion.
+   */
+  checkCompletion() {
+    var completionData = this.getCompletionData();
+
+    if (completionData.status === COMPLETION_STATE.INCOMPLETE) {
+      return;
+    }
+
+    Adapt.trigger('tracking:complete', completionData);
+    Adapt.log.debug('tracking:complete', completionData);
+  }
+
+  /**
+   * The return value of this function should be passed to the trigger of 'tracking:complete'.
+   * @returns An object representing the user's course completion.
+   */
+  getCompletionData() {
+    var completionData = {
+      status: COMPLETION_STATE.INCOMPLETE,
+      assessment: null
+    };
+
+    // Course complete is required.
+    if (this._config._requireContentCompleted && !Adapt.course.get('_isComplete')) {
+      // INCOMPLETE: course not complete.
+      return completionData;
+    }
+
+    // Assessment completed required.
+    if (this._config._requireAssessmentCompleted) {
+      if (!this._assessmentState) {
+        // INCOMPLETE: assessment is not complete.
+        return completionData;
+      }
+
+      // PASSED/FAILED: assessment completed.
+      completionData.status = this._assessmentState.isPass ? COMPLETION_STATE.PASSED : COMPLETION_STATE.FAILED;
+      completionData.assessment = this._assessmentState;
+
+      return completionData;
+    }
+
+    // COMPLETED: criteria met, no assessment requirements.
+    completionData.status = COMPLETION_STATE.COMPLETED;
+
+    return completionData;
+  }
+
+  /**
+   * Set the _config object to the values retrieved from config.json.
+   */
+  loadConfig() {
+    if (Adapt.config.has('_completionCriteria')) {
+      this._config = Adapt.config.get('_completionCriteria');
+    }
+  }
+
+}
+
+Adapt.tracking = new Tracking();
+
+export default Adapt.tracking;

--- a/src/core/js/tracking.js
+++ b/src/core/js/tracking.js
@@ -51,7 +51,7 @@ class Tracking extends Backbone.Controller {
    * Evaluate the course and assessment completion.
    */
   checkCompletion() {
-    var completionData = this.getCompletionData();
+    const completionData = this.getCompletionData();
 
     if (completionData.status === COMPLETION_STATE.INCOMPLETE) {
       return;
@@ -66,7 +66,7 @@ class Tracking extends Backbone.Controller {
    * @returns An object representing the user's course completion.
    */
   getCompletionData() {
-    var completionData = {
+    const completionData = {
       status: COMPLETION_STATE.INCOMPLETE,
       assessment: null
     };

--- a/src/core/js/views/adaptView.js
+++ b/src/core/js/views/adaptView.js
@@ -1,355 +1,351 @@
-define([
-  'core/js/adapt',
-  '../childEvent'
-], function(Adapt, ChildEvent) {
+import Adapt from 'core/js/adapt';
+import ChildEvent from 'core/js/childEvent';
 
-  class AdaptView extends Backbone.View {
+class AdaptView extends Backbone.View {
 
-    attributes() {
-      return {
-        'data-adapt-id': this.model.get('_id')
-      };
+  attributes() {
+    return {
+      'data-adapt-id': this.model.get('_id')
+    };
+  }
+
+  initialize() {
+    this.listenTo(this.model, {
+      'change:_isVisible': this.toggleVisibility,
+      'change:_isHidden': this.toggleHidden,
+      'change:_isComplete': this.onIsCompleteChange
+    });
+    this.model.set({
+      '_globals': Adapt.course.get('_globals'),
+      '_isReady': false
+    });
+    this._isRemoved = false;
+
+    if (Adapt.location._currentId === this.model.get('_id')) {
+      Adapt.parentView = this;
     }
 
-    initialize() {
-      this.listenTo(this.model, {
-        'change:_isVisible': this.toggleVisibility,
-        'change:_isHidden': this.toggleHidden,
-        'change:_isComplete': this.onIsCompleteChange
-      });
-      this.model.set({
-        '_globals': Adapt.course.get('_globals'),
-        '_isReady': false
-      });
-      this._isRemoved = false;
+    this.preRender();
+    this.render();
+    this.setupOnScreenHandler();
+  }
 
-      if (Adapt.location._currentId === this.model.get('_id')) {
-        Adapt.parentView = this;
+  preRender() {}
+
+  postRender() {
+    this.addChildren();
+  }
+
+  render() {
+    const type = this.constructor.type;
+    Adapt.trigger(`${type}View:preRender view:preRender`, this);
+
+    const data = this.model.toJSON();
+    data.view = this;
+    const template = Handlebars.templates[this.constructor.template];
+    this.$el.html(template(data));
+
+    Adapt.trigger(`${type}View:render view:render`, this);
+
+    _.defer(() => {
+      // don't call postRender after remove
+      if (this._isRemoved) return;
+
+      this.postRender();
+      Adapt.trigger(`${type}View:postRender view:postRender`, this);
+    });
+
+    return this;
+  }
+
+  setupOnScreenHandler() {
+    const onscreen = this.model.get('_onScreen');
+
+    if (!onscreen || !onscreen._isEnabled) return;
+
+    this.$el.addClass(`has-animation ${onscreen._classes}-before`);
+    this.$el.on('onscreen.adaptView', (e, m) => {
+      if (!m.onscreen) return;
+      const minVerticalInview = onscreen._percentInviewVertical || 33;
+      if (m.percentInviewVertical < minVerticalInview) return;
+      this.$el.addClass(`${onscreen._classes}-after`).off('onscreen.adaptView');
+    });
+  }
+
+  /**
+   * Add children and descendant views, first-child-first. Wait until all possible
+   * views are added before resolving asynchronously.
+   * Will trigger 'view:addChild'(ChildEvent), 'view:requestChild'(ChildEvent)
+   * and 'view:childAdded'(ParentView, ChildView) accordingly.
+   * @returns {number} Count of views added
+   */
+  async addChildren() {
+    this.nthChild = this.nthChild || 0;
+    // Check descendants first
+    let addedCount = await this.addDescendants(false);
+    // Iterate through existing available children and/or request new children
+    // if required and allowed
+    while (true) {
+      const models = this.model.getAvailableChildModels();
+      const event = this._getAddChildEvent(models[this.nthChild]);
+      if (!event) {
+        break;
       }
-
-      this.preRender();
-      this.render();
-      this.setupOnScreenHandler();
-    }
-
-    preRender() {}
-
-    postRender() {
-      this.addChildren();
-    }
-
-    render() {
-      const type = this.constructor.type;
-      Adapt.trigger(`${type}View:preRender view:preRender`, this);
-
-      const data = this.model.toJSON();
-      data.view = this;
-      const template = Handlebars.templates[this.constructor.template];
-      this.$el.html(template(data));
-
-      Adapt.trigger(`${type}View:render view:render`, this);
-
-      _.defer(() => {
-        // don't call postRender after remove
-        if (this._isRemoved) return;
-
-        this.postRender();
-        Adapt.trigger(`${type}View:postRender view:postRender`, this);
-      });
-
-      return this;
-    }
-
-    setupOnScreenHandler() {
-      const onscreen = this.model.get('_onScreen');
-
-      if (!onscreen || !onscreen._isEnabled) return;
-
-      this.$el.addClass(`has-animation ${onscreen._classes}-before`);
-      this.$el.on('onscreen.adaptView', (e, m) => {
-        if (!m.onscreen) return;
-        const minVerticalInview = onscreen._percentInviewVertical || 33;
-        if (m.percentInviewVertical < minVerticalInview) return;
-        this.$el.addClass(`${onscreen._classes}-after`).off('onscreen.adaptView');
-      });
-    }
-
-    /**
-     * Add children and descendant views, first-child-first. Wait until all possible
-     * views are added before resolving asynchronously.
-     * Will trigger 'view:addChild'(ChildEvent), 'view:requestChild'(ChildEvent)
-     * and 'view:childAdded'(ParentView, ChildView) accordingly.
-     * @returns {number} Count of views added
-     */
-    async addChildren() {
-      this.nthChild = this.nthChild || 0;
-      // Check descendants first
-      let addedCount = await this.addDescendants(false);
-      // Iterate through existing available children and/or request new children
-      // if required and allowed
-      while (true) {
-        const models = this.model.getAvailableChildModels();
-        const event = this._getAddChildEvent(models[this.nthChild]);
-        if (!event) {
-          break;
-        }
-        if (event.isForced) {
-          event.reset();
-        }
-        if (event.isStoppedImmediate || !event.model) {
-          // If addChild has been stopped before it is added then
-          // set all subsequent models and their children as not rendered
-          const subsequentModels = models.slice(this.nthChild);
-          subsequentModels.forEach(model => model.setOnChildren('_isRendered', false));
-          break;
-        }
-        // Set model state
-        const model = event.model;
-        model.set({
-          '_isRendered': true,
-          '_nthChild': ++this.nthChild
-        });
-        // Create child view
-        const ChildView = this.constructor.childView || Adapt.getViewClass(model);
-        if (!ChildView) {
-          throw new Error(`The component '${model.attributes._id}' ('${model.attributes._component}') has not been installed, and so is not available in your project.`);
-        }
-        const childView = new ChildView({ model });
-        this.addChildView(childView);
-        addedCount++;
-        if (event.isStoppedNext) {
-          break;
-        }
+      if (event.isForced) {
+        event.reset();
       }
-
-      if (!addedCount) {
-        return addedCount;
+      if (event.isStoppedImmediate || !event.model) {
+        // If addChild has been stopped before it is added then
+        // set all subsequent models and their children as not rendered
+        const subsequentModels = models.slice(this.nthChild);
+        subsequentModels.forEach(model => model.setOnChildren('_isRendered', false));
+        break;
       }
+      // Set model state
+      const model = event.model;
+      model.set({
+        '_isRendered': true,
+        '_nthChild': ++this.nthChild
+      });
+      // Create child view
+      const ChildView = this.constructor.childView || Adapt.getViewClass(model);
+      if (!ChildView) {
+        throw new Error(`The component '${model.attributes._id}' ('${model.attributes._component}') has not been installed, and so is not available in your project.`);
+      }
+      const childView = new ChildView({ model });
+      this.addChildView(childView);
+      addedCount++;
+      if (event.isStoppedNext) {
+        break;
+      }
+    }
 
-      // Children were added, unset _isReady
-      this.model.set('_isReady', false);
+    if (!addedCount) {
       return addedCount;
     }
 
-    /**
-     * Child views can be added with '_renderPosition': 'outer-append' or
-     * 'inner-append' (default). Each child view will trigger a
-     * 'view:childAdded'(ParentView, ChildView) event and be added to the
-     * this.getChildViews() array on this parent.
-     * @param {AdaptView} childView
-     * @returns {AdaptView} Returns this childView
-     */
-    addChildView(childView) {
-      const childViews = this.getChildViews() || [];
-      childViews.push(childView);
-      this.setChildViews(childViews);
-      const $parentContainer = this.$(this.constructor.childContainer);
-      switch (childView.model.get('_renderPosition')) {
-        case 'outer-append':
-          // Useful for trickle buttons, inline feedback etc
-          this.$el.append(childView.$el);
-          break;
-        case 'inner-append':
-        default:
-          $parentContainer.append(childView.$el);
-          break;
-      }
-      // Signify that a child has been added to the view to enable updates to status bars
-      Adapt.trigger('view:childAdded', this, childView);
-      return childView;
-    }
-
-    /**
-     * Iterates through existing childViews and runs addChildren on them, resolving
-     * the total count of views added asynchronously.
-     * @returns {number} Count of views added
-     */
-    async addDescendants() {
-      let addedDescendantCount = 0;
-      const childViews = this.getChildViews();
-      if (!childViews) {
-        return addedDescendantCount;
-      }
-      for (let i = 0, l = childViews.length; i < l; i++) {
-        const view = childViews[i];
-        addedDescendantCount = view.addChildren ? await view.addChildren() : 0;
-        if (addedDescendantCount) {
-          break;
-        }
-      }
-      if (!addedDescendantCount) {
-        this.model.checkReadyStatus();
-        return addedDescendantCount;
-      }
-      // Descendants were added, unset _isReady
-      this.model.set('_isReady', false);
-      return addedDescendantCount;
-    }
-
-    /**
-     * Resolves after outstanding asynchronous view additions are finished
-     * and ready.
-     */
-    async whenReady() {
-      if (this.model.get('_isReady')) return;
-      return new Promise(resolve => {
-        const onReadyChange = (model, value) => {
-          if (!value) return;
-          this.stopListening(this.model, 'change:_isReady', onReadyChange);
-          resolve();
-        };
-        this.listenTo(this.model, 'change:_isReady', onReadyChange);
-        this.model.checkReadyStatus();
-      });
-    }
-
-    /**
-     * Triggers and returns a new ChildEvent object for render control.
-     * This function is used by addChildren to manage event triggering.
-     * @param {AdaptModel} model
-     * @returns {ChildEvent}
-     */
-    _getAddChildEvent(model) {
-      const isRequestChild = (!model);
-      let event = new ChildEvent(null, this, model);
-      if (isRequestChild) {
-        // No model has been supplied, we are at the end of the available child list
-        const canRequestChild = this.model.get('_canRequestChild');
-        if (!canRequestChild) {
-          // This model cannot request children
-          return;
-        }
-        event.type = 'requestChild';
-        // Send a request asking for a new model
-        Adapt.trigger('view:requestChild', event);
-        if (!event.hasRequestChild) {
-          // No new model was supplied
-          // Close the event so that the final state can be scrutinized
-          event.close();
-          return;
-        }
-        // A new model has been supplied for the end of the list.
-      }
-      // Trigger an event to signify that a new model is to be added
-      event.type = 'addChild';
-      Adapt.trigger('view:addChild', event);
-      // Close the event so that the final state can be scrutinized
-      event.close();
-      return event;
-    }
-
-    /**
-     * Return an array of all child and descendant views.
-     * @param {boolean} [isParentFirst=false] Array returns with parents before children
-     * @returns {[AdaptView]}
-     */
-    findDescendantViews(isParentFirst) {
-      const descendants = [];
-      const childViews = this.getChildViews();
-      childViews && childViews.forEach(view => {
-        if (isParentFirst) descendants.push(view);
-        const children = view.findDescendantViews && view.findDescendantViews(isParentFirst);
-        if (children) descendants.push(...children);
-        if (!isParentFirst) descendants.push(view);
-      });
-      return descendants;
-    }
-
-    setReadyStatus() {
-      this.model.set('_isReady', true);
-    }
-
-    setCompletionStatus() {
-      if (!this.model.get('_isVisible')) return;
-      this.model.set({
-        _isComplete: true,
-        _isInteractionComplete: true
-      });
-    }
-
-    resetCompletionStatus(type) {
-      if (!this.model.get('_canReset')) return;
-
-      const descendantComponents = this.model.findDescendantModels('component');
-      if (descendantComponents.length === 0) {
-        this.model.reset(type);
-      } else {
-        descendantComponents.forEach(model => model.reset(type));
-      }
-    }
-
-    preRemove() {
-      const type = this.constructor.type;
-      Adapt.trigger(`${type}View:preRemove view:preRemove`, this);
-    }
-
-    remove() {
-      const type = this.constructor.type;
-      this.preRemove();
-      Adapt.trigger(`${type}View:remove view:remove`, this);
-      this._isRemoved = true;
-      this.stopListening();
-
-      Adapt.wait.for(end => {
-        this.$el.off('onscreen.adaptView');
-        super.remove();
-        _.defer(() => {
-          Adapt.trigger(`${type}View:postRemove view:postRemove`, this);
-        });
-        end();
-      });
-
-      return this;
-    }
-
-    setVisibility() {
-      return this.model.get('_isVisible') ? '' : 'u-visibility-hidden';
-    }
-
-    toggleVisibility() {
-      this.$el.toggleClass('u-visibility-hidden', !this.model.get('_isVisible'));
-    }
-
-    setHidden() {
-      return this.model.get('_isHidden') ? 'u-display-none' : '';
-    }
-
-    toggleHidden() {
-      this.$el.toggleClass('u-display-none', this.model.get('_isHidden'));
-    }
-
-    onIsCompleteChange(model, isComplete) {
-      this.$el.toggleClass('is-complete', isComplete);
-    }
-
-    /**
-     * @returns {[AdaptViews]}
-     */
-    getChildViews() {
-      return this._childViews;
-    }
-
-    /**
-     * @param {[AdaptView]} value
-     */
-    setChildViews(value) {
-      this._childViews = value;
-    }
-
-    /**
-     * Returns an indexed by id list of child views.
-     * @deprecated since 0.5.5
-     * @returns {{<string, AdaptView}}
-     */
-    get childViews() {
-      Adapt.log.deprecated(`view.childViews use view.getChildViews()`);
-      return _.indexBy(this.getChildViews(), view => view.model.get('_id'));
-    }
-
+    // Children were added, unset _isReady
+    this.model.set('_isReady', false);
+    return addedCount;
   }
 
-  AdaptView.className = '';
+  /**
+   * Child views can be added with '_renderPosition': 'outer-append' or
+   * 'inner-append' (default). Each child view will trigger a
+   * 'view:childAdded'(ParentView, ChildView) event and be added to the
+   * this.getChildViews() array on this parent.
+   * @param {AdaptView} childView
+   * @returns {AdaptView} Returns this childView
+   */
+  addChildView(childView) {
+    const childViews = this.getChildViews() || [];
+    childViews.push(childView);
+    this.setChildViews(childViews);
+    const $parentContainer = this.$(this.constructor.childContainer);
+    switch (childView.model.get('_renderPosition')) {
+      case 'outer-append':
+        // Useful for trickle buttons, inline feedback etc
+        this.$el.append(childView.$el);
+        break;
+      case 'inner-append':
+      default:
+        $parentContainer.append(childView.$el);
+        break;
+    }
+    // Signify that a child has been added to the view to enable updates to status bars
+    Adapt.trigger('view:childAdded', this, childView);
+    return childView;
+  }
 
-  return AdaptView;
+  /**
+   * Iterates through existing childViews and runs addChildren on them, resolving
+   * the total count of views added asynchronously.
+   * @returns {number} Count of views added
+   */
+  async addDescendants() {
+    let addedDescendantCount = 0;
+    const childViews = this.getChildViews();
+    if (!childViews) {
+      return addedDescendantCount;
+    }
+    for (let i = 0, l = childViews.length; i < l; i++) {
+      const view = childViews[i];
+      addedDescendantCount = view.addChildren ? await view.addChildren() : 0;
+      if (addedDescendantCount) {
+        break;
+      }
+    }
+    if (!addedDescendantCount) {
+      this.model.checkReadyStatus();
+      return addedDescendantCount;
+    }
+    // Descendants were added, unset _isReady
+    this.model.set('_isReady', false);
+    return addedDescendantCount;
+  }
 
-});
+  /**
+   * Resolves after outstanding asynchronous view additions are finished
+   * and ready.
+   */
+  async whenReady() {
+    if (this.model.get('_isReady')) return;
+    return new Promise(resolve => {
+      const onReadyChange = (model, value) => {
+        if (!value) return;
+        this.stopListening(this.model, 'change:_isReady', onReadyChange);
+        resolve();
+      };
+      this.listenTo(this.model, 'change:_isReady', onReadyChange);
+      this.model.checkReadyStatus();
+    });
+  }
+
+  /**
+   * Triggers and returns a new ChildEvent object for render control.
+   * This function is used by addChildren to manage event triggering.
+   * @param {AdaptModel} model
+   * @returns {ChildEvent}
+   */
+  _getAddChildEvent(model) {
+    const isRequestChild = (!model);
+    let event = new ChildEvent(null, this, model);
+    if (isRequestChild) {
+      // No model has been supplied, we are at the end of the available child list
+      const canRequestChild = this.model.get('_canRequestChild');
+      if (!canRequestChild) {
+        // This model cannot request children
+        return;
+      }
+      event.type = 'requestChild';
+      // Send a request asking for a new model
+      Adapt.trigger('view:requestChild', event);
+      if (!event.hasRequestChild) {
+        // No new model was supplied
+        // Close the event so that the final state can be scrutinized
+        event.close();
+        return;
+      }
+      // A new model has been supplied for the end of the list.
+    }
+    // Trigger an event to signify that a new model is to be added
+    event.type = 'addChild';
+    Adapt.trigger('view:addChild', event);
+    // Close the event so that the final state can be scrutinized
+    event.close();
+    return event;
+  }
+
+  /**
+   * Return an array of all child and descendant views.
+   * @param {boolean} [isParentFirst=false] Array returns with parents before children
+   * @returns {[AdaptView]}
+   */
+  findDescendantViews(isParentFirst) {
+    const descendants = [];
+    const childViews = this.getChildViews();
+    childViews && childViews.forEach(view => {
+      if (isParentFirst) descendants.push(view);
+      const children = view.findDescendantViews && view.findDescendantViews(isParentFirst);
+      if (children) descendants.push(...children);
+      if (!isParentFirst) descendants.push(view);
+    });
+    return descendants;
+  }
+
+  setReadyStatus() {
+    this.model.set('_isReady', true);
+  }
+
+  setCompletionStatus() {
+    if (!this.model.get('_isVisible')) return;
+    this.model.set({
+      _isComplete: true,
+      _isInteractionComplete: true
+    });
+  }
+
+  resetCompletionStatus(type) {
+    if (!this.model.get('_canReset')) return;
+
+    const descendantComponents = this.model.findDescendantModels('component');
+    if (descendantComponents.length === 0) {
+      this.model.reset(type);
+    } else {
+      descendantComponents.forEach(model => model.reset(type));
+    }
+  }
+
+  preRemove() {
+    const type = this.constructor.type;
+    Adapt.trigger(`${type}View:preRemove view:preRemove`, this);
+  }
+
+  remove() {
+    const type = this.constructor.type;
+    this.preRemove();
+    Adapt.trigger(`${type}View:remove view:remove`, this);
+    this._isRemoved = true;
+    this.stopListening();
+
+    Adapt.wait.for(end => {
+      this.$el.off('onscreen.adaptView');
+      super.remove();
+      _.defer(() => {
+        Adapt.trigger(`${type}View:postRemove view:postRemove`, this);
+      });
+      end();
+    });
+
+    return this;
+  }
+
+  setVisibility() {
+    return this.model.get('_isVisible') ? '' : 'u-visibility-hidden';
+  }
+
+  toggleVisibility() {
+    this.$el.toggleClass('u-visibility-hidden', !this.model.get('_isVisible'));
+  }
+
+  setHidden() {
+    return this.model.get('_isHidden') ? 'u-display-none' : '';
+  }
+
+  toggleHidden() {
+    this.$el.toggleClass('u-display-none', this.model.get('_isHidden'));
+  }
+
+  onIsCompleteChange(model, isComplete) {
+    this.$el.toggleClass('is-complete', isComplete);
+  }
+
+  /**
+   * @returns {[AdaptViews]}
+   */
+  getChildViews() {
+    return this._childViews;
+  }
+
+  /**
+   * @param {[AdaptView]} value
+   */
+  setChildViews(value) {
+    this._childViews = value;
+  }
+
+  /**
+   * Returns an indexed by id list of child views.
+   * @deprecated since 0.5.5
+   * @returns {{<string, AdaptView}}
+   */
+  get childViews() {
+    Adapt.log.deprecated(`view.childViews use view.getChildViews()`);
+    return _.indexBy(this.getChildViews(), view => view.model.get('_id'));
+  }
+
+}
+
+AdaptView.className = '';
+
+export default AdaptView;

--- a/src/core/js/views/articleView.js
+++ b/src/core/js/views/articleView.js
@@ -1,32 +1,28 @@
-define([
-  'core/js/adapt',
-  'core/js/views/adaptView'
-], function(Adapt, AdaptView) {
+import Adapt from 'core/js/adapt';
+import AdaptView from 'core/js/views/adaptView';
 
-  class ArticleView extends AdaptView {
+class ArticleView extends AdaptView {
 
-    className() {
-      return [
-        'article',
-        this.model.get('_id'),
-        this.model.get('_classes'),
-        this.setVisibility(),
-        this.setHidden(),
-        (this.model.get('_isComplete') ? 'is-complete' : ''),
-        (this.model.get('_isOptional') ? 'is-optional' : '')
-      ].join(' ');
-    }
-
+  className() {
+    return [
+      'article',
+      this.model.get('_id'),
+      this.model.get('_classes'),
+      this.setVisibility(),
+      this.setHidden(),
+      (this.model.get('_isComplete') ? 'is-complete' : ''),
+      (this.model.get('_isOptional') ? 'is-optional' : '')
+    ].join(' ');
   }
 
-  Object.assign(ArticleView, {
-    childContainer: '.block__container',
-    type: 'article',
-    template: 'article'
-  });
+}
 
-  Adapt.register('article', { view: ArticleView });
-
-  return ArticleView;
-
+Object.assign(ArticleView, {
+  childContainer: '.block__container',
+  type: 'article',
+  template: 'article'
 });
+
+Adapt.register('article', { view: ArticleView });
+
+export default ArticleView;

--- a/src/core/js/views/blockView.js
+++ b/src/core/js/views/blockView.js
@@ -1,32 +1,28 @@
-define([
-  'core/js/adapt',
-  'core/js/views/adaptView'
-], function(Adapt, AdaptView) {
+import Adapt from 'core/js/adapt';
+import AdaptView from 'core/js/views/adaptView';
 
-  class BlockView extends AdaptView {
+class BlockView extends AdaptView {
 
-    className() {
-      return [
-        'block',
-        this.model.get('_id'),
-        this.model.get('_classes'),
-        this.setVisibility(),
-        this.setHidden(),
-        (this.model.get('_isComplete') ? 'is-complete' : ''),
-        (this.model.get('_isOptional') ? 'is-optional' : '')
-      ].join(' ');
-    }
-
+  className() {
+    return [
+      'block',
+      this.model.get('_id'),
+      this.model.get('_classes'),
+      this.setVisibility(),
+      this.setHidden(),
+      (this.model.get('_isComplete') ? 'is-complete' : ''),
+      (this.model.get('_isOptional') ? 'is-optional' : '')
+    ].join(' ');
   }
 
-  Object.assign(BlockView, {
-    childContainer: '.component__container',
-    type: 'block',
-    template: 'block'
-  });
+}
 
-  Adapt.register('block', { view: BlockView });
-
-  return BlockView;
-
+Object.assign(BlockView, {
+  childContainer: '.component__container',
+  type: 'block',
+  template: 'block'
 });
+
+Adapt.register('block', { view: BlockView });
+
+export default BlockView;

--- a/src/core/js/views/buttonsView.js
+++ b/src/core/js/views/buttonsView.js
@@ -34,8 +34,8 @@ export default class ButtonsView extends Backbone.View {
   }
 
   render() {
-    var data = this.model.toJSON();
-    var template = Handlebars.templates['buttons'];
+    const data = this.model.toJSON();
+    const template = Handlebars.templates['buttons'];
     _.defer(_.bind(function() {
       this.postRender();
       Adapt.trigger('buttonsView:postRender', this);
@@ -48,7 +48,7 @@ export default class ButtonsView extends Backbone.View {
   }
 
   checkResetSubmittedState() {
-    var isSubmitted = this.model.get('_isSubmitted');
+    const isSubmitted = this.model.get('_isSubmitted');
 
     if (!isSubmitted) {
       this.$('.js-btn-marking').removeClass('is-incorrect is-correct').addClass('u-display-none');
@@ -61,7 +61,7 @@ export default class ButtonsView extends Backbone.View {
   }
 
   onActionClicked() {
-    var buttonState = this.model.get('_buttonState');
+    const buttonState = this.model.get('_buttonState');
     this.trigger('buttons:stateUpdate', BUTTON_STATE(buttonState));
     this.checkResetSubmittedState();
   }
@@ -89,8 +89,8 @@ export default class ButtonsView extends Backbone.View {
     this.updateAttemptsCount();
 
     // Use 'correct' instead of 'complete' to signify button state
-    var $buttonsAction = this.$('.js-btn-action');
-    var buttonState = BUTTON_STATE(changedAttribute);
+    const $buttonsAction = this.$('.js-btn-action');
+    const buttonState = BUTTON_STATE(changedAttribute);
     if (changedAttribute === BUTTON_STATE.CORRECT || changedAttribute === BUTTON_STATE.INCORRECT) {
       // Both 'correct' and 'incorrect' states have no model answer, so disable the submit button
 
@@ -98,9 +98,9 @@ export default class ButtonsView extends Backbone.View {
 
     } else {
 
-      var propertyName = textPropertyName[buttonState.asString];
-      var ariaLabel = this.model.get('_buttons')['_' + propertyName].ariaLabel;
-      var buttonText = this.model.get('_buttons')['_' + propertyName].buttonText;
+      const propertyName = textPropertyName[buttonState.asString];
+      const ariaLabel = this.model.get('_buttons')['_' + propertyName].ariaLabel;
+      const buttonText = this.model.get('_buttons')['_' + propertyName].buttonText;
 
       // Enable the button, make accessible and update aria labels and text
 
@@ -120,7 +120,7 @@ export default class ButtonsView extends Backbone.View {
   }
 
   checkFeedbackState() {
-    var canShowFeedback = this.model.get('_canShowFeedback');
+    const canShowFeedback = this.model.get('_canShowFeedback');
 
     this.$('.js-btn-action').toggleClass('is-full-width', !canShowFeedback);
     this.$('.js-btn-feedback').toggleClass('u-display-none', !canShowFeedback);
@@ -128,10 +128,10 @@ export default class ButtonsView extends Backbone.View {
   }
 
   updateAttemptsCount(model, changedAttribute) {
-    var isInteractionComplete = this.model.get('_isInteractionComplete');
-    var attemptsLeft = (this.model.get('_attemptsLeft')) ? this.model.get('_attemptsLeft') : this.model.get('_attempts');
-    var shouldDisplayAttempts = this.model.get('_shouldDisplayAttempts');
-    var attemptsString;
+    const isInteractionComplete = this.model.get('_isInteractionComplete');
+    const attemptsLeft = (this.model.get('_attemptsLeft')) ? this.model.get('_attemptsLeft') : this.model.get('_attempts');
+    const shouldDisplayAttempts = this.model.get('_shouldDisplayAttempts');
+    let attemptsString;
 
     this.checkResetSubmittedState();
 
@@ -157,8 +157,8 @@ export default class ButtonsView extends Backbone.View {
   showMarking() {
     if (!this.model.shouldShowMarking) return;
 
-    var isCorrect = this.model.get('_isCorrect');
-    var ariaLabels = Adapt.course.get('_globals')._accessibility._ariaLabels;
+    const isCorrect = this.model.get('_isCorrect');
+    const ariaLabels = Adapt.course.get('_globals')._accessibility._ariaLabels;
 
     this.$('.js-btn-marking')
       .removeClass('u-display-none')

--- a/src/core/js/views/buttonsView.js
+++ b/src/core/js/views/buttonsView.js
@@ -1,181 +1,177 @@
-define([
-  'core/js/adapt',
-  'core/js/enums/buttonStateEnum'
-], function(Adapt, BUTTON_STATE) {
+import Adapt from 'core/js/adapt';
+import BUTTON_STATE from 'core/js/enums/buttonStateEnum';
 
-  // convert BUTTON_STATE to property name
-  var textPropertyName = {
-    'SUBMIT': 'submit',
-    'CORRECT': 'correct',
-    'INCORRECT': 'incorrect',
-    'SHOW_CORRECT_ANSWER': 'showCorrectAnswer',
-    'HIDE_CORRECT_ANSWER': 'hideCorrectAnswer',
-    'SHOW_FEEDBACK': 'showFeedback',
-    'RESET': 'reset'
-  };
+// convert BUTTON_STATE to property name
+const textPropertyName = {
+  'SUBMIT': 'submit',
+  'CORRECT': 'correct',
+  'INCORRECT': 'incorrect',
+  'SHOW_CORRECT_ANSWER': 'showCorrectAnswer',
+  'HIDE_CORRECT_ANSWER': 'hideCorrectAnswer',
+  'SHOW_FEEDBACK': 'showFeedback',
+  'RESET': 'reset'
+};
 
-  var ButtonsView = Backbone.View.extend({
+export default class ButtonsView extends Backbone.View {
 
-    initialize: function(options) {
-      this.parent = options.parent;
-      this.listenTo(Adapt.parentView, 'postRemove', this.remove);
-      this.listenTo(this.model, {
-        'change:_buttonState': this.onButtonStateChanged,
-        'change:feedbackMessage': this.onFeedbackMessageChanged,
-        'change:_attemptsLeft': this.onAttemptsChanged,
-        'change:_canSubmit': this.onCanSubmitChange
-      });
-      this.render();
-    },
+  initialize(options) {
+    this.parent = options.parent;
+    this.listenTo(Adapt.parentView, 'postRemove', this.remove);
+    this.listenTo(this.model, {
+      'change:_buttonState': this.onButtonStateChanged,
+      'change:feedbackMessage': this.onFeedbackMessageChanged,
+      'change:_attemptsLeft': this.onAttemptsChanged,
+      'change:_canSubmit': this.onCanSubmitChange
+    });
+    this.render();
+  }
 
-    events: {
+  events() {
+    return {
       'click .js-btn-action': 'onActionClicked',
       'click .js-btn-feedback': 'onFeedbackClicked'
-    },
+    };
+  }
 
-    render: function() {
-      var data = this.model.toJSON();
-      var template = Handlebars.templates['buttons'];
-      _.defer(_.bind(function() {
-        this.postRender();
-        Adapt.trigger('buttonsView:postRender', this);
-      }, this));
-      this.$el.html(template(data));
-    },
+  render() {
+    var data = this.model.toJSON();
+    var template = Handlebars.templates['buttons'];
+    _.defer(_.bind(function() {
+      this.postRender();
+      Adapt.trigger('buttonsView:postRender', this);
+    }, this));
+    this.$el.html(template(data));
+  }
 
-    postRender: function() {
-      this.refresh();
-    },
+  postRender() {
+    this.refresh();
+  }
 
-    checkResetSubmittedState: function() {
-      var isSubmitted = this.model.get('_isSubmitted');
+  checkResetSubmittedState() {
+    var isSubmitted = this.model.get('_isSubmitted');
 
-      if (!isSubmitted) {
-        this.$('.js-btn-marking').removeClass('is-incorrect is-correct').addClass('u-display-none');
-        this.$el.removeClass('is-submitted');
-        this.model.set('feedbackMessage', undefined);
-        Adapt.a11y.toggleEnabled(this.$('.js-btn-feedback'), false);
-      } else {
-        this.$el.addClass('is-submitted');
-      }
-    },
+    if (!isSubmitted) {
+      this.$('.js-btn-marking').removeClass('is-incorrect is-correct').addClass('u-display-none');
+      this.$el.removeClass('is-submitted');
+      this.model.set('feedbackMessage', undefined);
+      Adapt.a11y.toggleEnabled(this.$('.js-btn-feedback'), false);
+    } else {
+      this.$el.addClass('is-submitted');
+    }
+  }
 
-    onActionClicked: function() {
-      var buttonState = this.model.get('_buttonState');
-      this.trigger('buttons:stateUpdate', BUTTON_STATE(buttonState));
-      this.checkResetSubmittedState();
-    },
+  onActionClicked() {
+    var buttonState = this.model.get('_buttonState');
+    this.trigger('buttons:stateUpdate', BUTTON_STATE(buttonState));
+    this.checkResetSubmittedState();
+  }
 
-    onFeedbackClicked: function() {
-      this.trigger('buttons:stateUpdate', BUTTON_STATE.SHOW_FEEDBACK);
-    },
+  onFeedbackClicked() {
+    this.trigger('buttons:stateUpdate', BUTTON_STATE.SHOW_FEEDBACK);
+  }
 
-    onFeedbackMessageChanged: function(model, changedAttribute) {
-      if (changedAttribute && this.model.get('_canShowFeedback')) {
-        // enable feedback button
-        Adapt.a11y.toggleEnabled(this.$('.js-btn-feedback'), true);
-      } else {
-        // disable feedback button
-        Adapt.a11y.toggleEnabled(this.$('.js-btn-feedback'), false);
-      }
-    },
+  onFeedbackMessageChanged(model, changedAttribute) {
+    if (changedAttribute && this.model.get('_canShowFeedback')) {
+      // enable feedback button
+      Adapt.a11y.toggleEnabled(this.$('.js-btn-feedback'), true);
+    } else {
+      // disable feedback button
+      Adapt.a11y.toggleEnabled(this.$('.js-btn-feedback'), false);
+    }
+  }
 
-    onCanSubmitChange: function() {
-      this.onButtonStateChanged(this.model, this.model.get('_buttonState'));
-    },
+  onCanSubmitChange() {
+    this.onButtonStateChanged(this.model, this.model.get('_buttonState'));
+  }
 
-    onButtonStateChanged: function(model, changedAttribute) {
+  onButtonStateChanged(model, changedAttribute) {
 
-      this.updateAttemptsCount();
+    this.updateAttemptsCount();
 
-      // Use 'correct' instead of 'complete' to signify button state
-      var $buttonsAction = this.$('.js-btn-action');
-      var buttonState = BUTTON_STATE(changedAttribute);
-      if (changedAttribute === BUTTON_STATE.CORRECT || changedAttribute === BUTTON_STATE.INCORRECT) {
-        // Both 'correct' and 'incorrect' states have no model answer, so disable the submit button
+    // Use 'correct' instead of 'complete' to signify button state
+    var $buttonsAction = this.$('.js-btn-action');
+    var buttonState = BUTTON_STATE(changedAttribute);
+    if (changedAttribute === BUTTON_STATE.CORRECT || changedAttribute === BUTTON_STATE.INCORRECT) {
+      // Both 'correct' and 'incorrect' states have no model answer, so disable the submit button
 
-        Adapt.a11y.toggleEnabled($buttonsAction, false);
+      Adapt.a11y.toggleEnabled($buttonsAction, false);
 
-      } else {
+    } else {
 
-        var propertyName = textPropertyName[buttonState.asString];
-        var ariaLabel = this.model.get('_buttons')['_' + propertyName].ariaLabel;
-        var buttonText = this.model.get('_buttons')['_' + propertyName].buttonText;
+      var propertyName = textPropertyName[buttonState.asString];
+      var ariaLabel = this.model.get('_buttons')['_' + propertyName].ariaLabel;
+      var buttonText = this.model.get('_buttons')['_' + propertyName].buttonText;
 
-        // Enable the button, make accessible and update aria labels and text
+      // Enable the button, make accessible and update aria labels and text
 
-        Adapt.a11y.toggleEnabled($buttonsAction, this.model.get('_canSubmit'));
-        $buttonsAction.html(buttonText).attr('aria-label', ariaLabel);
+      Adapt.a11y.toggleEnabled($buttonsAction, this.model.get('_canSubmit'));
+      $buttonsAction.html(buttonText).attr('aria-label', ariaLabel);
 
-        // Make model answer button inaccessible (but still enabled) for visual users due to
-        // the inability to represent selected incorrect/correct answers to a screen reader, may need revisiting
-        switch (changedAttribute) {
-          case BUTTON_STATE.SHOW_CORRECT_ANSWER:
-          case BUTTON_STATE.HIDE_CORRECT_ANSWER:
+      // Make model answer button inaccessible (but still enabled) for visual users due to
+      // the inability to represent selected incorrect/correct answers to a screen reader, may need revisiting
+      switch (changedAttribute) {
+        case BUTTON_STATE.SHOW_CORRECT_ANSWER:
+        case BUTTON_STATE.HIDE_CORRECT_ANSWER:
 
-            Adapt.a11y.toggleAccessible($buttonsAction, false);
-        }
-
-      }
-    },
-
-    checkFeedbackState: function() {
-      var canShowFeedback = this.model.get('_canShowFeedback');
-
-      this.$('.js-btn-action').toggleClass('is-full-width', !canShowFeedback);
-      this.$('.js-btn-feedback').toggleClass('u-display-none', !canShowFeedback);
-      this.$('.js-btn-marking').toggleClass('is-full-width u-display-none', !canShowFeedback);
-    },
-
-    updateAttemptsCount: function(model, changedAttribute) {
-      var isInteractionComplete = this.model.get('_isInteractionComplete');
-      var attemptsLeft = (this.model.get('_attemptsLeft')) ? this.model.get('_attemptsLeft') : this.model.get('_attempts');
-      var shouldDisplayAttempts = this.model.get('_shouldDisplayAttempts');
-      var attemptsString;
-
-      this.checkResetSubmittedState();
-
-      if (!isInteractionComplete && attemptsLeft !== 0) {
-        attemptsString = attemptsLeft + ' ';
-        if (attemptsLeft > 1) {
-          attemptsString += this.model.get('_buttons').remainingAttemptsText;
-        } else if (attemptsLeft === 1) {
-          attemptsString += this.model.get('_buttons').remainingAttemptText;
-        }
-
-      } else {
-        this.$('.js-display-attempts').addClass('u-visibility-hidden');
-        this.showMarking();
+          Adapt.a11y.toggleAccessible($buttonsAction, false);
       }
 
-      if (shouldDisplayAttempts) {
-        this.$('.js-insert-attempts-string').html(attemptsString);
+    }
+  }
+
+  checkFeedbackState() {
+    var canShowFeedback = this.model.get('_canShowFeedback');
+
+    this.$('.js-btn-action').toggleClass('is-full-width', !canShowFeedback);
+    this.$('.js-btn-feedback').toggleClass('u-display-none', !canShowFeedback);
+    this.$('.js-btn-marking').toggleClass('is-full-width u-display-none', !canShowFeedback);
+  }
+
+  updateAttemptsCount(model, changedAttribute) {
+    var isInteractionComplete = this.model.get('_isInteractionComplete');
+    var attemptsLeft = (this.model.get('_attemptsLeft')) ? this.model.get('_attemptsLeft') : this.model.get('_attempts');
+    var shouldDisplayAttempts = this.model.get('_shouldDisplayAttempts');
+    var attemptsString;
+
+    this.checkResetSubmittedState();
+
+    if (!isInteractionComplete && attemptsLeft !== 0) {
+      attemptsString = attemptsLeft + ' ';
+      if (attemptsLeft > 1) {
+        attemptsString += this.model.get('_buttons').remainingAttemptsText;
+      } else if (attemptsLeft === 1) {
+        attemptsString += this.model.get('_buttons').remainingAttemptText;
       }
 
-    },
-
-    showMarking: function() {
-      if (!this.model.shouldShowMarking) return;
-
-      var isCorrect = this.model.get('_isCorrect');
-      var ariaLabels = Adapt.course.get('_globals')._accessibility._ariaLabels;
-
-      this.$('.js-btn-marking')
-        .removeClass('u-display-none')
-        .addClass(isCorrect ? 'is-correct' : 'is-incorrect')
-        .attr('aria-label', isCorrect ? ariaLabels.answeredCorrectly : ariaLabels.answeredIncorrectly);
-    },
-
-    refresh: function() {
-      this.updateAttemptsCount();
-      this.checkResetSubmittedState();
-      this.checkFeedbackState();
-      this.onButtonStateChanged(null, this.model.get('_buttonState'));
-      this.onFeedbackMessageChanged(null, this.model.get('feedbackMessage'));
+    } else {
+      this.$('.js-display-attempts').addClass('u-visibility-hidden');
+      this.showMarking();
     }
 
-  });
+    if (shouldDisplayAttempts) {
+      this.$('.js-insert-attempts-string').html(attemptsString);
+    }
 
-  return ButtonsView;
+  }
 
-});
+  showMarking() {
+    if (!this.model.shouldShowMarking) return;
+
+    var isCorrect = this.model.get('_isCorrect');
+    var ariaLabels = Adapt.course.get('_globals')._accessibility._ariaLabels;
+
+    this.$('.js-btn-marking')
+      .removeClass('u-display-none')
+      .addClass(isCorrect ? 'is-correct' : 'is-incorrect')
+      .attr('aria-label', isCorrect ? ariaLabels.answeredCorrectly : ariaLabels.answeredIncorrectly);
+  }
+
+  refresh() {
+    this.updateAttemptsCount();
+    this.checkResetSubmittedState();
+    this.checkFeedbackState();
+    this.onButtonStateChanged(null, this.model.get('_buttonState'));
+    this.onFeedbackMessageChanged(null, this.model.get('feedbackMessage'));
+  }
+
+}

--- a/src/core/js/views/buttonsView.js
+++ b/src/core/js/views/buttonsView.js
@@ -36,10 +36,10 @@ export default class ButtonsView extends Backbone.View {
   render() {
     const data = this.model.toJSON();
     const template = Handlebars.templates['buttons'];
-    _.defer(_.bind(function() {
+    _.defer(() => {
       this.postRender();
       Adapt.trigger('buttonsView:postRender', this);
-    }, this));
+    });
     this.$el.html(template(data));
   }
 

--- a/src/core/js/views/componentView.js
+++ b/src/core/js/views/componentView.js
@@ -1,93 +1,89 @@
-define([
-  'core/js/adapt',
-  'core/js/views/adaptView'
-], function(Adapt, AdaptView) {
+import Adapt from 'core/js/adapt';
+import AdaptView from 'core/js/views/adaptView';
 
-  class ComponentView extends AdaptView {
+class ComponentView extends AdaptView {
 
-    attributes() {
-      if (!this.model.get('_isA11yRegionEnabled')) {
-        return AdaptView.resultExtend('attributes', {}, this);
-      }
-      return AdaptView.resultExtend('attributes', {
-        'aria-labelledby': this.model.get('_id') + '-heading',
-        'role': 'region'
-      }, this);
+  attributes() {
+    if (!this.model.get('_isA11yRegionEnabled')) {
+      return AdaptView.resultExtend('attributes', {}, this);
     }
-
-    className() {
-      return [
-        'component',
-        this.model.get('_component').toLowerCase(),
-        this.model.get('_id'),
-        this.model.get('_classes'),
-        this.setVisibility(),
-        this.setHidden(),
-        'is-' + this.model.get('_layout'),
-        (this.model.get('_isComplete') ? 'is-complete' : ''),
-        (this.model.get('_isOptional') ? 'is-optional' : '')
-      ].join(' ');
-    }
-
-    renderState() {
-      Adapt.log.removed('renderState is removed and moved to item title');
-    }
-
-    /**
-     * Allows components that want to use inview for completion to set that up
-     * @param {string} [inviewElementSelector] Allows to you to specify (via a selector) which DOM element to use for inview.
-     * Defaults to `'.component__inner'` if not supplied.
-     * @param {function} [callback] Allows you to specify what function is called when the component has been viewed, should
-     * you want to perform additional checks before setting the component to completed - see adapt-contrib-assessmentResults
-     * for an example. Defaults to `view.setCompletionStatus` if not specified.
-     */
-    setupInviewCompletion(inviewElementSelector = '.component__inner', callback = this.setCompletionStatus) {
-      this.$inviewElement = this.$(inviewElementSelector);
-      this.inviewCallback = callback;
-
-      this.$inviewElement.on('inview.componentView', this.onInview.bind(this));
-    }
-
-    removeInviewListener() {
-      if (!this.$inviewElement) return;
-      this.$inviewElement.off('inview.componentView');
-      this.$inviewElement = null;
-    }
-
-    onInview(event, visible, visiblePartX, visiblePartY) {
-      if (!visible) return;
-
-      switch (visiblePartY) {
-        case 'top':
-          this.hasSeenTop = true;
-          break;
-        case 'bottom':
-          this.hasSeenBottom = true;
-          break;
-        case 'both':
-          this.hasSeenTop = this.hasSeenBottom = true;
-      }
-
-      if (!this.hasSeenTop || !this.hasSeenBottom) return;
-
-      this.inviewCallback();
-
-      if (this.model.get('_isComplete')) {
-        this.removeInviewListener();
-      }
-    }
-
-    postRender() {}
-
-    remove() {
-      this.removeInviewListener();
-      super.remove();
-    }
-
+    return AdaptView.resultExtend('attributes', {
+      'aria-labelledby': this.model.get('_id') + '-heading',
+      'role': 'region'
+    }, this);
   }
 
-  ComponentView.type = 'component';
+  className() {
+    return [
+      'component',
+      this.model.get('_component').toLowerCase(),
+      this.model.get('_id'),
+      this.model.get('_classes'),
+      this.setVisibility(),
+      this.setHidden(),
+      'is-' + this.model.get('_layout'),
+      (this.model.get('_isComplete') ? 'is-complete' : ''),
+      (this.model.get('_isOptional') ? 'is-optional' : '')
+    ].join(' ');
+  }
 
-  return ComponentView;
+  renderState() {
+    Adapt.log.removed('renderState is removed and moved to item title');
+  }
 
-});
+  /**
+   * Allows components that want to use inview for completion to set that up
+   * @param {string} [inviewElementSelector] Allows to you to specify (via a selector) which DOM element to use for inview.
+   * Defaults to `'.component__inner'` if not supplied.
+   * @param {function} [callback] Allows you to specify what function is called when the component has been viewed, should
+   * you want to perform additional checks before setting the component to completed - see adapt-contrib-assessmentResults
+   * for an example. Defaults to `view.setCompletionStatus` if not specified.
+   */
+  setupInviewCompletion(inviewElementSelector = '.component__inner', callback = this.setCompletionStatus) {
+    this.$inviewElement = this.$(inviewElementSelector);
+    this.inviewCallback = callback;
+
+    this.$inviewElement.on('inview.componentView', this.onInview.bind(this));
+  }
+
+  removeInviewListener() {
+    if (!this.$inviewElement) return;
+    this.$inviewElement.off('inview.componentView');
+    this.$inviewElement = null;
+  }
+
+  onInview(event, visible, visiblePartX, visiblePartY) {
+    if (!visible) return;
+
+    switch (visiblePartY) {
+      case 'top':
+        this.hasSeenTop = true;
+        break;
+      case 'bottom':
+        this.hasSeenBottom = true;
+        break;
+      case 'both':
+        this.hasSeenTop = this.hasSeenBottom = true;
+    }
+
+    if (!this.hasSeenTop || !this.hasSeenBottom) return;
+
+    this.inviewCallback();
+
+    if (this.model.get('_isComplete')) {
+      this.removeInviewListener();
+    }
+  }
+
+  postRender() {}
+
+  remove() {
+    this.removeInviewListener();
+    super.remove();
+  }
+
+}
+
+ComponentView.type = 'component';
+
+export default ComponentView;

--- a/src/core/js/views/contentObjectView.js
+++ b/src/core/js/views/contentObjectView.js
@@ -1,169 +1,163 @@
-define([
-  'core/js/adapt',
-  'core/js/views/adaptView'
-], function(Adapt, AdaptView) {
+import Adapt from 'core/js/adapt';
+import AdaptView from 'core/js/views/adaptView';
 
-  class ContentObjectView extends AdaptView {
+export default class ContentObjectView extends AdaptView {
 
-    attributes() {
-      return AdaptView.resultExtend('attributes', {
-        'role': 'main',
-        'aria-labelledby': `${this.model.get('_id')}-heading`
-      }, this);
-    }
-
-    className() {
-      return [
-        this.constructor.type,
-        'contentobject',
-        this.constructor.className,
-        this.model.get('_id'),
-        this.model.get('_classes'),
-        this.setVisibility(),
-        (this.model.get('_isComplete') ? 'is-complete' : ''),
-        (this.model.get('_isOptional') ? 'is-optional' : '')
-      ].filter(Boolean).join(' ');
-    }
-
-    preRender() {
-      $.inview.lock(this.constructor.type + 'View');
-      this.disableAnimation = Adapt.config.has('_disableAnimation') ? Adapt.config.get('_disableAnimation') : false;
-      this.$el.css('opacity', 0);
-      this.listenTo(this.model, 'change:_isReady', this.isReady);
-    }
-
-    render() {
-      const type = this.constructor.type;
-      Adapt.trigger(`${type}View:preRender contentObjectView:preRender view:preRender`, this);
-
-      const data = this.model.toJSON();
-      data.view = this;
-      const template = Handlebars.templates[this.constructor.template];
-      this.$el.html(template(data));
-
-      Adapt.trigger(`${type}View:render contentObjectView:render view:render`, this);
-
-      _.defer(() => {
-        // don't call postRender after remove
-        if (this._isRemoved) return;
-
-        this.postRender();
-        Adapt.trigger(`${type}View:postRender contentObjectView:postRender view:postRender`, this);
-      });
-
-      return this;
-    }
-
-    async isReady() {
-      if (!this.model.get('_isReady') || this._isTriggeredReady) return;
-      this._isTriggeredReady = true;
-
-      const type = this.constructor.type;
-      const performIsReady = async () => {
-        Adapt.trigger(`${type}View:preReady contentObjectView:preReady view:preReady`, this);
-        await Adapt.wait.queue();
-        $('.js-loading').hide();
-        if (Adapt.get('_shouldContentObjectScrollTop') !== false) {
-          $(window).scrollTop(0);
-        }
-        Adapt.trigger(`${type}View:ready contentObjectView:ready view:ready`, this);
-        $.inview.unlock(`${type}View`);
-        const styleOptions = { opacity: 1 };
-        if (this.disableAnimation) {
-          this.$el.css(styleOptions);
-          $.inview();
-          _.defer(() => {
-            Adapt.trigger(`${type}View:postReady contentObjectView:postReady view:postReady`, this);
-          });
-        } else {
-          this.$el.velocity(styleOptions, {
-            duration: 'fast',
-            complete: () => {
-              $.inview();
-              Adapt.trigger(`${type}View:postReady contentObjectView:postReady view:postReady`, this);
-            }
-          });
-        }
-        $(window).scroll();
-      };
-
-      _.defer(performIsReady);
-    }
-
-    /**
-     * Force render up to specified id. Resolves when views are ready.
-     * @param {string} id
-     */
-    async renderTo(id) {
-      const isRenderToSelf = (id === this.model.get('_id'));
-      if (isRenderToSelf) return;
-      let models = this.model.getAllDescendantModels(true).filter(model => model.get('_isAvailable'));
-      const index = models.findIndex(model => model.get('_id') === id);
-      if (index === -1) {
-        throw new Error(`Cannot renderTo "${id}" as it isn't a descendant.`);
-      }
-      // Return early if the model is already rendered and ready
-      const model = models[index];
-      if (model.get('_isRendered') && model.get('_isReady')) {
-        return;
-      }
-      // Force all models up until the id to render
-      models = models.slice(0, index + 1);
-      const ids = _.indexBy(models, (model) => model.get('_id'));
-      const forceUntilId = (event) => {
-        const addingId = event.model.get('_id');
-        if (!ids[addingId]) return;
-        event.force();
-        if (addingId !== id) return;
-        Adapt.off('view:addChild', forceUntilId);
-      };
-      Adapt.on('view:addChild', forceUntilId);
-      // Trigger addChildren cascade
-      await this.addChildren();
-      await this.whenReady();
-      // Error if model isn't rendered and ready
-      if (!model.get('_isRendered') || !model.get('_isReady')) {
-        throw new Error(`Cannot renderTo "${id}".`);
-      }
-    }
-
-    preRemove() {
-      const type = this.constructor.type;
-      Adapt.trigger(`${type}View:preRemove contentObjectView:preRemove view:preRemove`, this);
-    }
-
-    remove() {
-      const type = this.constructor.type;
-      this.preRemove();
-      Adapt.trigger(`${type}View:remove contentObjectView:remove view:remove`, this);
-      this._isRemoved = true;
-
-      Adapt.wait.for(end => {
-        this.$el.off('onscreen.adaptView');
-        this.findDescendantViews().reverse().forEach(view => {
-          view.remove();
-        });
-        this.setChildViews(null);
-        super.remove();
-        _.defer(() => {
-          Adapt.trigger(`${type}View:postRemove contentObjectView:postRemove view:postRemove`, this);
-          this.trigger('postRemove');
-        });
-        end();
-      });
-
-      return this;
-    }
-
-    destroy() {
-      this.remove();
-      if (Adapt.parentView === this) {
-        Adapt.parentView = null;
-      }
-    }
-
+  attributes() {
+    return AdaptView.resultExtend('attributes', {
+      'role': 'main',
+      'aria-labelledby': `${this.model.get('_id')}-heading`
+    }, this);
   }
 
-  return ContentObjectView;
+  className() {
+    return [
+      this.constructor.type,
+      'contentobject',
+      this.constructor.className,
+      this.model.get('_id'),
+      this.model.get('_classes'),
+      this.setVisibility(),
+      (this.model.get('_isComplete') ? 'is-complete' : ''),
+      (this.model.get('_isOptional') ? 'is-optional' : '')
+    ].filter(Boolean).join(' ');
+  }
 
-});
+  preRender() {
+    $.inview.lock(this.constructor.type + 'View');
+    this.disableAnimation = Adapt.config.has('_disableAnimation') ? Adapt.config.get('_disableAnimation') : false;
+    this.$el.css('opacity', 0);
+    this.listenTo(this.model, 'change:_isReady', this.isReady);
+  }
+
+  render() {
+    const type = this.constructor.type;
+    Adapt.trigger(`${type}View:preRender contentObjectView:preRender view:preRender`, this);
+
+    const data = this.model.toJSON();
+    data.view = this;
+    const template = Handlebars.templates[this.constructor.template];
+    this.$el.html(template(data));
+
+    Adapt.trigger(`${type}View:render contentObjectView:render view:render`, this);
+
+    _.defer(() => {
+      // don't call postRender after remove
+      if (this._isRemoved) return;
+
+      this.postRender();
+      Adapt.trigger(`${type}View:postRender contentObjectView:postRender view:postRender`, this);
+    });
+
+    return this;
+  }
+
+  async isReady() {
+    if (!this.model.get('_isReady') || this._isTriggeredReady) return;
+    this._isTriggeredReady = true;
+
+    const type = this.constructor.type;
+    const performIsReady = async () => {
+      Adapt.trigger(`${type}View:preReady contentObjectView:preReady view:preReady`, this);
+      await Adapt.wait.queue();
+      $('.js-loading').hide();
+      if (Adapt.get('_shouldContentObjectScrollTop') !== false) {
+        $(window).scrollTop(0);
+      }
+      Adapt.trigger(`${type}View:ready contentObjectView:ready view:ready`, this);
+      $.inview.unlock(`${type}View`);
+      const styleOptions = { opacity: 1 };
+      if (this.disableAnimation) {
+        this.$el.css(styleOptions);
+        $.inview();
+        _.defer(() => {
+          Adapt.trigger(`${type}View:postReady contentObjectView:postReady view:postReady`, this);
+        });
+      } else {
+        this.$el.velocity(styleOptions, {
+          duration: 'fast',
+          complete: () => {
+            $.inview();
+            Adapt.trigger(`${type}View:postReady contentObjectView:postReady view:postReady`, this);
+          }
+        });
+      }
+      $(window).scroll();
+    };
+
+    _.defer(performIsReady);
+  }
+
+  /**
+   * Force render up to specified id. Resolves when views are ready.
+   * @param {string} id
+   */
+  async renderTo(id) {
+    const isRenderToSelf = (id === this.model.get('_id'));
+    if (isRenderToSelf) return;
+    let models = this.model.getAllDescendantModels(true).filter(model => model.get('_isAvailable'));
+    const index = models.findIndex(model => model.get('_id') === id);
+    if (index === -1) {
+      throw new Error(`Cannot renderTo "${id}" as it isn't a descendant.`);
+    }
+    // Return early if the model is already rendered and ready
+    const model = models[index];
+    if (model.get('_isRendered') && model.get('_isReady')) {
+      return;
+    }
+    // Force all models up until the id to render
+    models = models.slice(0, index + 1);
+    const ids = _.indexBy(models, (model) => model.get('_id'));
+    const forceUntilId = (event) => {
+      const addingId = event.model.get('_id');
+      if (!ids[addingId]) return;
+      event.force();
+      if (addingId !== id) return;
+      Adapt.off('view:addChild', forceUntilId);
+    };
+    Adapt.on('view:addChild', forceUntilId);
+    // Trigger addChildren cascade
+    await this.addChildren();
+    await this.whenReady();
+    // Error if model isn't rendered and ready
+    if (!model.get('_isRendered') || !model.get('_isReady')) {
+      throw new Error(`Cannot renderTo "${id}".`);
+    }
+  }
+
+  preRemove() {
+    const type = this.constructor.type;
+    Adapt.trigger(`${type}View:preRemove contentObjectView:preRemove view:preRemove`, this);
+  }
+
+  remove() {
+    const type = this.constructor.type;
+    this.preRemove();
+    Adapt.trigger(`${type}View:remove contentObjectView:remove view:remove`, this);
+    this._isRemoved = true;
+
+    Adapt.wait.for(end => {
+      this.$el.off('onscreen.adaptView');
+      this.findDescendantViews().reverse().forEach(view => {
+        view.remove();
+      });
+      this.setChildViews(null);
+      super.remove();
+      _.defer(() => {
+        Adapt.trigger(`${type}View:postRemove contentObjectView:postRemove view:postRemove`, this);
+        this.trigger('postRemove');
+      });
+      end();
+    });
+
+    return this;
+  }
+
+  destroy() {
+    this.remove();
+    if (Adapt.parentView === this) {
+      Adapt.parentView = null;
+    }
+  }
+
+}

--- a/src/core/js/views/drawerItemView.js
+++ b/src/core/js/views/drawerItemView.js
@@ -24,15 +24,15 @@ class DrawerItemView extends Backbone.View {
   }
 
   render() {
-    var data = this.model.toJSON();
-    var template = Handlebars.templates['drawerItem'];
+    const data = this.model.toJSON();
+    const template = Handlebars.templates['drawerItem'];
     $(this.el).html(template(data)).appendTo('.drawer__holder');
     return this;
   }
 
   onDrawerItemClicked(event) {
     event.preventDefault();
-    var eventCallback = this.model.get('eventCallback');
+    const eventCallback = this.model.get('eventCallback');
     Adapt.trigger(eventCallback);
   }
 

--- a/src/core/js/views/drawerItemView.js
+++ b/src/core/js/views/drawerItemView.js
@@ -1,41 +1,43 @@
-define([
-  'core/js/adapt'
-], function(Adapt) {
+import Adapt from 'core/js/adapt';
 
-  var DrawerItemView = Backbone.View.extend({
+class DrawerItemView extends Backbone.View {
 
-    className: 'drawer__menu drawer__item',
+  className() {
+    return 'drawer__menu drawer__item';
+  }
 
-    attributes: {
+  attributes() {
+    return {
       role: 'list'
-    },
+    };
+  }
 
-    initialize: function() {
-      this.listenTo(Adapt, 'drawer:empty', this.remove);
-      this.render();
-    },
+  initialize() {
+    this.listenTo(Adapt, 'drawer:empty', this.remove);
+    this.render();
+  }
 
-    events: {
+  events() {
+    return {
       'click .drawer__item-btn': 'onDrawerItemClicked'
-    },
+    };
+  }
 
-    render: function() {
-      var data = this.model.toJSON();
-      var template = Handlebars.templates['drawerItem'];
-      $(this.el).html(template(data)).appendTo('.drawer__holder');
-      return this;
-    },
+  render() {
+    var data = this.model.toJSON();
+    var template = Handlebars.templates['drawerItem'];
+    $(this.el).html(template(data)).appendTo('.drawer__holder');
+    return this;
+  }
 
-    onDrawerItemClicked: function(event) {
-      event.preventDefault();
-      var eventCallback = this.model.get('eventCallback');
-      Adapt.trigger(eventCallback);
-    }
+  onDrawerItemClicked(event) {
+    event.preventDefault();
+    var eventCallback = this.model.get('eventCallback');
+    Adapt.trigger(eventCallback);
+  }
 
-  }, {
-    type: 'drawerItem'
-  });
+}
 
-  return DrawerItemView;
+DrawerItemView.type = 'drawerItem';
 
-});
+export default DrawerItemView;

--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -1,285 +1,288 @@
-define([
-  'core/js/adapt',
-  'core/js/views/drawerItemView'
-], function(Adapt, DrawerItemView) {
+import Adapt from 'core/js/adapt';
+import DrawerItemView from 'core/js/views/drawerItemView';
 
-  var DrawerView = Backbone.View.extend({
+class DrawerView extends Backbone.View {
 
-    className: 'drawer u-display-none',
-    disableAnimation: false,
+  className() {
+    return 'drawer u-display-none';
+  }
 
-    attributes: {
+  attributes() {
+    return {
       'role': 'dialog',
       'aria-modal': 'true',
       'aria-labelledby': 'drawer-heading',
       'aria-hidden': 'true'
-    },
+    };
+  }
 
-    initialize: function() {
-      this.disableAnimation = Adapt.config.has('_disableAnimation') ? Adapt.config.get('_disableAnimation') : false;
-      this._isVisible = false;
-      this.drawerDir = 'right';
-      if (Adapt.config.get('_defaultDirection') === 'rtl') { // on RTL drawer on the left
-        this.drawerDir = 'left';
-      }
-      this.setupEventListeners();
-      this.render();
-      this.drawerDuration = Adapt.config.get('_drawer')._duration;
-      this.drawerDuration = (this.drawerDuration) ? this.drawerDuration : 400;
-      // Setup cached selectors
-      this.$wrapper = $('#wrapper');
-    },
+  initialize() {
+    this.disableAnimation = Adapt.config.has('_disableAnimation') ? Adapt.config.get('_disableAnimation') : false;
+    this._isVisible = false;
+    this.drawerDir = 'right';
+    if (Adapt.config.get('_defaultDirection') === 'rtl') { // on RTL drawer on the left
+      this.drawerDir = 'left';
+    }
+    this.setupEventListeners();
+    this.render();
+    this.drawerDuration = Adapt.config.get('_drawer')._duration;
+    this.drawerDuration = (this.drawerDuration) ? this.drawerDuration : 400;
+    // Setup cached selectors
+    this.$wrapper = $('#wrapper');
+  }
 
-    setupEventListeners: function() {
-      this.listenTo(Adapt, {
-        'navigation:toggleDrawer': this.toggleDrawer,
-        'drawer:triggerCustomView': this.openCustomView,
-        'drawer:closeDrawer': this.onCloseDrawer,
-        'remove': this.onRemove,
-        'drawer:remove': this.remove
-      });
+  setupEventListeners() {
+    this.listenTo(Adapt, {
+      'navigation:toggleDrawer': this.toggleDrawer,
+      'drawer:triggerCustomView': this.openCustomView,
+      'drawer:closeDrawer': this.onCloseDrawer,
+      'remove': this.onRemove,
+      'drawer:remove': this.remove
+    });
 
-      this._onKeyUp = _.bind(this.onKeyUp, this);
-      this.setupEscapeKey();
-    },
+    this._onKeyUp = _.bind(this.onKeyUp, this);
+    this.setupEscapeKey();
+  }
 
-    setupEscapeKey: function() {
-      $(window).on('keyup', this._onKeyUp);
-    },
+  setupEscapeKey() {
+    $(window).on('keyup', this._onKeyUp);
+  }
 
-    onKeyUp: function(event) {
-      if (event.which !== 27) return;
-      event.preventDefault();
+  onKeyUp(event) {
+    if (event.which !== 27) return;
+    event.preventDefault();
 
-      this.onCloseDrawer();
-    },
+    this.onCloseDrawer();
+  }
 
-    events: {
+  events() {
+    return {
       'click .drawer__back': 'onBackButtonClicked',
       'click .drawer__close': 'onCloseClicked'
-    },
+    };
+  }
 
-    render: function() {
-      var template = Handlebars.templates['drawer'];
-      $(this.el).html(template({ _globals: Adapt.course.get('_globals') })).prependTo('body');
-      var shadowTemplate = Handlebars.templates['shadow'];
-      $(shadowTemplate()).prependTo('body');
-      // Set defer on post render
-      _.defer(_.bind(function() {
-        this.postRender();
-      }, this));
-      return this;
-    },
+  render() {
+    var template = Handlebars.templates['drawer'];
+    $(this.el).html(template({ _globals: Adapt.course.get('_globals') })).prependTo('body');
+    var shadowTemplate = Handlebars.templates['shadow'];
+    $(shadowTemplate()).prependTo('body');
+    // Set defer on post render
+    _.defer(_.bind(function() {
+      this.postRender();
+    }, this));
+    return this;
+  }
 
-    // Set tabindex for select elements
-    postRender: function() {
-      this.$('a, button, input, select, textarea').attr('tabindex', -1);
+  // Set tabindex for select elements
+  postRender() {
+    this.$('a, button, input, select, textarea').attr('tabindex', -1);
 
-      this.checkIfDrawerIsAvailable();
-    },
+    this.checkIfDrawerIsAvailable();
+  }
 
-    openCustomView: function(view, hasBackButton) {
-      // Set whether back button should display
-      this._hasBackButton = hasBackButton;
-      this._isCustomViewVisible = true;
-      Adapt.trigger('drawer:empty');
-      this.showDrawer();
-      this.$('.drawer__holder').html(view);
-    },
+  openCustomView(view, hasBackButton) {
+    // Set whether back button should display
+    this._hasBackButton = hasBackButton;
+    this._isCustomViewVisible = true;
+    Adapt.trigger('drawer:empty');
+    this.showDrawer();
+    this.$('.drawer__holder').html(view);
+  }
 
-    checkIfDrawerIsAvailable: function() {
-      if (this.collection.length === 0) {
-        $('.js-nav-drawer-btn').addClass('u-display-none');
-        Adapt.trigger('drawer:noItems');
-        return;
-      }
-      $('.js-nav-drawer-btn').removeClass('u-display-none');
-    },
+  checkIfDrawerIsAvailable() {
+    if (this.collection.length === 0) {
+      $('.js-nav-drawer-btn').addClass('u-display-none');
+      Adapt.trigger('drawer:noItems');
+      return;
+    }
+    $('.js-nav-drawer-btn').removeClass('u-display-none');
+  }
 
-    onBackButtonClicked: function(event) {
-      event.preventDefault();
+  onBackButtonClicked(event) {
+    event.preventDefault();
+    this.showDrawer(true);
+  }
+
+  onCloseClicked(event) {
+    event.preventDefault();
+    this.hideDrawer();
+  }
+
+  onCloseDrawer($toElement) {
+    this.hideDrawer($toElement);
+  }
+
+  onRemove() {
+    this.hideDrawer();
+  }
+
+  toggleDrawer() {
+    if (this._isVisible && this._isCustomViewVisible === false) {
+      this.hideDrawer();
+    } else {
       this.showDrawer(true);
-    },
+    }
+  }
 
-    onCloseClicked: function(event) {
-      event.preventDefault();
-      this.hideDrawer();
-    },
+  showDrawer(emptyDrawer) {
+    this.$el.removeClass('u-display-none').removeAttr('aria-hidden');
+    // Only trigger popup:opened if drawer is visible, pass popup manager drawer element
+    if (!this._isVisible) {
+      Adapt.a11y.popupOpened(this.$el);
+      Adapt.a11y.scrollDisable('body');
+      this._isVisible = true;
+    }
 
-    onCloseDrawer: function($toElement) {
-      this.hideDrawer($toElement);
-    },
+    // Sets tab index to 0 for all tabbable elements in Drawer
+    this.$('a, button, input, select, textarea').attr('tabindex', 0);
 
-    onRemove: function() {
-      this.hideDrawer();
-    },
-
-    toggleDrawer: function() {
-      if (this._isVisible && this._isCustomViewVisible === false) {
-        this.hideDrawer();
-      } else {
-        this.showDrawer(true);
-      }
-    },
-
-    showDrawer: function(emptyDrawer) {
-      this.$el.removeClass('u-display-none').removeAttr('aria-hidden');
-      // Only trigger popup:opened if drawer is visible, pass popup manager drawer element
-      if (!this._isVisible) {
-        Adapt.a11y.popupOpened(this.$el);
-        Adapt.a11y.scrollDisable('body');
-        this._isVisible = true;
-      }
-
-      // Sets tab index to 0 for all tabbable elements in Drawer
-      this.$('a, button, input, select, textarea').attr('tabindex', 0);
-
-      if (emptyDrawer) {
-        this.$('.drawer__back').addClass('u-display-none');
+    if (emptyDrawer) {
+      this.$('.drawer__back').addClass('u-display-none');
+      this._isCustomViewVisible = false;
+      this.emptyDrawer();
+      if (this.collection.models.length === 1) {
+        // This callback triggers openCustomView() and sets
+        // _isCustomViewVisible to true, causing toggleDrawer()
+        // to re-render the drawer on every toggle button press
+        Adapt.trigger(this.collection.models[0].get('eventCallback'));
+        // Set _isCustomViewVisible to false to prevent re-rendering
+        // the drawer and fix the toggle functionality on toggle button press
         this._isCustomViewVisible = false;
-        this.emptyDrawer();
-        if (this.collection.models.length === 1) {
-          // This callback triggers openCustomView() and sets
-          // _isCustomViewVisible to true, causing toggleDrawer()
-          // to re-render the drawer on every toggle button press
-          Adapt.trigger(this.collection.models[0].get('eventCallback'));
-          // Set _isCustomViewVisible to false to prevent re-rendering
-          // the drawer and fix the toggle functionality on toggle button press
-          this._isCustomViewVisible = false;
-        } else {
-          this.renderItems();
-          Adapt.trigger('drawer:openedItemView');
-        }
       } else {
-        if (this._hasBackButton && this.collection.models.length > 1) {
-          this.$('.drawer__back').removeClass('u-display-none');
-        } else {
-          this.$('.drawer__back').addClass('u-display-none');
-        }
-        Adapt.trigger('drawer:openedCustomView');
+        this.renderItems();
+        Adapt.trigger('drawer:openedItemView');
       }
+    } else {
+      if (this._hasBackButton && this.collection.models.length > 1) {
+        this.$('.drawer__back').removeClass('u-display-none');
+      } else {
+        this.$('.drawer__back').addClass('u-display-none');
+      }
+      Adapt.trigger('drawer:openedCustomView');
+    }
 
-      // delay drawer animation until after background fadeout animation is complete
-      var direction = {};
-      if (this.disableAnimation) {
+    // delay drawer animation until after background fadeout animation is complete
+    var direction = {};
+    if (this.disableAnimation) {
+      $('.js-shadow').removeClass('u-display-none');
+      $('.js-drawer-holder').scrollTop(0);
+
+      direction[this.drawerDir] = 0;
+      this.$el.css(direction);
+      complete.call(this);
+    } else {
+      // eslint-disable-next-line object-property-newline
+      $('.js-shadow').velocity({ opacity: 1 }, { duration: this.drawerDuration, begin: _.bind(function() {
         $('.js-shadow').removeClass('u-display-none');
         $('.js-drawer-holder').scrollTop(0);
-
-        direction[this.drawerDir] = 0;
-        this.$el.css(direction);
         complete.call(this);
-      } else {
-        // eslint-disable-next-line object-property-newline
-        $('.js-shadow').velocity({ opacity: 1 }, { duration: this.drawerDuration, begin: _.bind(function() {
-          $('.js-shadow').removeClass('u-display-none');
-          $('.js-drawer-holder').scrollTop(0);
-          complete.call(this);
-        }, this) });
+      }, this) });
 
-        var showEasingAnimation = Adapt.config.get('_drawer')._showEasing;
-        var easing = (showEasingAnimation) || 'easeOutQuart';
+      var showEasingAnimation = Adapt.config.get('_drawer')._showEasing;
+      var easing = (showEasingAnimation) || 'easeOutQuart';
 
-        direction[this.drawerDir] = 0;
-        this.$el.velocity(direction, this.drawerDuration, easing);
-      }
+      direction[this.drawerDir] = 0;
+      this.$el.velocity(direction, this.drawerDuration, easing);
+    }
 
-      function complete() {
-        this.addShadowEvent();
-        Adapt.trigger('drawer:opened');
+    function complete() {
+      this.addShadowEvent();
+      Adapt.trigger('drawer:opened');
 
-        // focus on first tabbable element in drawer
-        Adapt.a11y.focusFirst(this.$el, { defer: true });
-      }
+      // focus on first tabbable element in drawer
+      Adapt.a11y.focusFirst(this.$el, { defer: true });
+    }
 
-    },
+  }
 
-    emptyDrawer: function() {
-      this.$('.drawer__holder').empty();
-    },
+  emptyDrawer() {
+    this.$('.drawer__holder').empty();
+  }
 
-    renderItems: function() {
-      Adapt.trigger('drawer:empty');
-      this.emptyDrawer();
-      var models = this.collection.models;
-      for (var i = 0, len = models.length; i < len; i++) {
-        var item = models[i];
-        new DrawerItemView({ model: item });
-      }
-    },
+  renderItems() {
+    Adapt.trigger('drawer:empty');
+    this.emptyDrawer();
+    var models = this.collection.models;
+    for (var i = 0, len = models.length; i < len; i++) {
+      var item = models[i];
+      new DrawerItemView({ model: item });
+    }
+  }
 
-    hideDrawer: function($toElement) {
-      var direction = {};
-      // only trigger popup:closed if drawer is visible
-      if (this._isVisible) {
-        Adapt.a11y.popupClosed($toElement);
-        this._isVisible = false;
-        Adapt.a11y.scrollEnable('body');
-      } else {
-        return;
-      }
+  hideDrawer($toElement) {
+    var direction = {};
+    // only trigger popup:closed if drawer is visible
+    if (this._isVisible) {
+      Adapt.a11y.popupClosed($toElement);
+      this._isVisible = false;
+      Adapt.a11y.scrollEnable('body');
+    } else {
+      return;
+    }
 
-      if (this.disableAnimation) {
+    if (this.disableAnimation) {
 
-        direction[this.drawerDir] = -this.$el.width();
+      direction[this.drawerDir] = -this.$el.width();
+      this.$el
+        .css(direction)
+        .addClass('u-display-none')
+        .attr('aria-hidden', 'true');
+
+      $('.js-shadow').addClass('u-display-none');
+
+      Adapt.trigger('drawer:closed');
+
+    } else {
+
+      var showEasingAnimation = Adapt.config.get('_drawer')._hideEasing;
+      var easing = (showEasingAnimation) || 'easeOutQuart';
+
+      direction[this.drawerDir] = -this.$el.width();
+      this.$el.velocity(direction, this.drawerDuration, easing, _.bind(function() {
         this.$el
-          .css(direction)
           .addClass('u-display-none')
           .attr('aria-hidden', 'true');
 
-        $('.js-shadow').addClass('u-display-none');
-
         Adapt.trigger('drawer:closed');
+      }, this));
 
-      } else {
+      $('.js-shadow').velocity({ opacity: 0 }, { duration: this.drawerDuration,
+        complete() {
+          $('.js-shadow').addClass('u-display-none');
+        } });
 
-        var showEasingAnimation = Adapt.config.get('_drawer')._hideEasing;
-        var easing = (showEasingAnimation) || 'easeOutQuart';
-
-        direction[this.drawerDir] = -this.$el.width();
-        this.$el.velocity(direction, this.drawerDuration, easing, _.bind(function() {
-          this.$el
-            .addClass('u-display-none')
-            .attr('aria-hidden', 'true');
-
-          Adapt.trigger('drawer:closed');
-        }, this));
-
-        $('.js-shadow').velocity({ opacity: 0 }, { duration: this.drawerDuration,
-          complete: function() {
-            $('.js-shadow').addClass('u-display-none');
-          } });
-
-      }
-
-      this._isCustomViewVisible = false;
-      this.removeShadowEvent();
-
-    },
-
-    addShadowEvent: function() {
-      $('.js-shadow').one('click touchstart', function() {
-        this.onCloseDrawer();
-      }.bind(this));
-    },
-
-    removeShadowEvent: function() {
-      $('.js-shadow').off('click touchstart');
-    },
-
-    remove: function() {
-      Backbone.View.prototype.remove.apply(this, arguments);
-      $(window).off('keyup', this._onKeyUp);
-
-      Adapt.trigger('drawer:empty');
-      this.collection.reset();
-      $('.js-shadow').remove();
     }
 
-  }, {
-    childContainer: '.js-drawer-holder',
-    childView: DrawerItemView
-  });
+    this._isCustomViewVisible = false;
+    this.removeShadowEvent();
 
-  return DrawerView;
+  }
 
+  addShadowEvent() {
+    $('.js-shadow').one('click touchstart', function() {
+      this.onCloseDrawer();
+    }.bind(this));
+  }
+
+  removeShadowEvent() {
+    $('.js-shadow').off('click touchstart');
+  }
+
+  remove() {
+    Backbone.View.prototype.remove.apply(this, arguments);
+    $(window).off('keyup', this._onKeyUp);
+
+    Adapt.trigger('drawer:empty');
+    this.collection.reset();
+    $('.js-shadow').remove();
+  }
+
+}
+
+Object.assign(DrawerView, {
+  childContainer: '.js-drawer-holder',
+  childView: DrawerItemView
 });
+
+export default DrawerView;

--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -91,12 +91,11 @@ class DrawerView extends Backbone.View {
   }
 
   checkIfDrawerIsAvailable() {
-    if (this.collection.length === 0) {
-      $('.js-nav-drawer-btn').addClass('u-display-none');
+    const isEmptyDrawer = (this.collection.length === 0);
+    $('.js-nav-drawer-btn').toggleClass('u-display-none', isEmptyDrawer);
+    if (isEmptyDrawer) {
       Adapt.trigger('drawer:noItems');
-      return;
     }
-    $('.js-nav-drawer-btn').removeClass('u-display-none');
   }
 
   onBackButtonClicked(event) {
@@ -154,11 +153,8 @@ class DrawerView extends Backbone.View {
         Adapt.trigger('drawer:openedItemView');
       }
     } else {
-      if (this._hasBackButton && this.collection.models.length > 1) {
-        this.$('.drawer__back').removeClass('u-display-none');
-      } else {
-        this.$('.drawer__back').addClass('u-display-none');
-      }
+      const hideDrawerBackButton = (!this._hasBackButton || this.collection.models.length <= 1);
+      this.$('.drawer__back').toggleClass('u-display-none', hideDrawerBackButton);
       Adapt.trigger('drawer:openedCustomView');
     }
 

--- a/src/core/js/views/drawerView.js
+++ b/src/core/js/views/drawerView.js
@@ -63,9 +63,9 @@ class DrawerView extends Backbone.View {
   }
 
   render() {
-    var template = Handlebars.templates['drawer'];
+    const template = Handlebars.templates['drawer'];
     $(this.el).html(template({ _globals: Adapt.course.get('_globals') })).prependTo('body');
-    var shadowTemplate = Handlebars.templates['shadow'];
+    const shadowTemplate = Handlebars.templates['shadow'];
     $(shadowTemplate()).prependTo('body');
     // Set defer on post render
     _.defer(_.bind(function() {
@@ -159,7 +159,7 @@ class DrawerView extends Backbone.View {
     }
 
     // delay drawer animation until after background fadeout animation is complete
-    var direction = {};
+    const direction = {};
     if (this.disableAnimation) {
       $('.js-shadow').removeClass('u-display-none');
       $('.js-drawer-holder').scrollTop(0);
@@ -175,8 +175,8 @@ class DrawerView extends Backbone.View {
         complete.call(this);
       }, this) });
 
-      var showEasingAnimation = Adapt.config.get('_drawer')._showEasing;
-      var easing = (showEasingAnimation) || 'easeOutQuart';
+      const showEasingAnimation = Adapt.config.get('_drawer')._showEasing;
+      const easing = (showEasingAnimation) || 'easeOutQuart';
 
       direction[this.drawerDir] = 0;
       this.$el.velocity(direction, this.drawerDuration, easing);
@@ -199,15 +199,15 @@ class DrawerView extends Backbone.View {
   renderItems() {
     Adapt.trigger('drawer:empty');
     this.emptyDrawer();
-    var models = this.collection.models;
-    for (var i = 0, len = models.length; i < len; i++) {
-      var item = models[i];
+    const models = this.collection.models;
+    for (let i = 0, len = models.length; i < len; i++) {
+      const item = models[i];
       new DrawerItemView({ model: item });
     }
   }
 
   hideDrawer($toElement) {
-    var direction = {};
+    const direction = {};
     // only trigger popup:closed if drawer is visible
     if (this._isVisible) {
       Adapt.a11y.popupClosed($toElement);
@@ -231,8 +231,8 @@ class DrawerView extends Backbone.View {
 
     } else {
 
-      var showEasingAnimation = Adapt.config.get('_drawer')._hideEasing;
-      var easing = (showEasingAnimation) || 'easeOutQuart';
+      const showEasingAnimation = Adapt.config.get('_drawer')._hideEasing;
+      const easing = (showEasingAnimation) || 'easeOutQuart';
 
       direction[this.drawerDir] = -this.$el.width();
       this.$el.velocity(direction, this.drawerDuration, easing, _.bind(function() {

--- a/src/core/js/views/headingView.js
+++ b/src/core/js/views/headingView.js
@@ -1,35 +1,31 @@
-define([
-  'core/js/adapt'
-], function(Adapt) {
+import Adapt from 'core/js/adapt';
 
-  var HeadingView = Backbone.View.extend({
+class HeadingView extends Backbone.View {
 
-    initialize: function() {
-      this.listenTo(Adapt.parentView, 'postRemove', this.remove);
-      this.listenTo(this.model, 'change:_isComplete', this.render);
-      this.render();
-    },
+  initialize() {
+    this.listenTo(Adapt.parentView, 'postRemove', this.remove);
+    this.listenTo(this.model, 'change:_isComplete', this.render);
+    this.render();
+  }
 
-    render: function() {
-      var template = Handlebars.templates[this.constructor.template];
-      var data = this.model.toJSON();
-      var customHeadingType = this.$el.attr('data-a11y-heading-type');
-      if (customHeadingType) data._type = customHeadingType;
-      this.$el.html(template(data));
-      this.checkCompletion();
-    },
+  render() {
+    var template = Handlebars.templates[this.constructor.template];
+    var data = this.model.toJSON();
+    var customHeadingType = this.$el.attr('data-a11y-heading-type');
+    if (customHeadingType) data._type = customHeadingType;
+    this.$el.html(template(data));
+    this.checkCompletion();
+  }
 
-    checkCompletion: function() {
-      var isComplete = this.model.get('_isComplete');
-      this.$el
-        .toggleClass('is-complete', isComplete)
-        .toggleClass('is-incomplete', !isComplete);
-    }
+  checkCompletion() {
+    var isComplete = this.model.get('_isComplete');
+    this.$el
+      .toggleClass('is-complete', isComplete)
+      .toggleClass('is-incomplete', !isComplete);
+  }
 
-  }, {
-    template: 'heading'
-  });
+}
 
-  return HeadingView;
+HeadingView.template = 'heading';
 
-});
+export default HeadingView;

--- a/src/core/js/views/headingView.js
+++ b/src/core/js/views/headingView.js
@@ -9,16 +9,16 @@ class HeadingView extends Backbone.View {
   }
 
   render() {
-    var template = Handlebars.templates[this.constructor.template];
-    var data = this.model.toJSON();
-    var customHeadingType = this.$el.attr('data-a11y-heading-type');
+    const template = Handlebars.templates[this.constructor.template];
+    const data = this.model.toJSON();
+    const customHeadingType = this.$el.attr('data-a11y-heading-type');
     if (customHeadingType) data._type = customHeadingType;
     this.$el.html(template(data));
     this.checkCompletion();
   }
 
   checkCompletion() {
-    var isComplete = this.model.get('_isComplete');
+    const isComplete = this.model.get('_isComplete');
     this.$el
       .toggleClass('is-complete', isComplete)
       .toggleClass('is-incomplete', !isComplete);

--- a/src/core/js/views/menuItemView.js
+++ b/src/core/js/views/menuItemView.js
@@ -1,44 +1,40 @@
-define([
-  'core/js/views/adaptView'
-], function(AdaptView) {
+import AdaptView from 'core/js/views/adaptView';
 
-  class MenuItemView extends AdaptView {
+class MenuItemView extends AdaptView {
 
-    attributes() {
-      return AdaptView.resultExtend('attributes', {
-        'role': 'listitem',
-        'aria-labelledby': this.model.get('_id') + '-heading'
-      }, this);
-    }
-
-    className() {
-      return [
-        'menu-item',
-        this.constructor.className,
-        this.model.get('_id'),
-        this.model.get('_classes'),
-        this.setVisibility(),
-        this.setHidden(),
-        (this.model.get('_isVisited') ? 'is-visited' : ''),
-        (this.model.get('_isComplete') ? 'is-complete' : ''),
-        (this.model.get('_isLocked') ? 'is-locked' : ''),
-        (this.model.get('_isOptional') ? 'is-optional' : '')
-      ].join(' ');
-    }
-
-    preRender() {
-      this.model.checkCompletionStatus();
-      this.model.checkInteractionCompletionStatus();
-    }
-
-    postRender() {
-      this.$el.imageready(this.setReadyStatus.bind(this));
-    }
-
+  attributes() {
+    return AdaptView.resultExtend('attributes', {
+      'role': 'listitem',
+      'aria-labelledby': this.model.get('_id') + '-heading'
+    }, this);
   }
 
-  MenuItemView.type = 'menuItem';
+  className() {
+    return [
+      'menu-item',
+      this.constructor.className,
+      this.model.get('_id'),
+      this.model.get('_classes'),
+      this.setVisibility(),
+      this.setHidden(),
+      (this.model.get('_isVisited') ? 'is-visited' : ''),
+      (this.model.get('_isComplete') ? 'is-complete' : ''),
+      (this.model.get('_isLocked') ? 'is-locked' : ''),
+      (this.model.get('_isOptional') ? 'is-optional' : '')
+    ].join(' ');
+  }
 
-  return MenuItemView;
+  preRender() {
+    this.model.checkCompletionStatus();
+    this.model.checkInteractionCompletionStatus();
+  }
 
-});
+  postRender() {
+    this.$el.imageready(this.setReadyStatus.bind(this));
+  }
+
+}
+
+MenuItemView.type = 'menuItem';
+
+export default MenuItemView;

--- a/src/core/js/views/menuView.js
+++ b/src/core/js/views/menuView.js
@@ -1,22 +1,18 @@
-define([
-  'core/js/views/contentObjectView',
-  'core/js/views/menuItemView'
-], function(ContentObjectView, MenuItemView) {
+import ContentObjectView from 'core/js/views/contentObjectView';
+import MenuItemView from 'core/js/views/menuItemView';
 
-  class MenuView extends ContentObjectView {}
+class MenuView extends ContentObjectView {}
 
-  Object.assign(MenuView, {
-    /**
-     * TODO:
-     * child view here should not be fixed to the MenuItemView
-     * menus may currently rely on this
-     */
-    childContainer: '.js-children',
-    childView: MenuItemView,
-    type: 'menu',
-    template: 'menu'
-  });
-
-  return MenuView;
-
+Object.assign(MenuView, {
+  /**
+   * TODO:
+   * child view here should not be fixed to the MenuItemView
+   * menus may currently rely on this
+   */
+  childContainer: '.js-children',
+  childView: MenuItemView,
+  type: 'menu',
+  template: 'menu'
 });
+
+export default MenuView;

--- a/src/core/js/views/navigationView.js
+++ b/src/core/js/views/navigationView.js
@@ -1,92 +1,88 @@
-define([
-  'core/js/adapt'
-], function(Adapt) {
+import Adapt from 'core/js/adapt';
 
-  class NavigationView extends Backbone.View {
+class NavigationView extends Backbone.View {
 
-    className() {
-      return 'nav';
-    }
-
-    events() {
-      return {
-        'click [data-event]': 'triggerEvent'
-      };
-    }
-
-    attributes() {
-      return {
-        'role': 'navigation'
-      };
-    }
-
-    initialize() {
-      this.listenToOnce(Adapt, {
-        'courseModel:dataLoading': this.remove
-      });
-      this.listenTo(Adapt, 'router:menu router:page', this.hideNavigationButton);
-      this.preRender();
-    }
-
-    preRender() {
-      Adapt.trigger('navigationView:preRender', this);
-      this.render();
-    }
-
-    render() {
-      const template = Handlebars.templates[this.constructor.template];
-      this.$el.html(template({
-        _globals: Adapt.course.get('_globals'),
-        _accessibility: Adapt.config.get('_accessibility')
-      })).insertBefore('#app');
-
-      _.defer(() => {
-        Adapt.trigger('navigationView:postRender', this);
-      });
-
-      return this;
-    }
-
-    triggerEvent(event) {
-      event.preventDefault();
-      const currentEvent = $(event.currentTarget).attr('data-event');
-      Adapt.trigger('navigation:' + currentEvent);
-      switch (currentEvent) {
-        case 'backButton':
-          Adapt.router.navigateToPreviousRoute();
-          break;
-        case 'homeButton':
-          Adapt.router.navigateToHomeRoute();
-          break;
-        case 'parentButton':
-          Adapt.router.navigateToParent();
-          break;
-        case 'skipNavigation':
-          this.skipNavigation();
-          break;
-        case 'returnToStart':
-          Adapt.startController.returnToStartLocation();
-          break;
-      }
-    }
-
-    skipNavigation() {
-      Adapt.a11y.focusFirst('.' + Adapt.location._contentType);
-    }
-
-    hideNavigationButton(model) {
-      const shouldHide = (model.get('_type') === 'course');
-      this.$('.nav__back-btn, .nav__home-btn').toggleClass('u-display-none', shouldHide);
-    }
-
-    showNavigationButton() {
-      this.$('.nav__back-btn, .nav__home-btn').removeClass('u-display-none');
-    }
-
+  className() {
+    return 'nav';
   }
 
-  NavigationView.template = 'nav';
+  events() {
+    return {
+      'click [data-event]': 'triggerEvent'
+    };
+  }
 
-  return NavigationView;
+  attributes() {
+    return {
+      'role': 'navigation'
+    };
+  }
 
-});
+  initialize() {
+    this.listenToOnce(Adapt, {
+      'courseModel:dataLoading': this.remove
+    });
+    this.listenTo(Adapt, 'router:menu router:page', this.hideNavigationButton);
+    this.preRender();
+  }
+
+  preRender() {
+    Adapt.trigger('navigationView:preRender', this);
+    this.render();
+  }
+
+  render() {
+    const template = Handlebars.templates[this.constructor.template];
+    this.$el.html(template({
+      _globals: Adapt.course.get('_globals'),
+      _accessibility: Adapt.config.get('_accessibility')
+    })).insertBefore('#app');
+
+    _.defer(() => {
+      Adapt.trigger('navigationView:postRender', this);
+    });
+
+    return this;
+  }
+
+  triggerEvent(event) {
+    event.preventDefault();
+    const currentEvent = $(event.currentTarget).attr('data-event');
+    Adapt.trigger('navigation:' + currentEvent);
+    switch (currentEvent) {
+      case 'backButton':
+        Adapt.router.navigateToPreviousRoute();
+        break;
+      case 'homeButton':
+        Adapt.router.navigateToHomeRoute();
+        break;
+      case 'parentButton':
+        Adapt.router.navigateToParent();
+        break;
+      case 'skipNavigation':
+        this.skipNavigation();
+        break;
+      case 'returnToStart':
+        Adapt.startController.returnToStartLocation();
+        break;
+    }
+  }
+
+  skipNavigation() {
+    Adapt.a11y.focusFirst('.' + Adapt.location._contentType);
+  }
+
+  hideNavigationButton(model) {
+    const shouldHide = (model.get('_type') === 'course');
+    this.$('.nav__back-btn, .nav__home-btn').toggleClass('u-display-none', shouldHide);
+  }
+
+  showNavigationButton() {
+    this.$('.nav__back-btn, .nav__home-btn').removeClass('u-display-none');
+  }
+
+}
+
+NavigationView.template = 'nav';
+
+export default NavigationView;

--- a/src/core/js/views/notifyPushView.js
+++ b/src/core/js/views/notifyPushView.js
@@ -1,124 +1,122 @@
-define([
-  'core/js/adapt'
-], function (Adapt) {
+import Adapt from 'core/js/adapt';
 
-  var NotifyPushView = Backbone.View.extend({
+export default class NotifyPushView extends Backbone.View {
 
-    className: function () {
-      var classes = 'notify-push ';
-      classes += (this.model.get('_classes') || '');
-      return classes;
-    },
+  className() {
+    var classes = 'notify-push ';
+    classes += (this.model.get('_classes') || '');
+    return classes;
+  }
 
-    attributes: {
+  attributes() {
+    return {
       'role': 'dialog',
       'aria-labelledby': 'notify-push-heading',
       'aria-modal': 'false'
-    },
+    };
+  }
 
-    initialize: function () {
-      this.listenTo(Adapt, {
-        'notify:pushShown notify:pushRemoved': this.updateIndexPosition,
-        'remove': this.remove
-      });
+  initialize() {
+    this.listenTo(Adapt, {
+      'notify:pushShown notify:pushRemoved': this.updateIndexPosition,
+      'remove': this.remove
+    });
 
-      this.listenTo(this.model.collection, {
-        'remove': this.updateIndexPosition,
-        'change:_index': this.updatePushPosition
-      });
+    this.listenTo(this.model.collection, {
+      'remove': this.updateIndexPosition,
+      'change:_index': this.updatePushPosition
+    });
 
-      this.preRender();
-      this.render();
-    },
+    this.preRender();
+    this.render();
+  }
 
-    events: {
+  events() {
+    return {
       'click .js-notify-push-close-btn': 'closePush',
       'click .js-notify-push-inner': 'triggerEvent'
-    },
+    };
+  }
 
-    preRender: function () {
-      this.hasBeenRemoved = false;
-    },
+  preRender() {
+    this.hasBeenRemoved = false;
+  }
 
-    render: function () {
-      var data = this.model.toJSON();
-      var template = Handlebars.templates['notifyPush'];
-      this.$el.html(template(data)).appendTo('#wrapper');
+  render() {
+    var data = this.model.toJSON();
+    var template = Handlebars.templates['notifyPush'];
+    this.$el.html(template(data)).appendTo('#wrapper');
 
-      _.defer(this.postRender.bind(this));
+    _.defer(this.postRender.bind(this));
 
-      return this;
-    },
+    return this;
+  }
 
-    postRender: function () {
-      this.$el.addClass('is-active');
+  postRender() {
+    this.$el.addClass('is-active');
 
-      _.delay(this.closePush.bind(this), this.model.get('_timeout'));
+    _.delay(this.closePush.bind(this), this.model.get('_timeout'));
 
-      Adapt.trigger('notify:pushShown');
-    },
+    Adapt.trigger('notify:pushShown');
+  }
 
-    closePush: function (event) {
-      if (event) {
-        event.preventDefault();
-      }
+  closePush(event) {
+    if (event) {
+      event.preventDefault();
+    }
 
-      // Check whether this view has been removed as the delay can cause it to be fired twice
-      if (this.hasBeenRemoved === false) {
+    // Check whether this view has been removed as the delay can cause it to be fired twice
+    if (this.hasBeenRemoved === false) {
 
-        this.hasBeenRemoved = true;
+      this.hasBeenRemoved = true;
 
-        this.$el.removeClass('is-active');
+      this.$el.removeClass('is-active');
 
-        _.delay(function () {
-          this.model.collection.remove(this.model);
-          Adapt.trigger('notify:pushRemoved', this);
-          this.remove();
-        }.bind(this), 600);
-      }
-    },
+      _.delay(function () {
+        this.model.collection.remove(this.model);
+        Adapt.trigger('notify:pushRemoved', this);
+        this.remove();
+      }.bind(this), 600);
+    }
+  }
 
-    triggerEvent: function (event) {
-      Adapt.trigger(this.model.get('_callbackEvent'));
-      this.closePush();
-    },
+  triggerEvent(event) {
+    Adapt.trigger(this.model.get('_callbackEvent'));
+    this.closePush();
+  }
 
-    updateIndexPosition: function () {
-      if (!this.hasBeenRemoved) {
-        var models = this.model.collection.models;
-        for (var i = 0, len = models.length; i < len; i++) {
-          var index = i;
-          var model = models[i];
-          if (model.get('_isActive') === true) {
-            model.set('_index', index);
-            this.updatePushPosition();
-          }
+  updateIndexPosition() {
+    if (!this.hasBeenRemoved) {
+      var models = this.model.collection.models;
+      for (var i = 0, len = models.length; i < len; i++) {
+        var index = i;
+        var model = models[i];
+        if (model.get('_isActive') === true) {
+          model.set('_index', index);
+          this.updatePushPosition();
         }
-      }
-    },
-
-    updatePushPosition: function () {
-      if (this.hasBeenRemoved) {
-        return;
-      }
-
-      if (typeof this.model.get('_index') !== 'undefined') {
-        var elementHeight = this.$el.height();
-        var offset = 20;
-        var navigationHeight = $('.nav').height();
-        var currentIndex = this.model.get('_index');
-        var flippedIndex = (currentIndex === 0) ? 1 : 0;
-
-        if (this.model.collection.where({ _isActive: true }).length === 1) {
-          flippedIndex = 0;
-        }
-
-        var positionLowerPush = (elementHeight + offset) * flippedIndex + navigationHeight + offset;
-        this.$el.css('top', positionLowerPush);
       }
     }
-  });
+  }
 
-  return NotifyPushView;
+  updatePushPosition() {
+    if (this.hasBeenRemoved) {
+      return;
+    }
 
-});
+    if (typeof this.model.get('_index') !== 'undefined') {
+      var elementHeight = this.$el.height();
+      var offset = 20;
+      var navigationHeight = $('.nav').height();
+      var currentIndex = this.model.get('_index');
+      var flippedIndex = (currentIndex === 0) ? 1 : 0;
+
+      if (this.model.collection.where({ _isActive: true }).length === 1) {
+        flippedIndex = 0;
+      }
+
+      var positionLowerPush = (elementHeight + offset) * flippedIndex + navigationHeight + offset;
+      this.$el.css('top', positionLowerPush);
+    }
+  }
+}

--- a/src/core/js/views/notifyPushView.js
+++ b/src/core/js/views/notifyPushView.js
@@ -3,7 +3,7 @@ import Adapt from 'core/js/adapt';
 export default class NotifyPushView extends Backbone.View {
 
   className() {
-    var classes = 'notify-push ';
+    let classes = 'notify-push ';
     classes += (this.model.get('_classes') || '');
     return classes;
   }
@@ -43,8 +43,8 @@ export default class NotifyPushView extends Backbone.View {
   }
 
   render() {
-    var data = this.model.toJSON();
-    var template = Handlebars.templates['notifyPush'];
+    const data = this.model.toJSON();
+    const template = Handlebars.templates['notifyPush'];
     this.$el.html(template(data)).appendTo('#wrapper');
 
     _.defer(this.postRender.bind(this));
@@ -87,10 +87,10 @@ export default class NotifyPushView extends Backbone.View {
 
   updateIndexPosition() {
     if (!this.hasBeenRemoved) {
-      var models = this.model.collection.models;
-      for (var i = 0, len = models.length; i < len; i++) {
-        var index = i;
-        var model = models[i];
+      const models = this.model.collection.models;
+      for (let i = 0, len = models.length; i < len; i++) {
+        const index = i;
+        const model = models[i];
         if (model.get('_isActive') === true) {
           model.set('_index', index);
           this.updatePushPosition();
@@ -105,17 +105,17 @@ export default class NotifyPushView extends Backbone.View {
     }
 
     if (typeof this.model.get('_index') !== 'undefined') {
-      var elementHeight = this.$el.height();
-      var offset = 20;
-      var navigationHeight = $('.nav').height();
-      var currentIndex = this.model.get('_index');
-      var flippedIndex = (currentIndex === 0) ? 1 : 0;
+      const elementHeight = this.$el.height();
+      const offset = 20;
+      const navigationHeight = $('.nav').height();
+      const currentIndex = this.model.get('_index');
+      let flippedIndex = (currentIndex === 0) ? 1 : 0;
 
       if (this.model.collection.where({ _isActive: true }).length === 1) {
         flippedIndex = 0;
       }
 
-      var positionLowerPush = (elementHeight + offset) * flippedIndex + navigationHeight + offset;
+      const positionLowerPush = (elementHeight + offset) * flippedIndex + navigationHeight + offset;
       this.$el.css('top', positionLowerPush);
     }
   }

--- a/src/core/js/views/notifyPushView.js
+++ b/src/core/js/views/notifyPushView.js
@@ -72,11 +72,11 @@ export default class NotifyPushView extends Backbone.View {
 
       this.$el.removeClass('is-active');
 
-      _.delay(function () {
+      _.delay(() => {
         this.model.collection.remove(this.model);
         Adapt.trigger('notify:pushRemoved', this);
         this.remove();
-      }.bind(this), 600);
+      }, 600);
     }
   }
 
@@ -86,17 +86,13 @@ export default class NotifyPushView extends Backbone.View {
   }
 
   updateIndexPosition() {
-    if (!this.hasBeenRemoved) {
-      const models = this.model.collection.models;
-      for (let i = 0, len = models.length; i < len; i++) {
-        const index = i;
-        const model = models[i];
-        if (model.get('_isActive') === true) {
-          model.set('_index', index);
-          this.updatePushPosition();
-        }
-      }
-    }
+    if (this.hasBeenRemoved) return;
+    const models = this.model.collection.models;
+    models.forEach((model, index) => {
+      if (!model.get('_isActive')) return;
+      model.set('_index', index);
+      this.updatePushPosition();
+    });
   }
 
   updatePushPosition() {

--- a/src/core/js/views/notifyView.js
+++ b/src/core/js/views/notifyView.js
@@ -193,7 +193,7 @@ export default class NotifyView extends Backbone.View {
 
   closeNotify() {
     // Make sure that only the top most notify is closed
-    const stackItem = Adapt.notify.stack[Adapt.notify.stack.length-1];
+    const stackItem = Adapt.notify.stack[Adapt.notify.stack.length - 1];
     if (this !== stackItem) return;
     Adapt.notify.stack.pop();
     // Prevent from being invoked multiple times - see https://github.com/adaptlearning/adapt_framework/issues/1659

--- a/src/core/js/views/notifyView.js
+++ b/src/core/js/views/notifyView.js
@@ -1,268 +1,262 @@
-define([
-  'core/js/adapt',
-  "core/js/views/adaptView"
-], function(Adapt, AdaptView) {
+import Adapt from 'core/js/adapt';
+import AdaptView from 'core/js/views/adaptView';
 
-  class NotifyView extends Backbone.View {
+export default class NotifyView extends Backbone.View {
 
-    className() {
-      return `notify ${this.model.get('_classes') || ''}`;
-    }
-
-    attributes () {
-      return Object.assign({
-        role: 'dialog',
-        'aria-labelledby': 'notify-heading',
-        'aria-modal': 'true'
-      }, this.model.get('_attributes'));
-    }
-
-    events() {
-      return {
-        'click .js-notify-btn-alert': 'onAlertButtonClicked',
-        'click .js-notify-btn-prompt': 'onPromptButtonClicked',
-        'click .js-notify-close-btn': 'onCloseButtonClicked',
-        'click .js-notify-shadow-click': 'onShadowClicked'
-      };
-    }
-
-    initialize() {
-      _.bindAll(this, 'resetNotifySize', 'onKeyUp');
-      this.disableAnimation = Adapt.config.get('_disableAnimation') || false;
-      this.isOpen = false;
-      this.hasOpened = false;
-      this.setupEventListeners();
-      this.render();
-    }
-
-    setupEventListeners() {
-      this.listenTo(Adapt, {
-        'remove page:scrollTo': this.closeNotify,
-        'notify:resize': this.resetNotifySize,
-        'notify:cancel': this.cancelNotify,
-        'notify:close': this.closeNotify,
-        'device:resize': this.resetNotifySize
-      });
-      this.setupEscapeKey();
-    }
-
-    setupEscapeKey() {
-      $(window).on('keyup', this.onKeyUp);
-    }
-
-    onKeyUp(event) {
-      if (event.which !== 27) return;
-      event.preventDefault();
-      this.cancelNotify();
-    }
-
-    render() {
-      const data = this.model.toJSON();
-      const template = Handlebars.templates.notify;
-      // hide notify container
-      this.$el.css('visibility', 'hidden');
-      // attach popup + shadow
-      this.$el.html(template(data)).appendTo('body');
-      // hide popup
-      this.$('.notify__popup').css('visibility', 'hidden');
-      // show notify container
-      this.$el.css('visibility', 'visible');
-      this.showNotify();
-      return this;
-    }
-
-    onAlertButtonClicked(event) {
-      event.preventDefault();
-      // tab index preservation, notify must close before subsequent callback is triggered
-      this.closeNotify();
-      Adapt.trigger(this.model.get('_callbackEvent'), this);
-    }
-
-    onPromptButtonClicked(event) {
-      event.preventDefault();
-      // tab index preservation, notify must close before subsequent callback is triggered
-      this.closeNotify();
-      Adapt.trigger($(event.currentTarget).attr('data-event'), this);
-    }
-
-    onCloseButtonClicked(event) {
-      event.preventDefault();
-      // tab index preservation, notify must close before subsequent callback is triggered
-      this.cancelNotify();
-    }
-
-    onShadowClicked(event) {
-      event.preventDefault();
-      if (this.model.get('_closeOnShadowClick') === false) return;
-      this.cancelNotify();
-    }
-
-    cancelNotify() {
-      if (this.model.get('_isCancellable') === false) return;
-      // tab index preservation, notify must close before subsequent callback is triggered
-      this.closeNotify();
-      Adapt.trigger('notify:cancelled', this);
-    }
-
-    resetNotifySize() {
-      if (!this.hasOpened) return;
-      this.resizeNotify();
-    }
-
-    resizeNotify() {
-      const windowHeight = $(window).height();
-      const notifyHeight = this.$('.notify__popup-inner').outerHeight();
-      const isFullWindow = (notifyHeight >= windowHeight);
-      this.$('.notify__popup').css({
-        'height': isFullWindow ? '100%' : 'auto',
-        'top': isFullWindow ? 0 : '',
-        'margin-top': isFullWindow ? '' : -(notifyHeight / 2),
-        'overflow-y': isFullWindow ? 'scroll' : '',
-        '-webkit-overflow-scrolling': isFullWindow ? 'touch' : ''
-      });
-    }
-
-    async showNotify() {
-      this.isOpen = true;
-      await this.addSubView();
-      // Add to the list of open popups
-      Adapt.notify.stack.push(this);
-      // Keep focus from previous action
-      this.$previousActiveElement = $(document.activeElement);
-      Adapt.trigger('notify:opened', this);
-      this.$el.imageready(this.onLoaded.bind(this));
-    }
-
-    onLoaded() {
-      if (this.disableAnimation) {
-        this.$('.notify__shadow').css('display', 'block');
-      } else {
-        this.$('.notify__shadow').velocity({ opacity: 0 }, { duration: 0 }).velocity({ opacity: 1 }, { duration: 400,
-          begin: () => {
-            this.$('.notify__shadow').css('display', 'block');
-          }
-        });
-      }
-      this.resizeNotify();
-      if (this.disableAnimation) {
-        this.$('.notify__popup').css('visibility', 'visible');
-        this.onOpened();
-      } else {
-        this.$('.notify__popup').velocity({ opacity: 0 }, { duration: 0 }).velocity({ opacity: 1 }, { duration: 400,
-          begin: () => {
-            // Make sure to make the notify visible and then set
-            // focus, disabled scroll and manage tabs
-            this.$('.notify__popup').css('visibility', 'visible');
-            this.onOpened();
-          }
-        });
-      }
-    }
-
-    onOpened() {
-      $.inview();
-      this.hasOpened = true;
-      // Allows popup manager to control focus
-      Adapt.a11y.popupOpened(this.$('.notify__popup'));
-      Adapt.a11y.scrollDisable('body');
-      $('html').addClass('notify');
-      // Set focus to first accessible element
-      Adapt.a11y.focusFirst(this.$('.notify__popup'), { defer: false });
-    }
-
-    async addSubView() {
-      this.subView = this.model.get('_view');
-      if (this.model.get('_id')) {
-        // Automatically render the specified id
-        const model = Adapt.findById(this.model.get('_id'));
-        const View = Adapt.getViewClass(model);
-        this.subView = new View({ model });
-      }
-      if (!this.subView) return;
-      this.subView.$el.on('resize', this.resetNotifySize);
-      this.$('.notify__content-inner').prepend(this.subView.$el);
-      if (!(this.subView instanceof AdaptView) || this.subView.model.get('_isReady')) return;
-      // Wait for the AdaptView subview to be ready
-      return new Promise(resolve => {
-        const check = (model, value) => {
-          if (!value) return;
-          this.subView.model.off('change:_isReady', check);
-          resolve();
-        }
-        this.subView.model.on('change:_isReady', check);
-      });
-    }
-
-    closeNotify() {
-      // Make sure that only the top most notify is closed
-      const stackItem = Adapt.notify.stack[Adapt.notify.stack.length-1];
-      if (this !== stackItem) return;
-      Adapt.notify.stack.pop();
-      // Prevent from being invoked multiple times - see https://github.com/adaptlearning/adapt_framework/issues/1659
-      if (!this.isOpen) return;
-      this.isOpen = false;
-      // If closeNotify is called before showNotify has finished then wait
-      // until it's open.
-      if (this.hasOpened) {
-        this.onCloseReady();
-        return;
-      }
-      this.listenToOnce(Adapt, 'popup:opened', () => {
-        // Wait for popup:opened to finish processing
-        _.defer(this.onCloseReady.bind(this));
-      });
-    }
-
-    onCloseReady() {
-      if (this.disableAnimation) {
-        this.$('.notify__popup').css('visibility', 'hidden');
-        this.$el.css('visibility', 'hidden');
-        this.remove();
-      } else {
-        this.$('.notify__popup').velocity({ opacity: 0 }, { duration: 400,
-          complete: () => {
-            this.$('.notify__popup').css('visibility', 'hidden');
-          }
-        });
-        this.$('.notify__shadow').velocity({ opacity: 0 }, { duration: 400,
-          complete: () => {
-            this.$el.css('visibility', 'hidden');
-            this.remove();
-          }
-        });
-      }
-      Adapt.a11y.scrollEnable('body');
-      $('html').removeClass('notify');
-      // Return focus to previous active element
-      Adapt.a11y.popupClosed(this.$previousActiveElement);
-      // Return reference to the notify view
-      Adapt.trigger('notify:closed', this);
-    }
-
-    remove(...args) {
-      this.removeSubView();
-      $(window).off('keyup', this.onKeyUp);
-      super.remove(...args);
-    }
-
-    removeSubView() {
-      if (!this.subView) return;
-      this.subView.$el.off('resize', this.resetNotifySize);
-      if (this.subView instanceof AdaptView) {
-        // Clear up nested views and models
-        const views = [...this.subView.findDescendantViews(), this.subView];
-        views.forEach(view => {
-          view.model.set('_isReady', false);
-          view.remove();
-        });
-      } else {
-        this.subView.remove();
-      }
-      this.subView = null;
-    }
-
+  className() {
+    return `notify ${this.model.get('_classes') || ''}`;
   }
 
-  return NotifyView;
+  attributes () {
+    return Object.assign({
+      role: 'dialog',
+      'aria-labelledby': 'notify-heading',
+      'aria-modal': 'true'
+    }, this.model.get('_attributes'));
+  }
 
-});
+  events() {
+    return {
+      'click .js-notify-btn-alert': 'onAlertButtonClicked',
+      'click .js-notify-btn-prompt': 'onPromptButtonClicked',
+      'click .js-notify-close-btn': 'onCloseButtonClicked',
+      'click .js-notify-shadow-click': 'onShadowClicked'
+    };
+  }
+
+  initialize() {
+    _.bindAll(this, 'resetNotifySize', 'onKeyUp');
+    this.disableAnimation = Adapt.config.get('_disableAnimation') || false;
+    this.isOpen = false;
+    this.hasOpened = false;
+    this.setupEventListeners();
+    this.render();
+  }
+
+  setupEventListeners() {
+    this.listenTo(Adapt, {
+      'remove page:scrollTo': this.closeNotify,
+      'notify:resize': this.resetNotifySize,
+      'notify:cancel': this.cancelNotify,
+      'notify:close': this.closeNotify,
+      'device:resize': this.resetNotifySize
+    });
+    this.setupEscapeKey();
+  }
+
+  setupEscapeKey() {
+    $(window).on('keyup', this.onKeyUp);
+  }
+
+  onKeyUp(event) {
+    if (event.which !== 27) return;
+    event.preventDefault();
+    this.cancelNotify();
+  }
+
+  render() {
+    const data = this.model.toJSON();
+    const template = Handlebars.templates.notify;
+    // hide notify container
+    this.$el.css('visibility', 'hidden');
+    // attach popup + shadow
+    this.$el.html(template(data)).appendTo('body');
+    // hide popup
+    this.$('.notify__popup').css('visibility', 'hidden');
+    // show notify container
+    this.$el.css('visibility', 'visible');
+    this.showNotify();
+    return this;
+  }
+
+  onAlertButtonClicked(event) {
+    event.preventDefault();
+    // tab index preservation, notify must close before subsequent callback is triggered
+    this.closeNotify();
+    Adapt.trigger(this.model.get('_callbackEvent'), this);
+  }
+
+  onPromptButtonClicked(event) {
+    event.preventDefault();
+    // tab index preservation, notify must close before subsequent callback is triggered
+    this.closeNotify();
+    Adapt.trigger($(event.currentTarget).attr('data-event'), this);
+  }
+
+  onCloseButtonClicked(event) {
+    event.preventDefault();
+    // tab index preservation, notify must close before subsequent callback is triggered
+    this.cancelNotify();
+  }
+
+  onShadowClicked(event) {
+    event.preventDefault();
+    if (this.model.get('_closeOnShadowClick') === false) return;
+    this.cancelNotify();
+  }
+
+  cancelNotify() {
+    if (this.model.get('_isCancellable') === false) return;
+    // tab index preservation, notify must close before subsequent callback is triggered
+    this.closeNotify();
+    Adapt.trigger('notify:cancelled', this);
+  }
+
+  resetNotifySize() {
+    if (!this.hasOpened) return;
+    this.resizeNotify();
+  }
+
+  resizeNotify() {
+    const windowHeight = $(window).height();
+    const notifyHeight = this.$('.notify__popup-inner').outerHeight();
+    const isFullWindow = (notifyHeight >= windowHeight);
+    this.$('.notify__popup').css({
+      'height': isFullWindow ? '100%' : 'auto',
+      'top': isFullWindow ? 0 : '',
+      'margin-top': isFullWindow ? '' : -(notifyHeight / 2),
+      'overflow-y': isFullWindow ? 'scroll' : '',
+      '-webkit-overflow-scrolling': isFullWindow ? 'touch' : ''
+    });
+  }
+
+  async showNotify() {
+    this.isOpen = true;
+    await this.addSubView();
+    // Add to the list of open popups
+    Adapt.notify.stack.push(this);
+    // Keep focus from previous action
+    this.$previousActiveElement = $(document.activeElement);
+    Adapt.trigger('notify:opened', this);
+    this.$el.imageready(this.onLoaded.bind(this));
+  }
+
+  onLoaded() {
+    if (this.disableAnimation) {
+      this.$('.notify__shadow').css('display', 'block');
+    } else {
+      this.$('.notify__shadow').velocity({ opacity: 0 }, { duration: 0 }).velocity({ opacity: 1 }, { duration: 400,
+        begin: () => {
+          this.$('.notify__shadow').css('display', 'block');
+        }
+      });
+    }
+    this.resizeNotify();
+    if (this.disableAnimation) {
+      this.$('.notify__popup').css('visibility', 'visible');
+      this.onOpened();
+    } else {
+      this.$('.notify__popup').velocity({ opacity: 0 }, { duration: 0 }).velocity({ opacity: 1 }, { duration: 400,
+        begin: () => {
+          // Make sure to make the notify visible and then set
+          // focus, disabled scroll and manage tabs
+          this.$('.notify__popup').css('visibility', 'visible');
+          this.onOpened();
+        }
+      });
+    }
+  }
+
+  onOpened() {
+    $.inview();
+    this.hasOpened = true;
+    // Allows popup manager to control focus
+    Adapt.a11y.popupOpened(this.$('.notify__popup'));
+    Adapt.a11y.scrollDisable('body');
+    $('html').addClass('notify');
+    // Set focus to first accessible element
+    Adapt.a11y.focusFirst(this.$('.notify__popup'), { defer: false });
+  }
+
+  async addSubView() {
+    this.subView = this.model.get('_view');
+    if (this.model.get('_id')) {
+      // Automatically render the specified id
+      const model = Adapt.findById(this.model.get('_id'));
+      const View = Adapt.getViewClass(model);
+      this.subView = new View({ model });
+    }
+    if (!this.subView) return;
+    this.subView.$el.on('resize', this.resetNotifySize);
+    this.$('.notify__content-inner').prepend(this.subView.$el);
+    if (!(this.subView instanceof AdaptView) || this.subView.model.get('_isReady')) return;
+    // Wait for the AdaptView subview to be ready
+    return new Promise(resolve => {
+      const check = (model, value) => {
+        if (!value) return;
+        this.subView.model.off('change:_isReady', check);
+        resolve();
+      };
+      this.subView.model.on('change:_isReady', check);
+    });
+  }
+
+  closeNotify() {
+    // Make sure that only the top most notify is closed
+    const stackItem = Adapt.notify.stack[Adapt.notify.stack.length-1];
+    if (this !== stackItem) return;
+    Adapt.notify.stack.pop();
+    // Prevent from being invoked multiple times - see https://github.com/adaptlearning/adapt_framework/issues/1659
+    if (!this.isOpen) return;
+    this.isOpen = false;
+    // If closeNotify is called before showNotify has finished then wait
+    // until it's open.
+    if (this.hasOpened) {
+      this.onCloseReady();
+      return;
+    }
+    this.listenToOnce(Adapt, 'popup:opened', () => {
+      // Wait for popup:opened to finish processing
+      _.defer(this.onCloseReady.bind(this));
+    });
+  }
+
+  onCloseReady() {
+    if (this.disableAnimation) {
+      this.$('.notify__popup').css('visibility', 'hidden');
+      this.$el.css('visibility', 'hidden');
+      this.remove();
+    } else {
+      this.$('.notify__popup').velocity({ opacity: 0 }, { duration: 400,
+        complete: () => {
+          this.$('.notify__popup').css('visibility', 'hidden');
+        }
+      });
+      this.$('.notify__shadow').velocity({ opacity: 0 }, { duration: 400,
+        complete: () => {
+          this.$el.css('visibility', 'hidden');
+          this.remove();
+        }
+      });
+    }
+    Adapt.a11y.scrollEnable('body');
+    $('html').removeClass('notify');
+    // Return focus to previous active element
+    Adapt.a11y.popupClosed(this.$previousActiveElement);
+    // Return reference to the notify view
+    Adapt.trigger('notify:closed', this);
+  }
+
+  remove(...args) {
+    this.removeSubView();
+    $(window).off('keyup', this.onKeyUp);
+    super.remove(...args);
+  }
+
+  removeSubView() {
+    if (!this.subView) return;
+    this.subView.$el.off('resize', this.resetNotifySize);
+    if (this.subView instanceof AdaptView) {
+      // Clear up nested views and models
+      const views = [...this.subView.findDescendantViews(), this.subView];
+      views.forEach(view => {
+        view.model.set('_isReady', false);
+        view.remove();
+      });
+    } else {
+      this.subView.remove();
+    }
+    this.subView = null;
+  }
+
+}

--- a/src/core/js/views/pageView.js
+++ b/src/core/js/views/pageView.js
@@ -1,36 +1,32 @@
-define([
-  'core/js/adapt',
-  'core/js/views/contentObjectView'
-], function(Adapt, ContentObjectView) {
+import Adapt from 'core/js/adapt';
+import ContentObjectView from 'core/js/views/contentObjectView';
 
-  class PageView extends ContentObjectView {
+class PageView extends ContentObjectView {
 
-    preRender() {
-      // checkIfResetOnRevisit on descendant models before render
-      this.model.getAllDescendantModels().forEach(model => {
-        if (!model.checkIfResetOnRevisit) return;
-        model.checkIfResetOnRevisit();
-      });
-      super.preRender();
-    }
-
-    remove() {
-      if (this.$pageLabel) {
-        this.$pageLabel.remove();
-      }
-      super.remove();
-    }
-
+  preRender() {
+    // checkIfResetOnRevisit on descendant models before render
+    this.model.getAllDescendantModels().forEach(model => {
+      if (!model.checkIfResetOnRevisit) return;
+      model.checkIfResetOnRevisit();
+    });
+    super.preRender();
   }
 
-  Object.assign(PageView, {
-    childContainer: '.article__container',
-    type: 'page',
-    template: 'page'
-  });
+  remove() {
+    if (this.$pageLabel) {
+      this.$pageLabel.remove();
+    }
+    super.remove();
+  }
 
-  Adapt.register('page', { view: PageView });
+}
 
-  return PageView;
-
+Object.assign(PageView, {
+  childContainer: '.article__container',
+  type: 'page',
+  template: 'page'
 });
+
+Adapt.register('page', { view: PageView });
+
+export default PageView;

--- a/src/core/js/views/questionView.js
+++ b/src/core/js/views/questionView.js
@@ -1,560 +1,557 @@
-define([
-  'core/js/adapt',
-  'core/js/views/componentView',
-  'core/js/views/buttonsView',
-  'core/js/models/questionModel',
-  'core/js/enums/buttonStateEnum'
-], function(Adapt, ComponentView, ButtonsView, QuestionModel, BUTTON_STATE) {
+import Adapt from 'core/js/adapt';
+import ComponentView from 'core/js/views/componentView';
+import ButtonsView from 'core/js/views/buttonsView';
+import BUTTON_STATE from 'core/js/enums/buttonStateEnum';
 
-  class QuestionView extends ComponentView {
+import 'core/js/models/questionModel';
 
-    className() {
-      return [
-        'component',
-        'is-question',
-        this.model.get('_component').toLowerCase(),
-        this.model.get('_id'),
-        this.model.get('_classes'),
-        this.setVisibility(),
-        'is-' + this.model.get('_layout'),
-        (this.model.get('_isComplete') ? 'is-complete' : ''),
-        (this.model.get('_isOptional') ? 'is-optional' : ''),
-        (this.model.get('_canShowModelAnswer') ? 'can-show-model-answer' : ''),
-        (this.model.get('_canShowFeedback') ? 'can-show-feedback' : ''),
-        (this.model.get('_canShowMarking') ? 'can-show-marking' : '')
-      ].join(' ');
+class QuestionView extends ComponentView {
+
+  className() {
+    return [
+      'component',
+      'is-question',
+      this.model.get('_component').toLowerCase(),
+      this.model.get('_id'),
+      this.model.get('_classes'),
+      this.setVisibility(),
+      'is-' + this.model.get('_layout'),
+      (this.model.get('_isComplete') ? 'is-complete' : ''),
+      (this.model.get('_isOptional') ? 'is-optional' : ''),
+      (this.model.get('_canShowModelAnswer') ? 'can-show-model-answer' : ''),
+      (this.model.get('_canShowFeedback') ? 'can-show-feedback' : ''),
+      (this.model.get('_canShowMarking') ? 'can-show-marking' : '')
+    ].join(' ');
+  }
+
+  preRender() {
+    // Setup listener for _isEnabled
+    this.listenTo(this.model, 'change:_isEnabled', this.onEnabledChanged);
+
+    this.listenTo(this.model, 'question:refresh', this.refresh);
+
+    // Checks to see if the question should be reset on revisit
+    this.checkIfResetOnRevisit();
+    // This method helps setup default settings on the model
+    this._runModelCompatibleFunction('setupDefaultSettings');
+    // Blank method for setting up questions before rendering
+    this.setupQuestion();
+  }
+
+  // Used in the question view to disabled the question when _isEnabled has been set to false
+  onEnabledChanged(model, changedAttribute) {
+
+    // If isEnabled == false add disabled class
+    // else remove disabled class
+    if (!changedAttribute) {
+      this.$('.component__widget').addClass('is-disabled');
+      this.disableQuestion();
+    } else {
+      this.$('.component__widget').removeClass('is-disabled');
+      this.enableQuestion();
     }
 
-    preRender() {
-      // Setup listener for _isEnabled
-      this.listenTo(this.model, 'change:_isEnabled', this.onEnabledChanged);
+  }
 
-      this.listenTo(this.model, 'question:refresh', this.refresh);
+  // Used by the question to disable the question during submit and complete stages
+  disableQuestion() {}
 
-      // Checks to see if the question should be reset on revisit
-      this.checkIfResetOnRevisit();
-      // This method helps setup default settings on the model
-      this._runModelCompatibleFunction('setupDefaultSettings');
-      // Blank method for setting up questions before rendering
-      this.setupQuestion();
-    }
+  // Used by the question to enable the question during interactions
+  enableQuestion() {}
 
-    // Used in the question view to disabled the question when _isEnabled has been set to false
-    onEnabledChanged(model, changedAttribute) {
+  // Used to check if the question should reset on revisit
+  checkIfResetOnRevisit() {
+    const isResetOnRevisit = this.model.get('_isResetOnRevisit');
+    // If reset is enabled set defaults
+    // Call blank method for question to handle
+    if (isResetOnRevisit) {
+      this.model.reset(isResetOnRevisit, true);
 
-      // If isEnabled == false add disabled class
-      // else remove disabled class
-      if (!changedAttribute) {
-        this.$('.component__widget').addClass('is-disabled');
-        this.disableQuestion();
-      } else {
-        this.$('.component__widget').removeClass('is-disabled');
-        this.enableQuestion();
-      }
-
-    }
-
-    // Used by the question to disable the question during submit and complete stages
-    disableQuestion() {}
-
-    // Used by the question to enable the question during interactions
-    enableQuestion() {}
-
-    // Used to check if the question should reset on revisit
-    checkIfResetOnRevisit() {
-      const isResetOnRevisit = this.model.get('_isResetOnRevisit');
-      // If reset is enabled set defaults
-      // Call blank method for question to handle
-      if (isResetOnRevisit) {
-        this.model.reset(isResetOnRevisit, true);
-
-        // Defer is added to allow the component to render
-        _.defer(() => {
-          this.resetQuestionOnRevisit(isResetOnRevisit);
-        });
-
-        return;
-      }
-
-      // If complete - display learner's answer
-      // or reset the question if not complete
-      const isInteractionComplete = this.model.get('_isInteractionComplete');
-      if (isInteractionComplete) {
-        this.model.set('_buttonState', BUTTON_STATE.HIDE_CORRECT_ANSWER);
-        // Defer is added to allow the component to render
-        _.defer(() => {
-          this.onHideCorrectAnswerClicked();
-        });
-
-        return;
-      }
-
-      this.model.set('_buttonState', BUTTON_STATE.SUBMIT);
       // Defer is added to allow the component to render
       _.defer(() => {
-        this.onResetClicked();
+        this.resetQuestionOnRevisit(isResetOnRevisit);
       });
+
+      return;
     }
 
-    // Used by the question to reset the question when revisiting the component
-    resetQuestionOnRevisit(type) {}
+    // If complete - display learner's answer
+    // or reset the question if not complete
+    const isInteractionComplete = this.model.get('_isInteractionComplete');
+    if (isInteractionComplete) {
+      this.model.set('_buttonState', BUTTON_STATE.HIDE_CORRECT_ANSWER);
+      // Defer is added to allow the component to render
+      _.defer(() => {
+        this.onHideCorrectAnswerClicked();
+      });
 
-    // Left blank for question setup - should be used instead of preRender
-    setupQuestion() {}
-
-    // Calls default methods to setup after the question is rendered
-    postRender() {
-      this.addButtonsView();
-      this.onQuestionRendered();
+      return;
     }
 
-    // Used to setup buttonsView and sets up the internal events for the question
-    addButtonsView() {
-      this.buttonsView = new ButtonsView({ model: this.model, el: this.$('.btn__container') });
+    this.model.set('_buttonState', BUTTON_STATE.SUBMIT);
+    // Defer is added to allow the component to render
+    _.defer(() => {
+      this.onResetClicked();
+    });
+  }
 
-      this.listenTo(this.buttonsView, 'buttons:stateUpdate', this.onButtonStateUpdate);
+  // Used by the question to reset the question when revisiting the component
+  resetQuestionOnRevisit(type) {}
 
+  // Left blank for question setup - should be used instead of preRender
+  setupQuestion() {}
+
+  // Calls default methods to setup after the question is rendered
+  postRender() {
+    this.addButtonsView();
+    this.onQuestionRendered();
+  }
+
+  // Used to setup buttonsView and sets up the internal events for the question
+  addButtonsView() {
+    this.buttonsView = new ButtonsView({ model: this.model, el: this.$('.btn__container') });
+
+    this.listenTo(this.buttonsView, 'buttons:stateUpdate', this.onButtonStateUpdate);
+
+  }
+
+  onButtonStateUpdate(buttonState) {
+
+    switch (buttonState) {
+      case BUTTON_STATE.SUBMIT:
+        this.onSubmitClicked();
+        break;
+      case BUTTON_STATE.RESET:
+        this.onResetClicked();
+        break;
+      case BUTTON_STATE.SHOW_CORRECT_ANSWER:
+        this.onShowCorrectAnswerClicked();
+        break;
+      case BUTTON_STATE.HIDE_CORRECT_ANSWER:
+        this.onHideCorrectAnswerClicked();
+        break;
+      case BUTTON_STATE.SHOW_FEEDBACK:
+        this.showFeedback();
+        break;
     }
 
-    onButtonStateUpdate(buttonState) {
+  }
 
-      switch (buttonState) {
-        case BUTTON_STATE.SUBMIT:
-          this.onSubmitClicked();
-          break;
-        case BUTTON_STATE.RESET:
-          this.onResetClicked();
-          break;
-        case BUTTON_STATE.SHOW_CORRECT_ANSWER:
-          this.onShowCorrectAnswerClicked();
-          break;
-        case BUTTON_STATE.HIDE_CORRECT_ANSWER:
-          this.onHideCorrectAnswerClicked();
-          break;
-        case BUTTON_STATE.SHOW_FEEDBACK:
-          this.showFeedback();
-          break;
-      }
+  // Blank method used just like postRender is for presentational components
+  onQuestionRendered() {}
 
+  // Triggered when the submit button is clicked
+  onSubmitClicked() {
+    // canSubmit is setup in questions and should return a boolean
+    // If the question stops the user form submitting - show instruction error
+    // and give a blank method, onCannotSubmit to the question
+    const canSubmit = this._runModelCompatibleFunction('canSubmit');
+
+    if (!canSubmit) {
+      this.showInstructionError();
+      this.onCannotSubmit();
+      return;
     }
 
-    // Blank method used just like postRender is for presentational components
-    onQuestionRendered() {}
+    // Used to update the amount of attempts the question has
+    this._runModelCompatibleFunction('updateAttempts');
 
-    // Triggered when the submit button is clicked
-    onSubmitClicked() {
-      // canSubmit is setup in questions and should return a boolean
-      // If the question stops the user form submitting - show instruction error
-      // and give a blank method, onCannotSubmit to the question
-      const canSubmit = this._runModelCompatibleFunction('canSubmit');
+    // Used to set attributes on the model after being submitted
+    // Also adds a class of submitted
+    this._runModelCompatibleFunction('setQuestionAsSubmitted');
 
-      if (!canSubmit) {
-        this.showInstructionError();
-        this.onCannotSubmit();
-        return;
-      }
+    // Used to remove instruction error that is set when
+    // the user has interacted in the wrong way
+    this.removeInstructionError();
 
-      // Used to update the amount of attempts the question has
-      this._runModelCompatibleFunction('updateAttempts');
+    // Used to store the users answer for later
+    // This is a blank method given to the question
+    this._runModelCompatibleFunction('storeUserAnswer');
 
-      // Used to set attributes on the model after being submitted
-      // Also adds a class of submitted
-      this._runModelCompatibleFunction('setQuestionAsSubmitted');
+    // Used to set question as correct:true/false
+    // Calls isCorrect which is blank for the question
+    // to fill out and return a boolean
+    this._runModelCompatibleFunction('markQuestion', 'isCorrect');
 
-      // Used to remove instruction error that is set when
-      // the user has interacted in the wrong way
-      this.removeInstructionError();
+    // Used by the question to set the score on the model
+    this._runModelCompatibleFunction('setScore');
 
-      // Used to store the users answer for later
-      // This is a blank method given to the question
-      this._runModelCompatibleFunction('storeUserAnswer');
+    // Used to check if the question is complete
+    // Triggers setCompletionStatus and adds class to widget
+    this._runModelCompatibleFunction('checkQuestionCompletion');
 
-      // Used to set question as correct:true/false
-      // Calls isCorrect which is blank for the question
-      // to fill out and return a boolean
-      this._runModelCompatibleFunction('markQuestion', 'isCorrect');
-
-      // Used by the question to set the score on the model
-      this._runModelCompatibleFunction('setScore');
-
-      // Used to check if the question is complete
-      // Triggers setCompletionStatus and adds class to widget
-      this._runModelCompatibleFunction('checkQuestionCompletion');
-
-      // Used by the question to display markings on the component
-      if (this.model.shouldShowMarking) {
-        this.showMarking();
-      }
-
-      this.recordInteraction();
-
-      // Used to setup the feedback by checking against
-      // question isCorrect or isPartlyCorrect
-      this._runModelCompatibleFunction('setupFeedback');
-
-      // Used to trigger an event so plugins can display feedback
-      // Do this before updating the buttons so that the focus can be
-      // shifted immediately
-      this.showFeedback();
-
-      // Force height re-calculations before the submit button
-      // becomes disabled.
-      $(window).resize();
-
-      // Used to update buttonsView based upon question state
-      // Update buttons happens before showFeedback to preserve tabindexes and after setupFeedback to allow buttons to use feedback attribute
-      this._runModelCompatibleFunction('updateButtons');
-
-      this.model.onSubmitted();
-      this.onSubmitted();
+    // Used by the question to display markings on the component
+    if (this.model.shouldShowMarking) {
+      this.showMarking();
     }
 
-    showInstructionError() {
-      Adapt.trigger('questionView:showInstructionError', this);
+    this.recordInteraction();
+
+    // Used to setup the feedback by checking against
+    // question isCorrect or isPartlyCorrect
+    this._runModelCompatibleFunction('setupFeedback');
+
+    // Used to trigger an event so plugins can display feedback
+    // Do this before updating the buttons so that the focus can be
+    // shifted immediately
+    this.showFeedback();
+
+    // Force height re-calculations before the submit button
+    // becomes disabled.
+    $(window).resize();
+
+    // Used to update buttonsView based upon question state
+    // Update buttons happens before showFeedback to preserve tabindexes and after setupFeedback to allow buttons to use feedback attribute
+    this._runModelCompatibleFunction('updateButtons');
+
+    this.model.onSubmitted();
+    this.onSubmitted();
+  }
+
+  showInstructionError() {
+    Adapt.trigger('questionView:showInstructionError', this);
+  }
+
+  // Blank method for question to fill out when the question cannot be submitted
+  onCannotSubmit() {}
+
+  // Blank method for question to fill out when the question was successfully submitted
+  onSubmitted() {}
+
+  // Used to set _isEnabled and _isSubmitted on the model
+  // Also adds a 'submitted' class to the widget
+  setQuestionAsSubmitted() {
+    this.model.setQuestionAsSubmitted();
+    this.$('.component__widget').addClass('is-submitted');
+  }
+
+  // Removes validation error class when the user canSubmit
+  removeInstructionError() {
+    this.$('.component__instruction-inner').removeClass('validation-error');
+  }
+
+  // This is important and should give the user feedback on how they answered the question
+  // Normally done through ticks and crosses by adding classes
+  showMarking() {}
+
+  // Checks if the question should be set to complete
+  // Calls setCompletionStatus and adds complete classes
+  checkQuestionCompletion() {
+
+    const isComplete = this.model.checkQuestionCompletion();
+
+    if (isComplete) {
+      this.$('.component__widget').addClass('is-complete show-user-answer');
     }
 
-    // Blank method for question to fill out when the question cannot be submitted
-    onCannotSubmit() {}
+  }
 
-    // Blank method for question to fill out when the question was successfully submitted
-    onSubmitted() {}
-
-    // Used to set _isEnabled and _isSubmitted on the model
-    // Also adds a 'submitted' class to the widget
-    setQuestionAsSubmitted() {
-      this.model.setQuestionAsSubmitted();
-      this.$('.component__widget').addClass('is-submitted');
-    }
-
-    // Removes validation error class when the user canSubmit
-    removeInstructionError() {
-      this.$('.component__instruction-inner').removeClass('validation-error');
-    }
-
-    // This is important and should give the user feedback on how they answered the question
-    // Normally done through ticks and crosses by adding classes
-    showMarking() {}
-
-    // Checks if the question should be set to complete
-    // Calls setCompletionStatus and adds complete classes
-    checkQuestionCompletion() {
-
-      const isComplete = this.model.checkQuestionCompletion();
-
-      if (isComplete) {
-        this.$('.component__widget').addClass('is-complete show-user-answer');
-      }
-
-    }
-
-    recordInteraction() {
-      if (this.model.get('_recordInteraction') === true || !this.model.has('_recordInteraction')) {
-        Adapt.trigger('questionView:recordInteraction', this);
-      }
-    }
-
-    // Used to show feedback based upon whether _canShowFeedback is true
-    showFeedback() {
-
-      if (this.model.get('_canShowFeedback')) {
-        Adapt.trigger('questionView:showFeedback', this);
-      } else {
-        Adapt.trigger('questionView:disabledFeedback', this);
-      }
-
-    }
-
-    onResetClicked() {
-      this.setQuestionAsReset();
-
-      this._runModelCompatibleFunction('resetUserAnswer');
-
-      this.resetQuestion();
-
-      this.model.checkCanSubmit();
-
-      this._runModelCompatibleFunction('updateButtons');
-
-      // onResetClicked is called as part of the checkIfResetOnRevisit
-      // function and as a button click. if the view is already rendered,
-      // then the button was clicked, focus on the first tabbable element
-      if (!this.model.get('_isReady')) return;
-      // Attempt to get the current page location
-      const currentModel = Adapt.findById(Adapt.location._currentId);
-      // Make sure the page is ready
-      if (!currentModel || !currentModel.get('_isReady')) return;
-      // Focus on the first readable item in this element
-      Adapt.a11y.focusNext(this.$el);
-
-    }
-
-    setQuestionAsReset() {
-      this.model.setQuestionAsReset();
-      this.$('.component__widget').removeClass('is-submitted');
-    }
-
-    // Used by the question view to reset the look and feel of the component.
-    // This could also include resetting item data
-    // This is triggered when the reset button is clicked so it shouldn't
-    // be a full reset
-    resetQuestion() {}
-
-    refresh() {
-      this.model.set('_buttonState', this.model.getButtonState());
-
-      if (this.model.shouldShowMarking && this.model.get('_isSubmitted')) {
-        this.showMarking();
-      }
-
-      if (this.buttonsView) {
-        _.defer(this.buttonsView.refresh.bind(this.buttonsView));
-      }
-    }
-
-    onShowCorrectAnswerClicked() {
-      this.setQuestionAsShowCorrect();
-
-      this._runModelCompatibleFunction('updateButtons');
-
-      this.showCorrectAnswer();
-    }
-
-    setQuestionAsShowCorrect() {
-      this.$('.component__widget')
-        .addClass('is-submitted show-correct-answer')
-        .removeClass('show-user-answer');
-    }
-
-    // Used by the question to display the correct answer to the user
-    showCorrectAnswer() {}
-
-    onHideCorrectAnswerClicked() {
-      this.setQuestionAsHideCorrect();
-
-      this._runModelCompatibleFunction('updateButtons');
-
-      this.hideCorrectAnswer();
-    }
-
-    setQuestionAsHideCorrect() {
-      this.$('.component__widget')
-        .addClass('is-submitted show-user-answer')
-        .removeClass('show-correct-answer');
-    }
-
-    // Used by the question to display the users answer and
-    // hide the correct answer
-    // Should use the values stored in storeUserAnswer
-    hideCorrectAnswer() {}
-
-    // Time elapsed between the time the interaction was made available to the learner for response and the time of the first response
-    getLatency() {
-      return null;
-    }
-
-    // This function is overridden if useQuestionModeOnly: false. see below.
-    _runModelCompatibleFunction(name, lookForViewOnlyFunction) {
-      return this.model[name](); // questionModel Only
+  recordInteraction() {
+    if (this.model.get('_recordInteraction') === true || !this.model.has('_recordInteraction')) {
+      Adapt.trigger('questionView:recordInteraction', this);
     }
   }
 
-  QuestionView._isQuestionType = true;
+  // Used to show feedback based upon whether _canShowFeedback is true
+  showFeedback() {
 
-  /* BACKWARDS COMPATIBILITY SECTION
-  * This section below is only for compatibility between the separated questionView+questionModel and the old questionView
-  * Remove this section in when all components use questionModel and there is no need to have model behaviour in the questionView
+    if (this.model.get('_canShowFeedback')) {
+      Adapt.trigger('questionView:showFeedback', this);
+    } else {
+      Adapt.trigger('questionView:disabledFeedback', this);
+    }
+
+  }
+
+  onResetClicked() {
+    this.setQuestionAsReset();
+
+    this._runModelCompatibleFunction('resetUserAnswer');
+
+    this.resetQuestion();
+
+    this.model.checkCanSubmit();
+
+    this._runModelCompatibleFunction('updateButtons');
+
+    // onResetClicked is called as part of the checkIfResetOnRevisit
+    // function and as a button click. if the view is already rendered,
+    // then the button was clicked, focus on the first tabbable element
+    if (!this.model.get('_isReady')) return;
+    // Attempt to get the current page location
+    const currentModel = Adapt.findById(Adapt.location._currentId);
+    // Make sure the page is ready
+    if (!currentModel || !currentModel.get('_isReady')) return;
+    // Focus on the first readable item in this element
+    Adapt.a11y.focusNext(this.$el);
+
+  }
+
+  setQuestionAsReset() {
+    this.model.setQuestionAsReset();
+    this.$('.component__widget').removeClass('is-submitted');
+  }
+
+  // Used by the question view to reset the look and feel of the component.
+  // This could also include resetting item data
+  // This is triggered when the reset button is clicked so it shouldn't
+  // be a full reset
+  resetQuestion() {}
+
+  refresh() {
+    this.model.set('_buttonState', this.model.getButtonState());
+
+    if (this.model.shouldShowMarking && this.model.get('_isSubmitted')) {
+      this.showMarking();
+    }
+
+    if (this.buttonsView) {
+      _.defer(this.buttonsView.refresh.bind(this.buttonsView));
+    }
+  }
+
+  onShowCorrectAnswerClicked() {
+    this.setQuestionAsShowCorrect();
+
+    this._runModelCompatibleFunction('updateButtons');
+
+    this.showCorrectAnswer();
+  }
+
+  setQuestionAsShowCorrect() {
+    this.$('.component__widget')
+      .addClass('is-submitted show-correct-answer')
+      .removeClass('show-user-answer');
+  }
+
+  // Used by the question to display the correct answer to the user
+  showCorrectAnswer() {}
+
+  onHideCorrectAnswerClicked() {
+    this.setQuestionAsHideCorrect();
+
+    this._runModelCompatibleFunction('updateButtons');
+
+    this.hideCorrectAnswer();
+  }
+
+  setQuestionAsHideCorrect() {
+    this.$('.component__widget')
+      .addClass('is-submitted show-user-answer')
+      .removeClass('show-correct-answer');
+  }
+
+  // Used by the question to display the users answer and
+  // hide the correct answer
+  // Should use the values stored in storeUserAnswer
+  hideCorrectAnswer() {}
+
+  // Time elapsed between the time the interaction was made available to the learner for response and the time of the first response
+  getLatency() {
+    return null;
+  }
+
+  // This function is overridden if useQuestionModeOnly: false. see below.
+  _runModelCompatibleFunction(name, lookForViewOnlyFunction) {
+    return this.model[name](); // questionModel Only
+  }
+}
+
+QuestionView._isQuestionType = true;
+
+/* BACKWARDS COMPATIBILITY SECTION
+* This section below is only for compatibility between the separated questionView+questionModel and the old questionView
+* Remove this section in when all components use questionModel and there is no need to have model behaviour in the questionView
+*/
+
+class ViewOnlyQuestionViewCompatibilityLayer extends QuestionView {
+
+  /* All of these functions have been moved to the questionModel.js file.
+    * On the rare occasion that they have not been overridden by the component and
+          that they call the view only questionView version,
+          these functions are included as redirects to the new Question Model.
+          It is very unlikely that these are needed but they are included to ensure compatibility.
+    * If you need to override these in your component you should now make and register a component model.
+    * Please remove them from your question component's view.
   */
 
-  class ViewOnlyQuestionViewCompatibilityLayer extends QuestionView {
+  // Returns an object specific to the question type.
+  getInteractionObject() {
+    Adapt.log.deprecated('QuestionView.getInteractionObject, please use QuestionModel.getInteractionObject');
+    return this.model.getInteractionObject();
+  }
 
-    /* All of these functions have been moved to the questionModel.js file.
-     * On the rare occasion that they have not been overridden by the component and
-            that they call the view only questionView version,
-            these functions are included as redirects to the new Question Model.
-            It is very unlikely that these are needed but they are included to ensure compatibility.
-     * If you need to override these in your component you should now make and register a component model.
-     * Please remove them from your question component's view.
-    */
+  // Retturns a string detailing how the user answered the question.
+  getResponse() {
+    Adapt.log.deprecated('QuestionView.getInteractionObject, please use QuestionModel.getInteractionObject');
+    return this.model.getResponse();
+  }
 
-    // Returns an object specific to the question type.
-    getInteractionObject() {
-      Adapt.log.deprecated('QuestionView.getInteractionObject, please use QuestionModel.getInteractionObject');
-      return this.model.getInteractionObject();
-    }
+  // Returns a string describing the type of interaction: "choice" and "matching" supported (see scorm wrapper)
+  getResponseType() {
+    Adapt.log.deprecated('QuestionView.getResponseType, please use QuestionModel.getResponseType');
+    return this.model.getResponseType();
+  }
 
-    // Retturns a string detailing how the user answered the question.
-    getResponse() {
-      Adapt.log.deprecated('QuestionView.getInteractionObject, please use QuestionModel.getInteractionObject');
-      return this.model.getResponse();
-    }
+  // Calls default methods to setup on questions
+  setupDefaultSettings() {
+    Adapt.log.deprecated('QuestionView.setupDefaultSettings, please use QuestionModel.setupDefaultSettings');
+    return this.model.setupDefaultSettings();
+  }
 
-    // Returns a string describing the type of interaction: "choice" and "matching" supported (see scorm wrapper)
-    getResponseType() {
-      Adapt.log.deprecated('QuestionView.getResponseType, please use QuestionModel.getResponseType');
-      return this.model.getResponseType();
-    }
+  // Used to setup either global or local button text
+  setupButtonSettings() {
+    Adapt.log.deprecated('QuestionView.setupButtonSettings, please use QuestionModel.setupButtonSettings');
+    return this.model.setupButtonSettings();
+  }
 
-    // Calls default methods to setup on questions
-    setupDefaultSettings() {
-      Adapt.log.deprecated('QuestionView.setupDefaultSettings, please use QuestionModel.setupDefaultSettings');
-      return this.model.setupDefaultSettings();
-    }
+  // Used to setup either global or local question weight/score
+  setupWeightSettings() {
+    Adapt.log.deprecated('QuestionView.setupWeightSettings, please use QuestionModel.setupWeightSettings');
+    return this.model.setupWeightSettings();
+  }
 
-    // Used to setup either global or local button text
-    setupButtonSettings() {
-      Adapt.log.deprecated('QuestionView.setupButtonSettings, please use QuestionModel.setupButtonSettings');
-      return this.model.setupButtonSettings();
-    }
+  // Use to check if the user is allowed to submit the question
+  // Maybe the user has to select an item?
+  canSubmit() {
+    Adapt.log.deprecated('QuestionView.canSubmit, please use QuestionModel.canSubmit');
+    return this.model.canSubmit();
+  }
 
-    // Used to setup either global or local question weight/score
-    setupWeightSettings() {
-      Adapt.log.deprecated('QuestionView.setupWeightSettings, please use QuestionModel.setupWeightSettings');
-      return this.model.setupWeightSettings();
-    }
+  // Used to update the amount of attempts the user has left
+  updateAttempts() {
+    Adapt.log.deprecated('QuestionView.updateAttempts, please use QuestionModel.updateAttempts');
+    return this.model.updateAttempts();
+  }
 
-    // Use to check if the user is allowed to submit the question
-    // Maybe the user has to select an item?
-    canSubmit() {
-      Adapt.log.deprecated('QuestionView.canSubmit, please use QuestionModel.canSubmit');
-      return this.model.canSubmit();
-    }
+  // This is important for returning or showing the users answer
+  // This should preserve the state of the users answers
+  storeUserAnswer() {
+    Adapt.log.deprecated('QuestionView.storeUserAnswer, please use QuestionModel.storeUserAnswer');
+    return this.model.storeUserAnswer();
+  }
 
-    // Used to update the amount of attempts the user has left
-    updateAttempts() {
-      Adapt.log.deprecated('QuestionView.updateAttempts, please use QuestionModel.updateAttempts');
-      return this.model.updateAttempts();
-    }
+  // Used by the question view to reset the stored user answer
+  resetUserAnswer() {
+    Adapt.log.deprecated('QuestionView.resetUserAnswer, please use QuestionModel.resetUserAnswer');
+    return this.model.resetUserAnswer();
+  }
 
-    // This is important for returning or showing the users answer
-    // This should preserve the state of the users answers
-    storeUserAnswer() {
-      Adapt.log.deprecated('QuestionView.storeUserAnswer, please use QuestionModel.storeUserAnswer');
-      return this.model.storeUserAnswer();
-    }
+  // Sets _isCorrect:true/false based upon isCorrect method below
+  markQuestion() {
 
-    // Used by the question view to reset the stored user answer
-    resetUserAnswer() {
-      Adapt.log.deprecated('QuestionView.resetUserAnswer, please use QuestionModel.resetUserAnswer');
-      return this.model.resetUserAnswer();
-    }
+    if (this._isInViewOnlyCompatibleMode('isCorrect')) {
 
-    // Sets _isCorrect:true/false based upon isCorrect method below
-    markQuestion() {
-
-      if (this._isInViewOnlyCompatibleMode('isCorrect')) {
-
-        if (this.isCorrect()) {
-          this.model.set('_isCorrect', true);
-        } else {
-          this.model.set('_isCorrect', false);
-        }
-
+      if (this.isCorrect()) {
+        this.model.set('_isCorrect', true);
       } else {
-        return this.model.markQuestion();
+        this.model.set('_isCorrect', false);
       }
+
+    } else {
+      return this.model.markQuestion();
     }
+  }
 
-    // Should return a boolean based upon whether to question is correct or not
-    isCorrect() {
-      Adapt.log.deprecated('QuestionView.isCorrect, please use QuestionModel.isCorrect');
-      return this.model.isCorrect();
-    }
+  // Should return a boolean based upon whether to question is correct or not
+  isCorrect() {
+    Adapt.log.deprecated('QuestionView.isCorrect, please use QuestionModel.isCorrect');
+    return this.model.isCorrect();
+  }
 
-    // Used to set the score based upon the _questionWeight
-    setScore() {
-      Adapt.log.deprecated('QuestionView.setScore, please use QuestionModel.setScore');
-      return this.model.setScore();
-    }
+  // Used to set the score based upon the _questionWeight
+  setScore() {
+    Adapt.log.deprecated('QuestionView.setScore, please use QuestionModel.setScore');
+    return this.model.setScore();
+  }
 
-    // Updates buttons based upon question state by setting
-    // _buttonState on the model which buttonsView listens to
-    updateButtons() {
-      Adapt.log.deprecated('QuestionView.updateButtons, please use QuestionModel.updateButtons');
-      return this.model.updateButtons();
-    }
+  // Updates buttons based upon question state by setting
+  // _buttonState on the model which buttonsView listens to
+  updateButtons() {
+    Adapt.log.deprecated('QuestionView.updateButtons, please use QuestionModel.updateButtons');
+    return this.model.updateButtons();
+  }
 
-    // Used to setup the correct, incorrect and partly correct feedback
-    setupFeedback() {
+  // Used to setup the correct, incorrect and partly correct feedback
+  setupFeedback() {
 
-      if (this._isInViewOnlyCompatibleMode('isPartlyCorrect')) {
+    if (this._isInViewOnlyCompatibleMode('isPartlyCorrect')) {
 
-        // Use view based feedback where necessary
-        if (this.model.get('_isCorrect')) {
-          this._runModelCompatibleFunction('setupCorrectFeedback');
-        } else if (this.isPartlyCorrect()) {
-          this._runModelCompatibleFunction('setupPartlyCorrectFeedback');
-        } else {
-          this._runModelCompatibleFunction('setupIncorrectFeedback');
-        }
-
+      // Use view based feedback where necessary
+      if (this.model.get('_isCorrect')) {
+        this._runModelCompatibleFunction('setupCorrectFeedback');
+      } else if (this.isPartlyCorrect()) {
+        this._runModelCompatibleFunction('setupPartlyCorrectFeedback');
       } else {
-        // Use model based feedback
-        this.model.setupFeedback();
+        this._runModelCompatibleFunction('setupIncorrectFeedback');
       }
 
+    } else {
+      // Use model based feedback
+      this.model.setupFeedback();
     }
 
-    // Used by the question to determine if the question is incorrect or partly correct
-    // Should return a boolean
-    isPartlyCorrect() {
-      Adapt.log.deprecated('QuestionView.isPartlyCorrect, please use QuestionModel.isPartlyCorrect');
-      return this.model.isPartlyCorrect();
-    }
+  }
 
-    setupCorrectFeedback() {
-      Adapt.log.deprecated('QuestionView.setupCorrectFeedback, please use QuestionModel.setupCorrectFeedback');
-      return this.model.setupCorrectFeedback();
-    }
+  // Used by the question to determine if the question is incorrect or partly correct
+  // Should return a boolean
+  isPartlyCorrect() {
+    Adapt.log.deprecated('QuestionView.isPartlyCorrect, please use QuestionModel.isPartlyCorrect');
+    return this.model.isPartlyCorrect();
+  }
 
-    setupPartlyCorrectFeedback() {
-      Adapt.log.deprecated('QuestionView.setupPartlyCorrectFeedback, please use QuestionModel.setupPartlyCorrectFeedback');
-      return this.model.setupPartlyCorrectFeedback();
-    }
+  setupCorrectFeedback() {
+    Adapt.log.deprecated('QuestionView.setupCorrectFeedback, please use QuestionModel.setupCorrectFeedback');
+    return this.model.setupCorrectFeedback();
+  }
 
-    setupIncorrectFeedback() {
-      Adapt.log.deprecated('QuestionView.setupIncorrectFeedback, please use QuestionModel.setupIncorrectFeedback');
-      return this.model.setupIncorrectFeedback();
-    }
+  setupPartlyCorrectFeedback() {
+    Adapt.log.deprecated('QuestionView.setupPartlyCorrectFeedback, please use QuestionModel.setupPartlyCorrectFeedback');
+    return this.model.setupPartlyCorrectFeedback();
+  }
 
-    // Helper functions for compatibility layer
-    _runModelCompatibleFunction(name, lookForViewOnlyFunction) {
-      if (this._isInViewOnlyCompatibleMode(name, lookForViewOnlyFunction)) {
-        return this[name](); // questionView
-      } else {
-        return this.model[name](); // questionModel
+  setupIncorrectFeedback() {
+    Adapt.log.deprecated('QuestionView.setupIncorrectFeedback, please use QuestionModel.setupIncorrectFeedback');
+    return this.model.setupIncorrectFeedback();
+  }
+
+  // Helper functions for compatibility layer
+  _runModelCompatibleFunction(name, lookForViewOnlyFunction) {
+    if (this._isInViewOnlyCompatibleMode(name, lookForViewOnlyFunction)) {
+      return this[name](); // questionView
+    } else {
+      return this.model[name](); // questionModel
+    }
+  }
+
+  _isInViewOnlyCompatibleMode(name, lookForViewOnlyFunction) {
+    // return false uses the model function questionModel
+    // return true uses the view only function questionView
+
+    const checkForFunction = (lookForViewOnlyFunction || name);
+
+    // if the function does NOT exist on the view at all, use the model only
+    if (!this.constructor.prototype[checkForFunction]) return false; // questionModel
+
+    // if the function DOES exist on the view and MATCHES the compatibility function above, use the model only
+    const hasCompatibleVersion = (ViewOnlyQuestionViewCompatibilityLayer.prototype.hasOwnProperty(checkForFunction));
+    const usingCompatibleVersion = (this.constructor.prototype[checkForFunction] === ViewOnlyQuestionViewCompatibilityLayer.prototype[checkForFunction]);
+    if (hasCompatibleVersion && usingCompatibleVersion) {
+      switch (checkForFunction) {
+        case 'setupFeedback':
+        case 'markQuestion':
+          return true; // questionView
       }
+      return false; // questionModel
     }
 
-    _isInViewOnlyCompatibleMode(name, lookForViewOnlyFunction) {
-      // return false uses the model function questionModel
-      // return true uses the view only function questionView
+    // if the function DOES exist on the view and does NOT match the compatibility function above, use the view function
+    return true; // questionView
+  }
 
-      const checkForFunction = (lookForViewOnlyFunction || name);
+};
 
-      // if the function does NOT exist on the view at all, use the model only
-      if (!this.constructor.prototype[checkForFunction]) return false; // questionModel
+// return question view class extended with the compatibility layer
+export default ViewOnlyQuestionViewCompatibilityLayer;
 
-      // if the function DOES exist on the view and MATCHES the compatibility function above, use the model only
-      const hasCompatibleVersion = (ViewOnlyQuestionViewCompatibilityLayer.prototype.hasOwnProperty(checkForFunction));
-      const usingCompatibleVersion = (this.constructor.prototype[checkForFunction] === ViewOnlyQuestionViewCompatibilityLayer.prototype[checkForFunction]);
-      if (hasCompatibleVersion && usingCompatibleVersion) {
-        switch (checkForFunction) {
-          case 'setupFeedback':
-          case 'markQuestion':
-            return true; // questionView
-        }
-        return false; // questionModel
-      }
-
-      // if the function DOES exist on the view and does NOT match the compatibility function above, use the view function
-      return true; // questionView
-    }
-
-  };
-
-  // return question view class extended with the compatibility layer
-  return ViewOnlyQuestionViewCompatibilityLayer;
-
-  /* END OF BACKWARDS COMPATIBILITY SECTION */
-
-});
+/* END OF BACKWARDS COMPATIBILITY SECTION */

--- a/src/core/js/wait.js
+++ b/src/core/js/wait.js
@@ -1,102 +1,96 @@
-define(function() {
+export default class Wait extends Backbone.Controller {
 
-  var Wait = Backbone.Controller.extend({
+  initialize() {
+    this._waitCount = 0;
+    this._callbackHandle = null;
 
-    _waitCount: 0,
-    _callbackHandle: null,
+    _.bindAll(this, 'begin', 'end');
+  }
 
-    initialize: function() {
-      _.bindAll(this, 'begin', 'end');
-    },
+  /**
+   * Returns true if there are items in the waiting count.
+   *
+   * @return {Boolean}
+   */
+  isWaiting() {
+    return (this._waitCount !== 0);
+  }
 
-    /**
-     * Returns true if there are items in the waiting count.
-     *
-     * @return {Boolean}
-     */
-    isWaiting: function() {
-      return (this._waitCount !== 0);
-    },
+  /**
+   * Add one item to the waiting count.
+   *
+   * @return {Object}
+   */
+  begin() {
+    if (!this.isWaiting()) this.trigger('wait');
 
-    /**
-     * Add one item to the waiting count.
-     *
-     * @return {Object}
-     */
-    begin: function() {
-      if (!this.isWaiting()) this.trigger('wait');
+    this._waitCount++;
 
-      this._waitCount++;
-
-      if (this._callbackHandle) {
-        clearTimeout(this._callbackHandle);
-        this._callbackHandle = null;
-      }
-
-      return this;
-    },
-
-    /**
-     * Remove an item from the waiting count and trigger ready asynchronously if no more items are waiting.
-     *
-     * @return {Object}
-     */
-    end: function() {
-      if (!this.isWaiting()) return this;
-
-      this._waitCount--;
-
-      if (this.isWaiting() || this._callbackHandle) return this;
-
-      this._callbackHandle = setTimeout(function() {
-        this._callbackHandle = null;
-        this.trigger('ready');
-      }.bind(this), 0);
-
-      return this;
-    },
-
-    /**
-     * Queue this function until all open waits have been ended.
-     *
-     * @param  {Function} [callback]
-     * @return {Object|Promise}
-     */
-    queue: function(callback) {
-      if (!callback) {
-        this.begin();
-
-        return new Promise(resolve => {
-          this.once('ready', resolve);
-          this.end();
-        });
-      }
-
-      this.begin();
-      this.once('ready', callback);
-      this.end();
-
-      return this;
-    },
-
-    /**
-     * Wait for this asynchronous function to execute before triggering ready event.
-     *
-     * @param  {Function} callback   [ Function to execute whilst holding queued callback. Once complete run first argument, done(). ]
-     * @return {Object}
-     */
-    for: function(callback) {
-      this.begin();
-
-      _.defer(function() {
-        callback(_.once(this.end));
-      }.bind(this));
-
-      return this;
+    if (this._callbackHandle) {
+      clearTimeout(this._callbackHandle);
+      this._callbackHandle = null;
     }
 
-  });
+    return this;
+  }
 
-  return Wait;
+  /**
+   * Remove an item from the waiting count and trigger ready asynchronously if no more items are waiting.
+   *
+   * @return {Object}
+   */
+  end() {
+    if (!this.isWaiting()) return this;
 
-});
+    this._waitCount--;
+
+    if (this.isWaiting() || this._callbackHandle) return this;
+
+    this._callbackHandle = setTimeout(function() {
+      this._callbackHandle = null;
+      this.trigger('ready');
+    }.bind(this), 0);
+
+    return this;
+  }
+
+  /**
+   * Queue this function until all open waits have been ended.
+   *
+   * @param  {Function} [callback]
+   * @return {Object|Promise}
+   */
+  queue(callback) {
+    if (!callback) {
+      this.begin();
+
+      return new Promise(resolve => {
+        this.once('ready', resolve);
+        this.end();
+      });
+    }
+
+    this.begin();
+    this.once('ready', callback);
+    this.end();
+
+    return this;
+  }
+
+  /**
+   * Wait for this asynchronous function to execute before triggering ready event.
+   *
+   * @param  {Function} callback   [ Function to execute whilst holding queued callback. Once complete run first argument, done(). ]
+   * @return {Object}
+   */
+  for(callback) {
+    this.begin();
+
+    _.defer(function() {
+      callback(_.once(this.end));
+    }.bind(this));
+
+    return this;
+  }
+
+}

--- a/src/core/js/wait.js
+++ b/src/core/js/wait.js
@@ -3,8 +3,8 @@ export default class Wait extends Backbone.Controller {
   initialize() {
     this._waitCount = 0;
     this._callbackHandle = null;
-
-    _.bindAll(this, 'begin', 'end');
+    this.being = this.begin.bind(this);
+    this.end = this.end.bind(this);
   }
 
   /**
@@ -85,11 +85,7 @@ export default class Wait extends Backbone.Controller {
    */
   for(callback) {
     this.begin();
-
-    _.defer(function() {
-      callback(_.once(this.end));
-    }.bind(this));
-
+    _.defer(() => callback(_.once(this.end)));
     return this;
   }
 


### PR DESCRIPTION
fixes #2999 

Please view with **whitespace off**.

This effectively enables intellisense in VSCode for the core framework classes and APIs (hopefully).

Tested in IE11 - working.

#### Changes
* Removed all amd `define`/`return` and replace with `import`/`export default`.
* Converted classic `var Class = Backbone.Class.extend({})` to ES6 `class Class extends Backbone.Class {}`
* Refactor `core/js/device.js`
* `var` to `let`/`const`
* Moved `LockingModel` into the inheritance chain rather than keep it as a duck-punch/money-patch