### PR TITLE
issue/3222

### DIFF
--- a/src/core/js/data.js
+++ b/src/core/js/data.js
@@ -90,9 +90,9 @@ class Data extends AdaptCollection {
 
     // Language not available to the course, so reset the active language.
     // This will trigger an onLanguageChange reload
-    if (!isLanguageAvailable) {
+    if (language !== Adapt.config.get('_defaultLanguage') && !isLanguageAvailable) {
       language = Adapt.config.get('_defaultLanguage')
-      Adapt.config.set('_activeLanguage', language);
+      Adapt.config.unset('_activeLanguage');
       return;
     }
 

--- a/src/core/js/data.js
+++ b/src/core/js/data.js
@@ -85,13 +85,12 @@ class Data extends AdaptCollection {
   async loadCourseData(newLanguage) {
 
     // All code that needs to run before adapt starts should go here
-    let language = Adapt.config.get('_activeLanguage');
+    const language = Adapt.config.get('_activeLanguage');
     const isLanguageAvailable = Adapt.config.get('_languagePicker')?._languages?.some(({ _language }) => _language === language);
 
     // Language not available to the course, so reset the active language.
     // This will trigger an onLanguageChange reload
     if (language !== Adapt.config.get('_defaultLanguage') && !isLanguageAvailable) {
-      language = Adapt.config.get('_defaultLanguage')
       Adapt.config.unset('_activeLanguage');
       return;
     }


### PR DESCRIPTION
Fixes [#3222](https://github.com/adaptlearning/adapt_framework/issues/3222)

compare active to default lang before unsetting activeLang

unset will prevent skipping of languagePicker screen on bad lang param