### PR TITLE
Removed tabindex from a11y-focuser element

### DIFF
--- a/src/core/js/a11y.js
+++ b/src/core/js/a11y.js
@@ -111,7 +111,7 @@ class A11y extends Backbone.Controller {
     if ($('#a11y-focuser').length) {
       return;
     }
-    $('body').append($('<div id="a11y-focuser" class="a11y-ignore" tabindex="-1" role="presentation">&nbsp;</div>'));
+    $('body').append($('<div id="a11y-focuser" class="a11y-ignore" role="presentation">&nbsp;</div>'));
   }
 
   _removeLegacyElements() {


### PR DESCRIPTION
Linked issue: https://github.com/adaptlearning/adapt_framework/issues/3057