### PR TITLE
issue/3101 a11y startup at configModel:dataLoaded

### DIFF
--- a/src/core/js/a11y.js
+++ b/src/core/js/a11y.js
@@ -73,7 +73,7 @@ class A11y extends Backbone.Controller {
 
     this._removeLegacyElements();
     this.listenToOnce(Adapt, {
-      'app:dataLoaded': this._onDataLoaded,
+      'configModel:dataLoaded': this._onConfigDataLoaded,
       'navigationView:postRender': this._removeLegacyElements
     }, this);
     Adapt.on('device:changed', this._setupNoSelect);
@@ -83,7 +83,7 @@ class A11y extends Backbone.Controller {
     });
   }
 
-  _onDataLoaded() {
+  _onConfigDataLoaded() {
     this.config = Adapt.config.get('_accessibility');
     this.config._isActive = false;
     this.config._options = _.defaults(this.config._options || {}, this.defaults());


### PR DESCRIPTION
fixes #3101 

### Fixed
* a11y api now starts up at `configModel:dataLoaded` instead of `app:dataLoaded`