### PR TITLE
issue/1568 Allow parse of @menu @page @article without offsets

### DIFF
--- a/src/core/js/adapt.js
+++ b/src/core/js/adapt.js
@@ -365,7 +365,8 @@ class AdaptSingleton extends LockingModel {
    * Trickle uses this function to determine where it should scrollTo after it unlocks
    */
   parseRelativeString(relativeString) {
-    const splitIndex = relativeString.search(/[ +\-\d]{1}/);
+    let splitIndex = relativeString.search(/[ +\-\d]{1}/);
+    if (splitIndex === -1) splitIndex = relativeString.length;
     const type = relativeString.slice(0, splitIndex).replace(/^@/, '');
     const offset = parseInt(relativeString.slice(splitIndex).trim() || 0);
     return {


### PR DESCRIPTION
fixes #1568 

### Changed
* Allowed `Adapt.parseRelativeString` to return `{ type: 'menu', offset: 0 }` when receiving type groups without an offset like `@menu`, `@page`, `@article` rather than `@menu+0` which is how to find the current ancestor menu