### PR TITLE
New: Added grunt `scripts:adaptpostcopy` command

### DIFF
--- a/grunt/tasks/build.js
+++ b/grunt/tasks/build.js
@@ -9,6 +9,7 @@ module.exports = function(grunt) {
     'build-config',
     'tracking-insert',
     'copy',
+    'scripts:adaptpostcopy',
     'schema-defaults',
     'language-data-manifests',
     'handlebars',

--- a/grunt/tasks/dev.js
+++ b/grunt/tasks/dev.js
@@ -8,6 +8,7 @@ module.exports = function(grunt) {
     'build-config',
     'tracking-insert',
     'copy',
+    'scripts:adaptpostcopy',
     'schema-defaults',
     'language-data-manifests',
     'handlebars',

--- a/grunt/tasks/diff.js
+++ b/grunt/tasks/diff.js
@@ -8,6 +8,7 @@ module.exports = function(grunt) {
     'build-config',
     'tracking-insert',
     'copy',
+    'scripts:adaptpostcopy',
     'schema-defaults',
     'language-data-manifests',
     'newer:handlebars:compile',

--- a/grunt/tasks/server-build.js
+++ b/grunt/tasks/server-build.js
@@ -9,6 +9,7 @@ module.exports = function(grunt) {
       '_log-vars',
       'build-config',
       'copy',
+      'scripts:adaptpostcopy',
       'language-data-manifests',
       'less:' + requireMode,
       'handlebars',


### PR DESCRIPTION
Fixes #3342

### New
* Added an additional script for plugins to hook into. Fires following the files being copied to the build folder, but before other helper commands such as `replace`.


