### PR TITLE
issue/3287 Added missing assessment configurations

### DIFF
--- a/src/course/en/articles.json
+++ b/src/course/en/articles.json
@@ -30,25 +30,31 @@
         "_assessment": {
             "_isEnabled": true,
             "_id": "a-15",
-            "_isPercentageBased": true,
+            "_suppressMarking": false,
             "_scoreToPass": 75,
+            "_correctToPass": 75,
+            "_isPercentageBased": true,
             "_includeInTotalScore": true,
             "_assessmentWeight": 1,
-            "_suppressMarking": false,
+            "_isResetOnRevisit": true,
+            "_attempts": "infinite",
             "_allowResetIfPassed": false,
+            "_scrollToOnReset": false,
             "_banks": {
                 "_isEnabled": true,
                 "_split": "2,2",
                 "_randomisation": true
+            },
+            "_randomisation": {
+                "_isEnabled": false,
+                "_blockCount": 1
             },
             "_questions": {
                 "_resetType": "hard",
                 "_canShowFeedback": false,
                 "_canShowMarking": false,
                 "_canShowModelAnswer": false
-            },
-            "_isResetOnRevisit": true,
-            "_attempts": "infinite"
+            }
         },
         "_trickle": {
             "_isEnabled": true,


### PR DESCRIPTION
fixes #3287 

### Fixed
* Populated vanilla course assessment article with relevant example.json defaults