### PR TITLE
issue/3180 Update babel-plugin-transform-amd-to-es6

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@types/backbone": "^1.4.1",
         "@types/jquery": "^3.3.31",
         "async": "^3.1.1",
-        "babel-plugin-transform-amd-to-es6": "^0.4.0",
+        "babel-plugin-transform-amd-to-es6": "^0.5.3",
         "babel-plugin-transform-react-templates": "^0.1.0",
         "chalk": "^2.4.1",
         "columnify": "^1.5.4",


### PR DESCRIPTION
fixes #3180 

### Updated
* [babel-plugin-transform-amd-to-es6](https://github.com/cgkineo/babel-plugin-transform-amd-to-es6) node module to latest version, which has a new umd > amd preconversion then amd > es6

### Test
* Add [adapt-chartjs](https://github.com/dancgray/adapt-chartjs) to your project, the umd library `js/Chart.min` should transpile correctly