### PR TITLE
issue/3309 Drop IE11 compilation

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -6,4 +6,3 @@ last 2 edge versions
 last 2 ios_saf versions
 last 2 and_chr versions
 firefox esr
-ie 11


### PR DESCRIPTION
fixes #3309 

Reduces the size of the output by some 300kb, improves the relationship between the source-code and source-maps thereby improving in-browser debugging, speeds up compile.

### Removed
* IE11 compilation