### PR TITLE
issue/3142 Added id to component__header

### DIFF
--- a/src/core/templates/partials/component.hbs
+++ b/src/core/templates/partials/component.hbs
@@ -2,7 +2,7 @@
 {{import_globals}}
 
 {{#any displayTitle body instruction}}
-<div class="component__header {{lowercase _component}}__header">
+<div class="component__header {{lowercase _component}}__header" id="{{_id}}-header">
   <div class="component__header-inner {{lowercase _component}}__header-inner">
 
     {{#if displayTitle}}


### PR DESCRIPTION
part of https://github.com/adaptlearning/adapt_framework/issues/3142

### Added 
* `id` to `component__header`


### Testing
Use prs [gmcq#129](https://github.com/adaptlearning/adapt-contrib-gmcq/pull/129) and [mcq#159](https://github.com/adaptlearning/adapt-contrib-mcq/pull/159), then <kbd>Tab</kbd> to navigate to mcq/gmcq answer options.

The answer option reads the entire component header, better orientating the user.