### PR TITLE
issue/3305 Support for alternative course folder name

### DIFF
--- a/grunt/config/copy.js
+++ b/grunt/config/copy.js
@@ -29,8 +29,8 @@ module.exports = function(grunt, options) {
         {
           expand: true,
           src: ['<%= languages %>/**/*', '!**/*.<%= jsonext %>'],
-          cwd: '<%= sourcedir %>course/',
-          dest: '<%= outputdir %>course/'
+          cwd: '<%= sourcedir %><%= coursedir %>/',
+          dest: '<%= outputdir %><%= coursedir %>/'
         }
       ]
     },
@@ -39,8 +39,8 @@ module.exports = function(grunt, options) {
         {
           expand: true,
           src: ['<%= languages %>/*.<%= jsonext %>', '*.<%= jsonext %>'],
-          cwd: '<%= sourcedir %>course/',
-          dest: '<%= outputdir %>course/'
+          cwd: '<%= sourcedir %><%= coursedir %>/',
+          dest: '<%= outputdir %><%= coursedir %>/'
         }
       ]
     }

--- a/grunt/config/json-minify.js
+++ b/grunt/config/json-minify.js
@@ -1,7 +1,7 @@
 module.exports = function(grunt, options) {
   return {
     minify: {
-      files: '<%= outputdir %>/course/**/*.<%= jsonext %>'
+      files: '<%= outputdir %>/<%= coursedir %>/**/*.<%= jsonext %>'
     }
   };
 };

--- a/grunt/config/jsonlint.js
+++ b/grunt/config/jsonlint.js
@@ -1,3 +1,3 @@
 module.exports = {
-  src: ['<%= sourcedir %>course/<%=languages%>/*.<%=jsonext%>']
+  src: ['<%= sourcedir %><%= coursedir %>/<%=languages%>/*.<%=jsonext%>']
 };

--- a/grunt/config/less.js
+++ b/grunt/config/less.js
@@ -59,7 +59,7 @@ module.exports = function(grunt, options) {
           '<%= sourcedir %>menu/<%= menu %>/**/*.less',
           '<%= sourcedir %>theme/<%= theme %>/**/*.less'
         ],
-        config: '<%= outputdir %>course/config.<%= jsonext %>',
+        config: '<%= outputdir %><%= coursedir %>/config.<%= jsonext %>',
         sourcemaps: true,
         compress: false,
         dest: '<%= outputdir %>',
@@ -94,7 +94,7 @@ module.exports = function(grunt, options) {
           '<%= sourcedir %>menu/<%= menu %>/**/*.less',
           '<%= sourcedir %>theme/<%= theme %>/**/*.less'
         ],
-        config: '<%= outputdir %>course/config.<%= jsonext %>',
+        config: '<%= outputdir %><%= coursedir %>/config.<%= jsonext %>',
         sourcemaps: false,
         compress: true,
         dest: '<%= outputdir %>',

