### PR TITLE
Update: release job now uses v3 for checkout and setup-node actions

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
       - name: Install dependencies


### PR DESCRIPTION
[//]: # (Link the PR to the original issue)
Fixes #3340 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Update
* Packages used for release action updated to Node16 compatible version