### PR TITLE
issue/1486 Ignore optional source models in locking

### DIFF
--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -764,7 +764,7 @@ export default class AdaptModel extends LockingModel {
       try {
         const model = Adapt.findById(id);
 
-        if (!model.get('_isAvailable')) continue;
+        if (!model.get('_isAvailable') || model.get('_isOptional')) continue;
         if (!model.get('_isComplete')) return true;
       } catch (e) {
         console.warn(`AdaptModel.shouldLock: unknown _lockedBy ID '${id}' found on ${child.get('_id')}`);

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -717,28 +717,28 @@ export default class AdaptModel extends LockingModel {
   }
 
   setSequentialLocking() {
-    const lastChildren = this.getAvailableChildModels();
-    const firstChild = lastChildren.shift();
-    lastChildren.reduce((previousChild, child) => {
+    const children = this.getAvailableChildModels();
+    const firstChild = children.shift();
+    children.reduce((previousChild, child) => {
       const isLockedByPreviousChild = (!previousChild.get('_isComplete') && !previousChild.get('_isOptional'));
       return child.set('_isLocked', isLockedByPreviousChild);
     }, firstChild);
   }
 
   setUnlockFirstLocking() {
-    const lastChildren = this.getAvailableChildModels();
-    const firstChild = lastChildren.shift();
+    const children = this.getAvailableChildModels();
+    const firstChild = children.shift();
     const isLockedByFirstChild = (!firstChild.get('_isComplete') && !firstChild.get('_isOptional'));
-    lastChildren.forEach(child => child.set('_isLocked', isLockedByFirstChild));
+    children.forEach(child => child.set('_isLocked', isLockedByFirstChild));
   }
 
   setLockLastLocking() {
-    const firstChildren = this.getAvailableChildModels();
-    const lastChild = firstChildren.pop();
-    const isLockedByFirstChildren = firstChildren.some(child =>
+    const children = this.getAvailableChildModels();
+    const lastChild = children.pop();
+    const isLockedByChildren = children.some(child =>
       (!child.get('_isComplete') && !child.get('_isOptional'))
     );
-    lastChild.set('_isLocked', isLockedByFirstChildren);
+    lastChild.set('_isLocked', isLockedByChildren);
   }
 
   setCustomLocking() {

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -735,9 +735,7 @@ export default class AdaptModel extends LockingModel {
   setLockLastLocking() {
     const children = this.getAvailableChildModels();
     const lastChild = children.pop();
-    const isLockedByChildren = children.some(child =>
-      (!child.get('_isComplete') && !child.get('_isOptional'))
-    );
+    const isLockedByChildren = children.some(child => (!child.get('_isComplete') && !child.get('_isOptional')));
     lastChild.set('_isLocked', isLockedByChildren);
   }
 

--- a/src/core/js/models/adaptModel.js
+++ b/src/core/js/models/adaptModel.js
@@ -60,12 +60,12 @@ export default class AdaptModel extends LockingModel {
     const indexInTrackingIdDescendants = trackingIdDescendants.findIndex(descendant => descendant === this);
     if (indexInTrackingIdDescendants >= 0) {
       // Is either the nearestTrackingIdModel (0) or one of its flattened descendants (>0)
-      return [trackingId, indexInTrackingIdDescendants];
+      return [ trackingId, indexInTrackingIdDescendants ];
     }
     // Is an ancestor of the nearestTrackingIdModel
     const trackingIdAncestors = nearestTrackingIdModel.getAncestorModels();
     const ancestorDistance = trackingIdAncestors.findIndex(ancestor => ancestor === this);
-    return [trackingId, -(ancestorDistance + 1)];
+    return [ trackingId, -(ancestorDistance + 1) ];
   }
 
   /**
@@ -361,7 +361,7 @@ export default class AdaptModel extends LockingModel {
    */
   getTypeGroups() {
     if (this._typeGroups) return this._typeGroups;
-    const typeGroups = [this.get('_type')];
+    const typeGroups = [ this.get('_type') ];
     let parentClass = this;
     while ((parentClass = Object.getPrototypeOf(parentClass))) {
       if (!Object.prototype.hasOwnProperty.call(parentClass, 'getTypeGroup')) continue;


### PR DESCRIPTION
fixes #1486 

### Fixed
* Ignore optional source models in locking derivation, such that optional models can be locked by mandatory models but no model can be locked by optional models. [Bottom part](https://github.com/adaptlearning/adapt_framework/pull/3146/files#diff-260f88149840d5e54230b6e03f9b641d71aef375dcb74cefffd553798f94412aR719-R761)
* Some linting issues. [Top part](https://github.com/adaptlearning/adapt_framework/pull/3146/files#diff-260f88149840d5e54230b6e03f9b641d71aef375dcb74cefffd553798f94412aR19-R694)