--- a/grunt/config/watch.js
+++ b/grunt/config/watch.js
@@ -17,11 +17,11 @@ module.exports = {
     tasks: ['handlebars', 'javascript:dev']
   },
   courseJson: {
-    files: ['<%= sourcedir %>course/**/*.<%= jsonext %>', '<%= outputdir %>course/*/language_data_manifest.js'],
+    files: ['<%= sourcedir %><%= coursedir %>/**/*.<%= jsonext %>', '<%= outputdir %><%= coursedir %>/*/language_data_manifest.js'],
     tasks: ['language-data-manifests', 'jsonlint', 'check-json', 'newer:copy:courseJson', 'schema-defaults']
   },
   courseAssets: {
-    files: ['<%= sourcedir %>course/<%=languages%>/*', '!<%= sourcedir %>course/<%=languages%>/*.<%= jsonext %>'],
+    files: ['<%= sourcedir %><%= coursedir %>/<%=languages%>/*', '!<%= sourcedir %><%= coursedir %>/<%=languages%>/*.<%= jsonext %>'],
     tasks: ['newer:copy:courseAssets']
   },
   js: {

--- a/grunt/helpers.js
+++ b/grunt/helpers.js
@@ -1,5 +1,5 @@
 var _ = require('underscore');
-var fs = require('fs');
+var fs = require('fs-extra');
 var path = require('path');
 // extends grunt.file.expand with { order: cb(filePaths) }
 require('grunt-file-order');
@@ -149,6 +149,7 @@ module.exports = function(grunt) {
     defaults: {
       sourcedir: 'src/',
       outputdir: 'build/',
+      coursedir: 'course',
       cachepath: null,
       jsonext: 'json',
       theme: '**',
@@ -195,11 +196,13 @@ module.exports = function(grunt) {
     generateConfigData: function() {
 
       var root = __dirname.split(path.sep).slice(0, -1).join(path.sep);
+      var adaptJSON = fs.readJSONSync(`${root}/adapt.json`);
       var sourcedir = appendSlash(grunt.option('sourcedir')) || exports.defaults.sourcedir;
       var outputdir = appendSlash(grunt.option('outputdir')) || exports.defaults.outputdir;
       var cachepath = grunt.option('cachepath') || null;
       var tempdir = outputdir + '.temp/';
       var jsonext = grunt.option('jsonext') || exports.defaults.jsonext;
+      var coursedir = grunt.option('coursedir') || adaptJSON.coursedir || exports.defaults.coursedir;
 
       var languageFolders = '';
       if (grunt.option('languages') && grunt.option('languages').split(',').length > 1) {
@@ -212,7 +215,7 @@ module.exports = function(grunt) {
       var configDir = grunt.option('outputdir') ? outputdir : sourcedir;
       // add root path if necessary, and point to course/config.json
 
-      var configPath = path.join(path.resolve(root, configDir), 'course', 'config.' + jsonext);
+      var configPath = path.join(path.resolve(root, configDir), coursedir, 'config.' + jsonext);
 
       try {
         var buildConfig = grunt.file.readJSON(configPath).build || {};
@@ -229,6 +232,7 @@ module.exports = function(grunt) {
         sourcedir: sourcedir,
         outputdir: outputdir,
         configdir: configDir,
+        coursedir: coursedir,
         cachepath: cachepath,
         tempdir: tempdir,
         jsonext: jsonext,
@@ -255,6 +259,7 @@ module.exports = function(grunt) {
         rootPath: data.root,
         outputPath: data.outputdir,
         sourcePath: data.sourcedir,
+        courseDir: data.coursedir,
         includedFilter: exports.includedFilter,
         jsonext: data.jsonext,
         trackingIdType: data.trackingIdType,
@@ -357,6 +362,7 @@ module.exports = function(grunt) {
         rootPath: buildConfig.root,
         outputPath: buildConfig.outputdir,
         sourcePath: buildConfig.sourcedir,
+        courseDir: buildConfig.coursedir,
         includedFilter: exports.includedFilter,
         jsonext: buildConfig.jsonext,
         trackingIdType: buildConfig.trackingIdType,

--- a/grunt/helpers/Data.js
+++ b/grunt/helpers/Data.js
@@ -25,6 +25,7 @@ class Data {
    * @param {Object} options
    * @param {Framework} options.framework
    * @param {string} options.sourcePath
+   * @param {string} options.courseDir
    * @param {string} options.jsonext
    * @param {string} options.trackingIdType
    * @param {function} options.log
@@ -32,6 +33,7 @@ class Data {
   constructor({
     framework = null,
     sourcePath = null,
+    courseDir = null,
     jsonext = 'json',
     trackingIdType = 'block',
     log = console.log
@@ -40,6 +42,8 @@ class Data {
     this.framework = framework;
     /** @type {string} */
     this.sourcePath = sourcePath;
+    /** @type {string} */
+    this.courseDir = courseDir;
     /** @type {string} */
     this.jsonext = jsonext;
     /** @type {string} */
@@ -54,11 +58,12 @@ class Data {
 
   /** @returns {Data} */
   load() {
-    const coursePath = path.join(this.sourcePath, 'course').replace(/\\/g, '/');
+    const coursePath = path.join(this.sourcePath, this.courseDir).replace(/\\/g, '/');
     this.languages = globs.sync(path.join(coursePath, '*/')).map(languagePath => {
       const language = new Language({
         framework: this.framework,
         languagePath,
+        courseDir: this.courseDir,
         jsonext: this.jsonext,
         trackingIdType: this.trackingIdType,
         log: this.log
@@ -130,6 +135,7 @@ class Data {
       toLang = new Language({
         framework: this.framework,
         languagePath: newPath,
+        courseDir: this.courseDir,
         jsonext: this.jsonext,
         trackingIdType: this.trackingIdType
       });

--- a/grunt/helpers/Framework.js
+++ b/grunt/helpers/Framework.js
@@ -31,6 +31,7 @@ class Framework {
     rootPath = process.cwd(),
     outputPath = process.cwd() + '/build/',
     sourcePath = process.cwd() + '/src/',
+    courseDir = 'course',
     includedFilter = function() { return true; },
     jsonext = 'json',
     trackingIdType = 'block',
@@ -44,6 +45,8 @@ class Framework {
     this.outputPath = outputPath.replace(/\\/g, '/');
     /** @type {string} */
     this.sourcePath = sourcePath.replace(/\\/g, '/');
+    /** @type {string} */
+    this.courseDir = courseDir;
     /** @type {function} */
     this.includedFilter = includedFilter;
     /** @type {string} */
@@ -92,6 +95,7 @@ class Framework {
     const data = new Data({
       framework: this,
       sourcePath: useOutputData ? this.outputPath : this.sourcePath,
+      courseDir: this.courseDir,
       jsonext: this.jsonext,
       trackingIdType: this.trackingIdType,
       log: this.log
@@ -152,6 +156,7 @@ class Framework {
       sourcePath: this.sourcePath,
       languagePath,
       outputPath: this.outputPath,
+      courseDir: this.courseDir,
       useOutputData: this.useOutputData,
       isTest,
       log: this.log,

--- a/grunt/helpers/Plugins.js
+++ b/grunt/helpers/Plugins.js
@@ -23,6 +23,7 @@ class Plugins {
     framework = null,
     includedFilter = function() { return true; },
     sourcePath = process.cwd() + '/src/',
+    courseDir = 'course',
     log = console.log,
     warn = console.warn
   } = {}) {
@@ -32,6 +33,8 @@ class Plugins {
     this.includedFilter = includedFilter;
     /** @type {string} */
     this.sourcePath = sourcePath;
+    /** @type {string} */
+    this.courseDir = courseDir;
     /** @type {function} */
     this.log = log;
     /** @type {function} */
@@ -47,7 +50,7 @@ class Plugins {
   get pluginLocations() {
     return [
       `${this.sourcePath}core/`,
-      `${this.sourcePath}!(core|course)/*/`
+      `${this.sourcePath}!(core|${this.courseDir})/*/`
     ];
   }
 

--- a/grunt/helpers/Translate.js
+++ b/grunt/helpers/Translate.js
@@ -47,6 +47,7 @@ class Translate {
     sourcePath = '',
     languagePath = path.join(process.cwd(), 'languagefiles'),
     outputPath = '',
+    courseDir = 'course',
     useOutputData = false,
     isTest = false,
     log = console.log,
@@ -73,6 +74,8 @@ class Translate {
     this.sourcePath = sourcePath.replace(/\\/g, '/');
     /** @type {string} */
     this.outputPath = outputPath.replace(/\\/g, '/');
+    /** @type {string} */
+    this.courseDir = courseDir;
     /** @type {Framework} */
     this.useOutputData = useOutputData;
     /** @type {string} */
@@ -92,6 +95,7 @@ class Translate {
     this.data = new Data({
       framework: this.framework,
       sourcePath: this.useOutputData ? this.outputPath : this.sourcePath,
+      courseDir: this.courseDir,
       jsonext: this.jsonext,
       trackingIdType: this.framework.trackingIdType,
       log: this.log


### PR DESCRIPTION
part of https://github.com/adaptlearning/adapt_framework/issues/3305

### Added
* Allow alternative course folder name to be specified at the grunt command `grunt dev --coursedir=alternative` or in the adapt.json at `"coursedir": "alternative"`

### Testing
1. To change the folder from `course` to `alternative` and test out the code
```sh
git clone https://github.com/adaptlearning/adapt_framework 3305-course
cd 3305-course
git checkout issue/3305
mv src/course src/alternative
adapt devinstall && npm install
cd src/core
git checkout issue/3305
cd ../../
grunt dev --coursedir=alternative
```
2. You will need to find and replace all of the images in the json files from `course/` to `alternative/`