### PR TITLE
issue/3163 New scoring api

### DIFF
--- a/src/core/js/models/itemModel.js
+++ b/src/core/js/models/itemModel.js
@@ -5,7 +5,8 @@ export default class ItemModel extends LockingModel {
   defaults() {
     return {
       _isActive: false,
-      _isVisited: false
+      _isVisited: false,
+      _score: 0
     };
   }
 

--- a/src/core/js/models/itemsQuestionModel.js
+++ b/src/core/js/models/itemsQuestionModel.js
@@ -113,25 +113,25 @@ export default class ItemsQuestionModel extends BlendedItemsComponentQuestionMod
   }
 
   get score() {
-    if (!this.get('_isItemScoring')) return super.score;
+    if (!this.get('_hasItemScoring')) return super.score;
     const children = this.getChildren()?.toArray() || [];
     return children.reduce((score, child) => (score += child.get('_isActive') ? child.get('_score') || 0 : 0), 0);
   }
 
   get maxScore() {
-    if (!this.get('_isItemScoring')) return super.maxScore;
+    if (!this.get('_hasItemScoring')) return super.maxScore;
     const children = this.getChildren()?.toArray() || [];
     const scores = children.map(child => child.get('_score') || 0);
     scores.sort();
-    return scores.reverse().slice(0, this.get('_seletable')).filter(score => score > 0).reduce((maxScore, score) => (maxScore += score), 0);
+    return scores.reverse().slice(0, this.get('_selectable')).filter(score => score > 0).reduce((maxScore, score) => (maxScore += score), 0);
   }
 
   get minScore() {
-    if (!this.get('_isItemScoring')) return super.minScore;
+    if (!this.get('_hasItemScoring')) return super.minScore;
     const children = this.getChildren()?.toArray() || [];
     const scores = children.map(child => child.get('_score') || 0);
     scores.sort();
-    return scores.slice(0, this.get('_seletable')).filter(score => score < 0).reduce((minScore, score) => (minScore += score), 0);
+    return scores.slice(0, this.get('_selectable')).filter(score => score < 0).reduce((minScore, score) => (minScore += score), 0);
   }
 
   setupFeedback() {

--- a/src/core/js/models/itemsQuestionModel.js
+++ b/src/core/js/models/itemsQuestionModel.js
@@ -112,6 +112,28 @@ export default class ItemsQuestionModel extends BlendedItemsComponentQuestionMod
     this.set('_score', score);
   }
 
+  get score() {
+    if (!this.get('_isItemScoring')) return super.score;
+    const children = this.getChildren()?.toArray() || [];
+    return children.reduce((score, child) => (score += child.get('_isActive') ? child.get('_score') || 0 : 0), 0);
+  }
+
+  get maxScore() {
+    if (!this.get('_isItemScoring')) return super.maxScore;
+    const children = this.getChildren()?.toArray() || [];
+    const scores = children.map(child => child.get('_score') || 0);
+    scores.sort();
+    return scores.reverse().slice(0, this.get('_seletable')).filter(score => score > 0).reduce((maxScore, score) => (maxScore += score), 0);
+  }
+
+  get minScore() {
+    if (!this.get('_isItemScoring')) return super.minScore;
+    const children = this.getChildren()?.toArray() || [];
+    const scores = children.map(child => child.get('_score') || 0);
+    scores.sort();
+    return scores.slice(0, this.get('_seletable')).filter(score => score < 0).reduce((minScore, score) => (minScore += score), 0);
+  }
+
   setupFeedback() {
     if (!this.has('_feedback')) return;
 

--- a/src/core/js/models/itemsQuestionModel.js
+++ b/src/core/js/models/itemsQuestionModel.js
@@ -44,7 +44,6 @@ export default class ItemsQuestionModel extends BlendedItemsComponentQuestionMod
     this.setQuestionAsSubmitted();
     this.markQuestion();
     this.setScore();
-    this.updateScore();
     this.setupFeedback();
   }
 

--- a/src/core/js/models/itemsQuestionModel.js
+++ b/src/core/js/models/itemsQuestionModel.js
@@ -44,6 +44,7 @@ export default class ItemsQuestionModel extends BlendedItemsComponentQuestionMod
     this.setQuestionAsSubmitted();
     this.markQuestion();
     this.setScore();
+    this.updateScore();
     this.setupFeedback();
   }
 

--- a/src/core/js/models/questionModel.js
+++ b/src/core/js/models/questionModel.js
@@ -20,6 +20,7 @@ class QuestionModel extends ComponentModel {
       _canSubmit: true,
       _isSubmitted: false,
       _questionWeight: Adapt.config.get('_questionWeight'),
+      _isItemScoring: false,
       _items: []
     });
   }

