### PR TITLE
Highlight the Node requirements of the framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,6 @@ See [Contributing to the Adapt Framework](https://github.com/adaptlearning/adapt
 
 ## License
 <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>  Adapt is licensed under the [GNU General Public License, Version 3](https://github.com/adaptlearning/adapt_framework/blob/master/LICENSE).
+
+## Requirements
+Node >=14 is required for the grunt tasks to run as needed

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "bugs": {
         "url": "https://github.com/adaptlearning/adapt_framework/issues"
     },
+    "engines": {
+        "node": ">=14"
+    },
     "dependencies": {
         "@babel/core": "^7.16.5",
         "@babel/plugin-transform-react-jsx": "^7.16.5",


### PR DESCRIPTION
Fixes #3288

The grunt tasks of the framework now require Node v14+ but this was not indicated in the documentation