### PR TITLE
issue/3195 Missing .model on line 465 creating error

### DIFF
--- a/src/core/js/views/questionView.js
+++ b/src/core/js/views/questionView.js
@@ -462,7 +462,7 @@ class ViewOnlyQuestionViewCompatibilityLayer extends QuestionView {
         this.model.set('_isCorrect', false);
       }
 
-      this.set({
+      this.model.set({
         _rawScore: this.model.get('_isCorrect') ? this.model.get('_questionWeight') : 0,
         _maxScore: this.model.get('_questionWeight'),
         _minScore: 0


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt_framework/issues/3195

### Fixed
* Typo with missing `this.model` in compatibility layer