### PR TITLE
Closed Captions default to OFF if srclang is not english (Fixes #3336)

### DIFF
--- a/src/course/en/components.json
+++ b/src/course/en/components.json
@@ -210,6 +210,7 @@
         "_setCompletionOn": "play",
         "_useClosedCaptions": true,
         "_allowFullScreen": true,
+        "_startLanguage": "en",
         "title": "Media",
         "displayTitle": "Media",
         "body": "Sometimes we need to make use of rich media to really drive home a point, bring a complex subject to life or simply use audio to literally do the talking. This is when the <b>Media</b> component comes to the fore.<br><br>Component can be either single or spanned.",


### PR DESCRIPTION
https://github.com/adaptlearning/adapt_framework/compare/issue/3336
fixes https://github.com/adaptlearning/adapt-contrib-media/issues/235

### Fix
- Closed Captions default to OFF if srclang is not english