### PR TITLE
issue/3064 Cannot spread non-iterable jquery object in ie11

### DIFF
--- a/src/core/js/a11y/browserFocus.js
+++ b/src/core/js/a11y/browserFocus.js
@@ -70,7 +70,7 @@ export default class BrowserFocus extends Backbone.Controller {
     if (!config._isEnabled || !config._options._isFocusOnClickEnabled) {
       return;
     }
-    const $stack = $([...$element, ...$element.parents()]);
+    const $stack = $([...$element.toArray(), ...$element.parents().toArray()]);
     const $focusable = $stack.filter(config._options._tabbableElements);
     if (!$focusable.length) {
       return;


### PR DESCRIPTION
fixes #3064 

### Change
* Explicitly convert jquery objects to array before spreading