### PR TITLE
Set bold font weight for b and strong tags

### DIFF
--- a/src/core/less/_defaults/base.less
+++ b/src/core/less/_defaults/base.less
@@ -74,3 +74,10 @@ zw {
 nb {
   white-space: nowrap;
 }
+
+// Set bold font weight for b and strong tags
+// --------------------------------------------------
+b,
+strong {
+  font-weight: bold;
+}


### PR DESCRIPTION
It's expected that these tags are bold.

The current font-weight: bolder; inherited from normalize.less only increase the weight to the next weight value which can be less than the standard bold (700).
https://www.quirksmode.org/css/text/fontweight.html

resolves https://github.com/adaptlearning/adapt_framework/issues/3193