### PR TITLE
allow the tracking-remove grunt task to run even if spoor isn't installed

### DIFF
--- a/grunt/tasks/tracking-remove.js
+++ b/grunt/tasks/tracking-remove.js
@@ -1,7 +1,6 @@
 module.exports = function(grunt) {
   const Helpers = require('../helpers')(grunt);
   grunt.registerTask('tracking-remove', 'Removes all tracking IDs', function() {
-    if (!Helpers.isPluginInstalled('adapt-contrib-spoor')) return;
     const data = Helpers.getFramework().getData();
     data.removeTrackingIds();
   });


### PR DESCRIPTION
fixes #3068 