### PR TITLE
skip nav btn visible when focused

### DIFF
--- a/src/core/less/core/nav.less
+++ b/src/core/less/core/nav.less
@@ -15,6 +15,23 @@
     .l-container-responsive(@max-width);
   }
 
+  &__skip-btn {
+    position: absolute;
+    left: 0;
+    margin-top: 0;
+    top: -100%;
+    z-index: 100;
+    .transition(top @duration ease-in-out);
+
+    html:not(.has-accessibility) & {
+      .u-display-none;
+    }
+
+    &:focus {
+      top: 0;
+    }
+  }
+
   &__back-btn {
     .u-float-left;
   }

--- a/src/core/templates/nav.hbs
+++ b/src/core/templates/nav.hbs
@@ -5,7 +5,7 @@
 <div class="nav__inner u-clearfix">
 
   {{#if _accessibility._isSkipNavigationEnabled}}
-  <button class="nav__btn nav__skip-btn aria-label a11y-ignore-focus" data-event="skipNavigation" aria-label="{{_globals._accessibility._ariaLabels.skipNavigation}}">
+  <button class="btn-text nav__btn nav__skip-btn" data-event="skipNavigation" aria-label="{{_globals._accessibility._ariaLabels.skipNavigation}}">
       {{{_globals._accessibility.skipNavigationText}}}
   </button>
   {{/if}}


### PR DESCRIPTION
Resolves https://github.com/adaptlearning/adapt_framework/issues/3040

* Shows 'skip navigation' button on browser tab focus 

Note: skip navigation button does not appear when focused using the arrows keys in combination with a screen reader 