### PR TITLE
issue/3252 Extra path and error handling to gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,5 @@
 [submodule "src/core"]
-	path = src/core
-	branch = v6.0.3
-	url = https://github.com/adaptlearning/adapt-contrib-core
+  path = src/core
+  branch = master
+  url = https://github.com/adaptlearning/adapt-contrib-core
+  installBranch = v6.0.3

--- a/gitmodules.js
+++ b/gitmodules.js
@@ -57,7 +57,8 @@ for (const subPath in modules) {
   const hasPackageJSON = fs.existsSync(path.join(dirPath, 'package.json'));
   if (!hasPackageJSON) {
     console.log(`Cleaning ${subPath}`);
-    fs.rmSync(dirPath, { recursive: true, force: true });
+    // rmSync was introduced in node v14.14.0
+    fs[fs.rmSync ? 'rmSync' : 'rmdirSync'](dirPath, { recursive: true, force: true });
   }
   if (hasPackageJSON) {
     console.log(`Updating ${subPath} from origin`);

--- a/gitmodules.js
+++ b/gitmodules.js
@@ -56,7 +56,7 @@ for (const subPath in modules) {
   const url = modules[subPath].url;
   console.log(`Cleaning ${subPath}`);
   fs.rmSync(dirPath, { recursive: true, force: true });
-  console.log(`Cloning submodule ${url} to ${subPath}`);
+  console.log(`Cloning submodule ${url} into ${subPath}`);
   ChildProcess.execSync(`git clone ${url} ${subPath}`, {
     cwd: __dirname,
     env,
@@ -70,7 +70,7 @@ for (const subPath in modules) {
   const branch = (modules[subPath].installBranch || modules[subPath].branch);
   const hasGit = fs.existsSync(path.join(dirPath, '.git'));
   if (!hasGit) continue;
-  console.log(`Switching submodule ${subPath} into branch ${branch}`);
+  console.log(`Switching submodule ${subPath} to branch ${branch}`);
   ChildProcess.execSync(`git checkout ${branch}`, {
     cwd: dirPath,
     env,

--- a/gitmodules.js
+++ b/gitmodules.js
@@ -54,20 +54,8 @@ const env = Object.assign({}, process.env, {
 for (const subPath in modules) {
   const dirPath = path.join(__dirname, subPath);
   const url = modules[subPath].url;
-  const hasPackageJSON = fs.existsSync(path.join(dirPath, 'package.json'));
-  if (!hasPackageJSON) {
-    console.log(`Removing erroneous files from ${subPath}`);
-    fs.rmSync(dirPath, { recursive: true, force: true });
-  }
-  if (hasPackageJSON) {
-    console.log(`Updating ${subPath} from origin`);
-    ChildProcess.execSync(`git fetch --prune`, {
-      cwd: dirPath,
-      env,
-      stdio: 'inherit'
-    });
-    continue;
-  };
+  console.log(`Cleaning ${subPath}`);
+  fs.rmSync(dirPath, { recursive: true, force: true });
   console.log(`Cloning submodule ${url} to ${subPath}`);
   ChildProcess.execSync(`git clone ${url} ${subPath}`, {
     cwd: __dirname,
@@ -82,7 +70,7 @@ for (const subPath in modules) {
   const branch = (modules[subPath].installBranch || modules[subPath].branch);
   const hasGit = fs.existsSync(path.join(dirPath, '.git'));
   if (!hasGit) continue;
-  console.log(`Switching submodule ${subPath} to branch ${branch}`);
+  console.log(`Switching submodule ${subPath} into branch ${branch}`);
   ChildProcess.execSync(`git checkout ${branch}`, {
     cwd: dirPath,
     env,

--- a/gitmodules.js
+++ b/gitmodules.js
@@ -54,8 +54,20 @@ const env = Object.assign({}, process.env, {
 for (const subPath in modules) {
   const dirPath = path.join(__dirname, subPath);
   const url = modules[subPath].url;
-  console.log(`Cleaning ${subPath}`);
-  fs.rmSync(dirPath, { recursive: true, force: true });
+  const hasPackageJSON = fs.existsSync(path.join(dirPath, 'package.json'));
+  if (!hasPackageJSON) {
+    console.log(`Cleaning ${subPath}`);
+    fs.rmSync(dirPath, { recursive: true, force: true });
+  }
+  if (hasPackageJSON) {
+    console.log(`Updating ${subPath} from origin`);
+    ChildProcess.execSync(`git fetch --prune`, {
+      cwd: dirPath,
+      env,
+      stdio: 'inherit'
+    });
+    continue;
+  };
   console.log(`Cloning submodule ${url} into ${subPath}`);
   ChildProcess.execSync(`git clone ${url} ${subPath}`, {
     cwd: __dirname,


### PR DESCRIPTION
fixes #3252 

### Fixed
* Ensured path is correct for git commands
* Moved install branch to non-conflicting property in `.gitmodules`
* Remove potentially errorneous files before attempting to clone