### PR TITLE
Fix: Revert to generic less globs for theme and menu (fixes #3361)

### DIFF
--- a/grunt/config/less.js
+++ b/grunt/config/less.js
@@ -92,8 +92,8 @@ module.exports = function(grunt, options) {
         src: [
           '<%= sourcedir %>components/*/less/**/*.less',
           '<%= sourcedir %>extensions/*/less/**/*.less',
-          '<%= sourcedir %>menu/<%= menu %>/*/less/**/*.less',
-          '<%= sourcedir %>theme/<%= theme %>/*less/**/*.less'
+          '<%= sourcedir %>menu/<%= menu %>/**/*.less',
+          '<%= sourcedir %>theme/<%= theme %>/**/*.less'
         ],
         config: '<%= outputdir %><%= coursedir %>/config.<%= jsonext %>',
         sourcemaps: false,


### PR DESCRIPTION
fixes #3361 

### Fix
* Reverted to generic globs so that, whether or not --menu or --theme are defined at the terminal, the globs work properly