--- a/src/core/js/models/questionModel.js
+++ b/src/core/js/models/questionModel.js
@@ -76,7 +76,7 @@ class QuestionModel extends ComponentModel {
       // If they are empty use the global defaults.
       const componentButtons = this.get('_buttons');
 
-      for (let key in componentButtons) {
+      for (const key in componentButtons) {
         if (typeof componentButtons[key] === 'object') {
           // Button text.
           if (!componentButtons[key].buttonText && globalButtons[key].buttonText) {
@@ -145,6 +145,18 @@ class QuestionModel extends ComponentModel {
 
   // Used to set the score based upon the _questionWeight
   setScore() {}
+
+  get score() {
+    return this.get('_isCorrect') ? this.get('_questionWeight') : 0;
+  }
+
+  get maxScore() {
+    return this.get('_questionWeight');
+  }
+
+  get minScore() {
+    return 0;
+  }
 
   // Checks if the question should be set to complete
   // Calls setCompletionStatus and adds complete classes

--- a/src/core/js/models/questionModel.js
+++ b/src/core/js/models/questionModel.js
@@ -20,7 +20,7 @@ class QuestionModel extends ComponentModel {
       _canSubmit: true,
       _isSubmitted: false,
       _questionWeight: Adapt.config.get('_questionWeight'),
-      _isItemScoring: false,
+      _hasItemScoring: false,
       _items: []
     });
   }

--- a/src/core/js/models/questionModel.js
+++ b/src/core/js/models/questionModel.js
@@ -55,6 +55,7 @@ class QuestionModel extends ComponentModel {
   init() {
     this.setupDefaultSettings();
     this.setLocking('_canSubmit', true);
+    this.updateRawScore();
     super.init();
   }
 
@@ -139,6 +140,8 @@ class QuestionModel extends ComponentModel {
       this.set('_isCorrect', false);
     }
 
+    this.updateRawScore();
+
   }
 
   // Should return a boolean based upon whether to question is correct or not
@@ -147,8 +150,16 @@ class QuestionModel extends ComponentModel {
   // Used to set the score based upon the _questionWeight
   setScore() {}
 
+  updateRawScore() {
+    this.set({
+      _rawScore: this.score,
+      _maxScore: this.maxScore,
+      _minScore: this.minScore
+    });
+  }
+
   get score() {
-    return this.get('_isCorrect') ? this.get('_questionWeight') : 0;
+    return this.get('_isCorrect') ? this.maxScore : 0;
   }
 
   get maxScore() {

--- a/src/core/js/views/questionView.js
+++ b/src/core/js/views/questionView.js
@@ -554,7 +554,7 @@ class ViewOnlyQuestionViewCompatibilityLayer extends QuestionView {
     if (!this.constructor.prototype[checkForFunction]) return false; // questionModel
 
     // if the function DOES exist on the view and MATCHES the compatibility function above, use the model only
-    const hasCompatibleVersion = (ViewOnlyQuestionViewCompatibilityLayer.prototype.hasOwnProperty(checkForFunction));
+    const hasCompatibleVersion = (Object.prototype.hasOwnProperty.call(ViewOnlyQuestionViewCompatibilityLayer.prototype, checkForFunction));
     const usingCompatibleVersion = (this.constructor.prototype[checkForFunction] === ViewOnlyQuestionViewCompatibilityLayer.prototype[checkForFunction]);
     if (hasCompatibleVersion && usingCompatibleVersion) {
       switch (checkForFunction) {

--- a/src/core/js/views/questionView.js
+++ b/src/core/js/views/questionView.js
@@ -462,6 +462,12 @@ class ViewOnlyQuestionViewCompatibilityLayer extends QuestionView {
         this.model.set('_isCorrect', false);
       }
 
+      this.set({
+        _rawScore: this.model.get('_isCorrect') ? this.model.get('_questionWeight') : 0,
+        _maxScore: this.model.get('_questionWeight'),
+        _minScore: 0
+      });
+
     } else {
       return this.model.markQuestion();
     }


### PR DESCRIPTION
#3163 
fixes #1974
fixes #893

### Added
* `QuestionModel.score` returns `0` for incorrect/partly correct or `maxScore` for correct
* `QuestionModel.maxScore` returns `_questionWeight`
* `QuestionModel.minScore` returns `0`
* `QuestionModel._hasItemScoring` to control item scoring
* `QuestionModel.updateRawScore()` adds `_rawScore = get score`, `_maxScore = get maxScore`, `_minScore = get minScore` on `init` and `markQuestion` to give access to the values in templates
* `ItemsQuestionModel.score` when `_hasItemScoring === true` return sum of `_items._isActive && _items._score`
* `ItemsQuestionModel.maxScore` when `_hasItemScoring=== true` return the sum of `_selectable` highest positive `_items._score`
* `ItemsQuestionModel.minScore` when `_hasItemScoring=== true` return the sum of `_selectable` lowest negative `_items._score`
* `ItemsQuestionModel._score` defaulted to 0

Test with https://github.com/adaptlearning/adapt-contrib-assessment/pull/132