### PR TITLE
issue/3148 Added partly correct and any correct answer options to ItemsQuestionModel

### DIFF
--- a/src/core/js/models/itemsQuestionModel.js
+++ b/src/core/js/models/itemsQuestionModel.js
@@ -74,7 +74,7 @@ export default class ItemsQuestionModel extends BlendedItemsComponentQuestionMod
 
     const isItemCorrect = itemModel => itemModel.get('_shouldBeSelected') && !itemModel.get('_isPartlyCorrect');
     const isItemPartlyCorrect = itemModel => itemModel.get('_isPartlyCorrect');
-    const isItemInCorrect = itemModel => !itemModel.get('_shouldBeSelected') && !itemModel.get('_isPartlyCorrect');
+    const isItemIncorrect = itemModel => !itemModel.get('_shouldBeSelected') && !itemModel.get('_isPartlyCorrect');
 
     const sum = (list, predicate) => list.reduce((sum, item) => sum + (predicate(item) ? 1 : 0), 0);
 
@@ -82,7 +82,7 @@ export default class ItemsQuestionModel extends BlendedItemsComponentQuestionMod
       _numberOfRequiredAnswers: sum(allChildren, isItemCorrect),
       _numberOfCorrectAnswers: sum(activeChildren, isItemCorrect),
       _numberOfPartlyCorrectAnswers: sum(activeChildren, isItemPartlyCorrect),
-      _numberOfIncorrectAnswers: sum(activeChildren, isItemInCorrect)
+      _numberOfIncorrectAnswers: sum(activeChildren, isItemIncorrect)
     };
 
     activeChildren.forEach(itemModel => itemModel.set('_isCorrect', itemModel.get('_shouldBeSelected')));

