### PR TITLE
Update: Adds context to status indicators

### DIFF
--- a/src/course/en/course.json
+++ b/src/course/en/course.json
@@ -43,6 +43,11 @@
     "_accessibility": {
       "skipNavigationText": "Skip navigation",
       "_ariaLabels": {
+        "course": "Course",
+        "contentObject": "Page",
+        "article": "Article",
+        "block": "Block",
+        "component": "Component",
         "answeredIncorrectly": "You answered incorrectly",
         "answeredCorrectly": "You answered correctly",
         "selectedAnswer": "selected",


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Update
Status indicators in the aria-label should come first. Additionally, without context as to what is the status is reporting on can cause confusion as to the purpose of the status indicators. It was agreed the best path forward was to present all aria-headers in the following format:
[context (if applicable)] [status]. [title]

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Grab this PR
2. Grab the following PR from core heading updates: https://github.com/adaptlearning/adapt-contrib-core/pull/206

[//]: # (Mention any other dependencies)
This is linked to:
https://github.com/adaptlearning/adapt-contrib-core/pull/206
https://github.com/adaptlearning/adapt-contrib-core/issues/151

