### PR TITLE
issue/3232 Fix for adapt-cli and adapt-contrib-core

### DIFF
--- a/gitmodules.js
+++ b/gitmodules.js
@@ -57,7 +57,7 @@ if (isFrameworkClone) {
 } else {
   // Clone submodules
   for (const path in modules) {
-    if (fs.existsSync(path)) continue;
+    if (fs.existsSync(`${path}/package.json`)) continue;
     const url = modules[path].url;
     console.log(`Cloning submodule ${url} to ${path}`);
     ChildProcess.execSync(`git clone ${url} ${path}`, {


### PR DESCRIPTION
fixes #3232 

Fixes `adapt create course` for `src/core` to [adapt-contrib-core](https://github.com/adaptlearning/adapt-contrib-core) submodule.

### Fixed
* If the `preinstall` script is run from a zip download rather than a clone, ensure submodules are cloned instead of being updated.

### To test
Run `$ adapt create course` with branch `issue/3232` instead of `master`