### PR TITLE
issue/3312 Allow configurable javascript targets

### DIFF
--- a/grunt/helpers.js
+++ b/grunt/helpers.js
@@ -241,7 +241,8 @@ module.exports = function(grunt) {
         menu: grunt.option('menu') || exports.defaults.menu,
         languages: languageFolders || exports.defaults.languages,
         scriptSafe: exports.defaults.scriptSafe,
-        strictMode: false
+        strictMode: false,
+        targets: buildConfig.targets || ''
       };
 
       if (buildConfig.jsonext) data.jsonext = buildConfig.jsonext;

--- a/grunt/tasks/javascript.js
+++ b/grunt/tasks/javascript.js
@@ -270,6 +270,9 @@ module.exports = function(grunt) {
         };
       };
 
+      const targets = buildConfig.targets || fs.readFileSync('.browserslistrc').toString().replace(/#+[^\n]+\n/gm, '').replace(/\r/g, '').split('\n').filter(Boolean).join(', ');
+      grunt.log.ok(`Targets: ${targets}`);
+
       const inputOptions = {
         input: './' + options.baseUrl + options.name,
         shimMissingExports: true,
@@ -300,7 +303,8 @@ module.exports = function(grunt) {
                   exclude: [
                     // Breaks lockingModel.js, set function vs set variable
                     'transform-function-name'
-                  ]
+                  ],
+                  targets
                 }
               ]
             ],

--- a/grunt/tasks/javascript.js
+++ b/grunt/tasks/javascript.js
@@ -270,8 +270,8 @@ module.exports = function(grunt) {
         };
       };
 
-      const targets = buildConfig.targets || fs.readFileSync('.browserslistrc').toString().replace(/#+[^\n]+\n/gm, '').replace(/\r/g, '').split('\n').filter(Boolean).join(', ');
-      grunt.log.ok(`Targets: ${targets}`);
+      const targets = buildConfig.targets || null;
+      grunt.log.ok(`Targets: ${targets || fs.readFileSync('.browserslistrc').toString().replace(/#+[^\n]+\n/gm, '').replace(/\r/g, '').split('\n').filter(Boolean).join(', ')}`);
 
       const inputOptions = {
         input: './' + options.baseUrl + options.name,


### PR DESCRIPTION
fixes #3312 

### Added
* `targets` to config.json:build

### Test with
`"targets": "ie 11, last 2 chrome versions, last 2 firefox versions, last 2 safari versions, last 2 edge versions, last 2 ios_saf versions, last 2 and_chr versions, firefox esr"`