### PR TITLE
issue/3236 Allow for drop of ie11

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,9 @@
+# comment out where appropriate
+last 2 chrome versions
+last 2 firefox versions
+last 2 safari versions
+last 2 edge versions
+last 2 ios_saf versions
+last 2 and_chr versions
+firefox esr
+ie 11

--- a/grunt/tasks/javascript.js
+++ b/grunt/tasks/javascript.js
@@ -296,9 +296,6 @@ module.exports = function(grunt) {
                 {
                   useBuiltIns: 'entry',
                   corejs: 3,
-                  targets: {
-                    ie: '11'
-                  },
                   exclude: [
                     // Breaks lockingModel.js, set function vs set variable
                     'transform-function-name'


### PR DESCRIPTION
part fix for #3236 

### Changed
* Allow ES output to be determined by external config file as per https://babeljs.io/docs/en/babel-preset-env#browserslist-integration

### Testing
* Ensure to switch to [issue/3236](https://github.com/adaptlearning/adapt-contrib-core/tree/issue/3236) branch of adapt-contrib-core [pr#1](https://github.com/adaptlearning/adapt-contrib-core/pull/1) remove `ie11` line from [.browserslistrc](https://github.com/adaptlearning/adapt_framework/blob/f46f558ce3b4d03f54751ee0d115947725047e83/.browserslistrc#L9) and `grunt dev`
