### PR TITLE
issue/3002 Made imagemin dependencies optional

### DIFF
--- a/grunt/tasks/compress.js
+++ b/grunt/tasks/compress.js
@@ -6,10 +6,19 @@ module.exports = function(grunt) {
     const globs = require('globs');
     async function compressImages() {
       grunt.log.ok(`Compressing images...`);
-      const imagemin = require('imagemin');
-      const imageminJpegtran = require('imagemin-jpegtran');
-      const imageminPngquant = require('imagemin-pngquant');
-      const imageminSvgo = require('imagemin-svgo');
+      let imagemin;
+      let imageminJpegtran;
+      let imageminPngquant;
+      let imageminSvgo;
+      try {
+        imagemin = require('imagemin');
+        imageminJpegtran = require('imagemin-jpegtran');
+        imageminPngquant = require('imagemin-pngquant');
+        imageminSvgo = require('imagemin-svgo');
+      } catch (err) {
+        grunt.log.error(`Optional imagemin dependencies were not installed.`);
+        return;
+      }
       const sourceFiles = globs.sync(options.images.src);
       const destFiles = await imagemin(sourceFiles, {
         plugins: [

--- a/package.json
+++ b/package.json
@@ -41,10 +41,6 @@
         "grunt-replace": "^1.0.1",
         "handlebars": "^4.0.12",
         "iconv-lite": "^0.4.24",
-        "imagemin": "^7.0.1",
-        "imagemin-jpegtran": "^7.0.0",
-        "imagemin-pngquant": "^9.0.0",
-        "imagemin-svgo": "^8.0.0",
         "jit-grunt": "^0.10.0",
         "jschardet": "^1.6.0",
         "jshint-stylish": "^2.2.1",
@@ -65,5 +61,11 @@
         "eslint-plugin-promise": "^4.2.1",
         "eslint-plugin-requirejs": "^4.0.0",
         "eslint-plugin-standard": "^4.0.0"
+    },
+    "optionalDependencies": {
+        "imagemin": "^7.0.1",
+        "imagemin-jpegtran": "^7.0.0",
+        "imagemin-pngquant": "^9.0.0",
+        "imagemin-svgo": "^8.0.0"
     }
 }


### PR DESCRIPTION
#3002 
* Made imagemin dependencies optional
* Added error when `grunt compress` is executed without requisite dependencies

#### Testing
1. Remove `node_modules/imagemin`
2. Run `grunt compress`

#### Reference
1. [Optional dependencies](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#optionaldependencies)