### PR TITLE
issue/2805 Added a mechanism for trackingId location agnosticism

### DIFF
--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -346,6 +346,15 @@ class AdaptSingleton extends LockingModel {
   }
 
   /**
+   * Returns the model represented by the trackingPosition.
+   * @param {Array<Number, Number>} trackingPosition Represents the relative location of a model to a _trackingId
+   * @returns {Backbone.Model}
+   */
+  findByTrackingPosition(trackingPosition) {
+    return this.data.findByTrackingPosition(trackingPosition);
+  }
+
+  /**
    * Relative strings describe the number and type of hops in the model hierarchy
    * @param {string} relativeString "@component +1" means to move one component forward from the current model
    * This function would return the following:

--- a/src/core/js/data.js
+++ b/src/core/js/data.js
@@ -202,10 +202,33 @@ class Data extends AdaptCollection {
   findById(id) {
     const model = this._byAdaptID[id];
     if (!model) {
-      console.warn(`Adapt.findById() unable to find collection type for id: ${id}`);
+      console.warn(`Adapt.findById() unable to find id: ${id}`);
       return;
     }
     return model;
+  }
+
+  /**
+   * Returns the model represented by the trackingPosition.
+   * @param {Array<Number, Number>} trackingPosition Represents the relative location of a model to a _trackingId
+   * @returns {Backbone.Model}
+   */
+  findByTrackingPosition(trackingPosition) {
+    const [ trackingId, indexInTrackingIdDescendants ] = trackingPosition;
+    const trackingIdModel = this.find(model => model.get('_trackingId') === trackingId);
+    if (!trackingIdModel) {
+      console.warn(`Adapt.findByTrackingPosition() unable to find trackingPosition: ${trackingPosition}`);
+      return;
+    }
+    if (indexInTrackingIdDescendants >= 0) {
+      // Model is either the trackingId model or a descendant
+      const trackingIdDescendants = [trackingIdModel].concat(trackingIdModel.getAllDescendantModels(true));
+      return trackingIdDescendants[indexInTrackingIdDescendants];
+    }
+    // Model is an ancestor of the trackingId model
+    const trackingIdAncestors = trackingIdModel.getAncestorModels();
+    const ancestorDistance = Math.abs(indexInTrackingIdDescendants) - 1;
+    return trackingIdAncestors[ancestorDistance];
   }
 
 }


### PR DESCRIPTION
 fixes #2805 

Provides a simple method of identifying models based upon the course's `_trackingId` properties, regardless of their location, be them on the `blocks` or `components`.

### Added
* `Adapt.findByTrackingPosition` similar to `Adapt.findById` but for `_trackingId` relative save/restore functions
* `AdaptModel.trackingPosition` which returns the model's trackingPosition relative to its nearest `_trackingId`

A tracking position is comprised of two numbers, the `_trackingId` and the relative offset from it. The relative offset is positive for a descendant or negative for an ancestor.

### Changed
* Comment in `Adapt.findById` was inaccurate

### Testing
```js
// Test all trackingPositions can be found for the course
Adapt.data.forEach((model) => {
  var id = model.get('_id');
  var trackingPosition = model.trackingPosition;
  console.log(trackingPosition, id);
  var found = Adapt.findByTrackingPosition(trackingPosition);
  if (id !== found.get('_id')) throw "Mismatch";
});
```

Try with `grunt dev` and `grunt dev --trackingidtype='component'`

https://github.com/adaptlearning/adapt_framework/pull/2806