--- a/src/core/js/models/itemsQuestionModel.js
+++ b/src/core/js/models/itemsQuestionModel.js
@@ -70,8 +70,11 @@ export default class ItemsQuestionModel extends BlendedItemsComponentQuestionMod
 
   isCorrect() {
 
+    const selectable = this.get('_selectable');
+
     const props = {
       _numberOfRequiredAnswers: 0,
+      _numberOfPartlyCorrectAnswers: 0,
       _numberOfIncorrectAnswers: 0,
       _isAtLeastOneCorrectSelection: false,
       _numberOfCorrectAnswers: 0
@@ -79,11 +82,20 @@ export default class ItemsQuestionModel extends BlendedItemsComponentQuestionMod
 
     this.getChildren().each(itemModel => {
       const itemShouldBeActive = itemModel.get('_shouldBeSelected');
+      const isPartlyCorrect = itemModel.get('_isPartlyCorrect');
+
       if (itemShouldBeActive) {
         props._numberOfRequiredAnswers++;
       }
 
       if (!itemModel.get('_isActive')) return;
+
+      if (isPartlyCorrect) {
+        // force partly correct feedback and mark as correct
+        props._isAtLeastOneCorrectSelection = true;
+        props._numberOfPartlyCorrectAnswers++;
+        itemModel.set('_isCorrect', true);
+      }
 
       if (!itemShouldBeActive) {
         props._numberOfIncorrectAnswers++;
@@ -97,10 +109,12 @@ export default class ItemsQuestionModel extends BlendedItemsComponentQuestionMod
 
     this.set(props);
 
+    const hasAtLeastSelectableCorrectAnswers = (props._numberOfCorrectAnswers >= selectable);
     const hasRightNumberOfCorrectAnswers = (props._numberOfCorrectAnswers === props._numberOfRequiredAnswers);
     const hasNoIncorrectAnswers = !props._numberOfIncorrectAnswers;
+    const hasNoPartlyCorrectAnswers = !props._numberOfPartlyCorrectAnswers;
 
-    return hasRightNumberOfCorrectAnswers && hasNoIncorrectAnswers;
+    return (hasRightNumberOfCorrectAnswers || hasAtLeastSelectableCorrectAnswers) && hasNoIncorrectAnswers && hasNoPartlyCorrectAnswers;
   }
 
   // Sets the score based upon the questionWeight

--- a/src/core/js/models/itemsQuestionModel.js
+++ b/src/core/js/models/itemsQuestionModel.js
@@ -90,9 +90,9 @@ export default class ItemsQuestionModel extends BlendedItemsComponentQuestionMod
     props._isAtLeastOneCorrectSelection = (props._numberOfCorrectAnswers || props._numberOfPartlyCorrectAnswers);
 
     const numberOfSelectableAnswers = this.get('_selectable');
-    const hasAtLeastSelectableCorrectAnswers = (props._numberOfCorrectAnswers >= numberOfSelectableAnswers);
-    const hasRightNumberOfCorrectAnswers = (props._numberOfCorrectAnswers === props._numberOfRequiredAnswers);
-    const hasCorrectAnswers = (hasAtLeastSelectableCorrectAnswers || hasRightNumberOfCorrectAnswers);
+    const hasSelectableCorrectAnswers = (props._numberOfCorrectAnswers === numberOfSelectableAnswers);
+    const hasAllCorrectAnswers = (props._numberOfCorrectAnswers === props._numberOfRequiredAnswers);
+    const hasCorrectAnswers = (hasSelectableCorrectAnswers || hasAllCorrectAnswers);
     const hasIncorrectAnswers = props._numberOfIncorrectAnswers;
     const hasPartlyCorrectAnswers = props._numberOfPartlyCorrectAnswers;
 

--- a/src/core/js/models/itemsQuestionModel.js
+++ b/src/core/js/models/itemsQuestionModel.js
@@ -69,52 +69,36 @@ export default class ItemsQuestionModel extends BlendedItemsComponentQuestionMod
   }
 
   isCorrect() {
+    const allChildren = this.getChildren();
+    const activeChildren = allChildren.filter(itemModel => itemModel.get('_isActive'));
 
-    const selectable = this.get('_selectable');
+    const isItemCorrect = itemModel => itemModel.get('_shouldBeSelected') && !itemModel.get('_isPartlyCorrect');
+    const isItemPartlyCorrect = itemModel => itemModel.get('_isPartlyCorrect');
+    const isItemInCorrect = itemModel => !itemModel.get('_shouldBeSelected') && !itemModel.get('_isPartlyCorrect');
+
+    const sum = (list, predicate) => list.reduce((sum, item) => sum + (predicate(item) ? 1 : 0), 0);
 
     const props = {
-      _numberOfRequiredAnswers: 0,
-      _numberOfPartlyCorrectAnswers: 0,
-      _numberOfIncorrectAnswers: 0,
-      _isAtLeastOneCorrectSelection: false,
-      _numberOfCorrectAnswers: 0
+      _numberOfRequiredAnswers: sum(allChildren, isItemCorrect),
+      _numberOfCorrectAnswers: sum(activeChildren, isItemCorrect),
+      _numberOfPartlyCorrectAnswers: sum(activeChildren, isItemPartlyCorrect),
+      _numberOfIncorrectAnswers: sum(activeChildren, isItemInCorrect)
     };
 
-    this.getChildren().each(itemModel => {
-      const itemShouldBeActive = itemModel.get('_shouldBeSelected');
-      const isPartlyCorrect = itemModel.get('_isPartlyCorrect');
+    activeChildren.forEach(itemModel => itemModel.set('_isCorrect', itemModel.get('_shouldBeSelected')));
 
-      if (itemShouldBeActive) {
-        props._numberOfRequiredAnswers++;
-      }
+    props._isAtLeastOneCorrectSelection = (props._numberOfCorrectAnswers || props._numberOfPartlyCorrectAnswers);
 
-      if (!itemModel.get('_isActive')) return;
-
-      if (isPartlyCorrect) {
-        // force partly correct feedback and mark as correct
-        props._isAtLeastOneCorrectSelection = true;
-        props._numberOfPartlyCorrectAnswers++;
-        itemModel.set('_isCorrect', true);
-      }
-
-      if (!itemShouldBeActive) {
-        props._numberOfIncorrectAnswers++;
-        return;
-      }
-
-      props._isAtLeastOneCorrectSelection = true;
-      props._numberOfCorrectAnswers++;
-      itemModel.set('_isCorrect', true);
-    });
+    const numberOfSelectableAnswers = this.get('_selectable');
+    const hasAtLeastSelectableCorrectAnswers = (props._numberOfCorrectAnswers >= numberOfSelectableAnswers);
+    const hasRightNumberOfCorrectAnswers = (props._numberOfCorrectAnswers === props._numberOfRequiredAnswers);
+    const hasCorrectAnswers = (hasAtLeastSelectableCorrectAnswers || hasRightNumberOfCorrectAnswers);
+    const hasIncorrectAnswers = props._numberOfIncorrectAnswers;
+    const hasPartlyCorrectAnswers = props._numberOfPartlyCorrectAnswers;
 
     this.set(props);
 
-    const hasAtLeastSelectableCorrectAnswers = (props._numberOfCorrectAnswers >= selectable);
-    const hasRightNumberOfCorrectAnswers = (props._numberOfCorrectAnswers === props._numberOfRequiredAnswers);
-    const hasNoIncorrectAnswers = !props._numberOfIncorrectAnswers;
-    const hasNoPartlyCorrectAnswers = !props._numberOfPartlyCorrectAnswers;
-
-    return (hasRightNumberOfCorrectAnswers || hasAtLeastSelectableCorrectAnswers) && hasNoIncorrectAnswers && hasNoPartlyCorrectAnswers;
+    return hasCorrectAnswers && !hasIncorrectAnswers && !hasPartlyCorrectAnswers;
   }
 
   // Sets the score based upon the questionWeight


### PR DESCRIPTION
#3148

Added support for selecting any correct answer.
Added support for marking as partly correct if any `_isPartlyCorrect` item is selected.

### Added
* `_isPartlyCorrect` to question items

### Changed
* `isCorrect` is `true` when a `_selectable` number of `_shouldBeSelected: true` items are active
* `isCorrect` is `false` if any `_isPartlyCorrect: true` items are active
* `isPartlyCorrect` is `true` if any `_isPartlyCorrect: true` items are active


To test in the AAT use https://github.com/adaptlearning/adapt-contrib-mcq/pull/160 and https://github.com/adaptlearning/adapt-contrib-gmcq/pull/130