### PR TITLE
issue/3277 Fix for build.cachepath = null

### DIFF
--- a/grunt/config/replace.js
+++ b/grunt/config/replace.js
@@ -70,7 +70,7 @@ module.exports = function(grunt, options) {
       return {
         'course': filterNullValues(courseJson),
         'config': filterNullValues(configJson),
-        'build': Helpers.generateConfigData()
+        'build': filterNullValues(Helpers.generateConfigData())
       };
     } catch (ex) {
       return {};


### PR DESCRIPTION
fixes bug in https://github.com/adaptlearning/adapt_framework/pull/3278
fixes #3277 

![image](https://user-images.githubusercontent.com/7974663/157732870-e5bac4c0-6bf5-4ca4-bbf0-6197a4cbe000.png)


### Fixed
* Strip null values from `build` object in `replace` task for `imsmanifest.xml`