### PR TITLE
issue/3208 Correct bad libraries/ imports

### DIFF
--- a/grunt/config/javascript.js
+++ b/grunt/config/javascript.js
@@ -27,6 +27,9 @@ module.exports = function(grunt, options) {
           '<%= sourcedir %>menu/*/templates/**/*.jsx',
           '<%= sourcedir %>theme/*/templates/**/*.jsx'
         ],
+        externalMap: {
+          '.*/libraries/(?!mediaelement-fullscreen-hook)+': 'libraries/'
+        },
         external: {
           jquery: 'empty:',
           underscore: 'empty:',
@@ -95,6 +98,9 @@ module.exports = function(grunt, options) {
           '<%= sourcedir %>menu/*/templates/**/*.jsx',
           '<%= sourcedir %>theme/*/templates/**/*.jsx'
         ],
+        externalMap: {
+          '.*/libraries/(?!mediaelement-fullscreen-hook)+': 'libraries/'
+        },
         external: {
           jquery: 'empty:',
           underscore: 'empty:',

--- a/grunt/tasks/javascript.js
+++ b/grunt/tasks/javascript.js
@@ -196,7 +196,7 @@ module.exports = function(grunt) {
               moduleId = moduleId.replace(mapPart, options.map[mapPart]);
             }
             // Remap ../libraries/ or core/js/libraries/ to libraries/
-            moduleId = Object.entries(externalMap).reduce((moduleId, [ match, replaceWith]) => moduleId.replace((new RegExp(match, 'g')), replaceWith), moduleId);
+            moduleId = Object.entries(externalMap).reduce((moduleId, [ match, replaceWith ]) => moduleId.replace((new RegExp(match, 'g')), replaceWith), moduleId);
             const isRelative = (moduleId[0] === '.');
             if (isRelative) {
               if (!parentId) {

--- a/grunt/tasks/javascript.js
+++ b/grunt/tasks/javascript.js
@@ -164,6 +164,7 @@ module.exports = function(grunt) {
       // Process remapping and external model configurations
       const mapParts = Object.keys(options.map);
       const externalParts = Object.keys(options.external);
+      const externalMap = options.externalMap;
 
       const findFile = function(filename) {
         filename = filename.replace(convertSlashes, '/');
@@ -194,6 +195,8 @@ module.exports = function(grunt) {
               // Remap module, usually coreJS/adapt to core/js/adapt etc
               moduleId = moduleId.replace(mapPart, options.map[mapPart]);
             }
+            // Remap ../libraries/ or core/js/libraries/ to libraries/
+            moduleId = Object.entries(externalMap).reduce((moduleId, [ match, replaceWith]) => moduleId.replace((new RegExp(match, 'g')), replaceWith), moduleId);
             const isRelative = (moduleId[0] === '.');
             if (isRelative) {
               if (!parentId) {
@@ -307,6 +310,7 @@ module.exports = function(grunt) {
               [
                 'transform-amd-to-es6',
                 {
+                  umdToAMDModules: true,
                   amdToES6Modules: true,
                   amdDefineES6Modules: true,
                   ignoreNestedRequires: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1413,9 +1413,9 @@
             }
         },
         "babel-plugin-transform-amd-to-es6": {
-            "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/babel-plugin-transform-amd-to-es6/-/babel-plugin-transform-amd-to-es6-0.5.4.tgz",
-            "integrity": "sha512-LWlsGSCRvIGTk0Ti04bK1rDye12SHhA7JhMzculKmQnNKAriQhMZIjV5UU20goGKvEIEqVbqJUZDI9aM3WcfyA==",
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-amd-to-es6/-/babel-plugin-transform-amd-to-es6-0.6.1.tgz",
+            "integrity": "sha512-r9QxY3RC/uPGaYf5cyZ34+ZMtQO5srB+pxfaO4HOz5rm0iwu6SAbeDTwQD1DnwqZr+egVTpseSbjwPGyZZJcGw==",
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "minimatch": "^3.0.4"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@types/backbone": "^1.4.1",
         "@types/jquery": "^3.3.31",
         "async": "^3.1.1",
-        "babel-plugin-transform-amd-to-es6": "^0.5.4",
+        "babel-plugin-transform-amd-to-es6": "^0.6.1",
         "babel-plugin-transform-react-templates": "^0.1.0",
         "chalk": "^2.4.1",
         "columnify": "^1.5.4",


### PR DESCRIPTION
#3208 

### Fixed
* Remap `../libraries/` or `core/js/libraries/` style imports to `libraries/` which will keep them out of the compilation process

### Updated
* `babel-plugin-transform-amd-to-es6` from v 0.5.4 to 0.6.1