### PR TITLE
issue/3004 grunt compress target fix

### DIFF
--- a/grunt/config/compress.js
+++ b/grunt/config/compress.js
@@ -3,7 +3,7 @@ module.exports = function(grunt, options) {
     options: {
       images: {
         src: [
-          '<%= outputdir %>**/*.{jpg,jpeg,png,svg}'
+          '<%= configdir %>**/*.{jpg,jpeg,png,svg}'
         ]
       }
     }

--- a/grunt/helpers.js
+++ b/grunt/helpers.js
@@ -226,6 +226,7 @@ module.exports = function(grunt) {
         root: root,
         sourcedir: sourcedir,
         outputdir: outputdir,
+        configdir: configDir,
         tempdir: tempdir,
         jsonext: jsonext,
         trackingIdType: grunt.option('trackingidtype') || 'block',


### PR DESCRIPTION
fixes #3004 

#### Changed
* compress task now takes outputdir if specified at command line or sourcedir otherwise