### PR TITLE
New: Cache management for subsequent compilation improvements (fixes #3363)

### DIFF
--- a/grunt/helpers/CacheManager.js
+++ b/grunt/helpers/CacheManager.js
@@ -28,9 +28,8 @@ module.exports = class CacheManager {
     return tempPath;
   }
 
-  get cachePath() {
-    const projectPath = process.cwd();
-    const projectHash = CacheManager.hash(projectPath);
+  cachePath(basePath, outputFilePath = process.cwd()) {
+    const projectHash = CacheManager.hash(path.join(basePath, outputFilePath));
     const cachePath = path.join(this.tempPath, `${projectHash}.cache`);
     return cachePath;
   }

--- a/grunt/helpers/CacheManager.js
+++ b/grunt/helpers/CacheManager.js
@@ -1,0 +1,89 @@
+const crypto = require('crypto');
+const os = require('os');
+const path = require('path');
+const globs = require('globs');
+const fs = require('fs-extra');
+
+const ONE_MINUTE = 60 * 1000;
+const ONE_HOUR = 60 * ONE_MINUTE;
+const ONE_WEEK = 7 * 24 * ONE_HOUR;
+
+module.exports = class CacheManager {
+
+  constructor (grunt, maxAge = ONE_WEEK) {
+    this.grunt = grunt;
+    this.maxAge = maxAge;
+    fs.ensureDirSync(this.tempPath);
+  }
+
+  static hash (path) {
+    return crypto
+      .createHash('sha1')
+      .update(path, 'utf8')
+      .digest('hex');
+  }
+
+  get tempPath() {
+    const tempPath = path.join(os.tmpdir(), 'adapt_framework');
+    return tempPath;
+  }
+
+  get cachePath() {
+    const projectPath = process.cwd();
+    const projectHash = CacheManager.hash(projectPath);
+    const cachePath = path.join(this.tempPath, `${projectHash}.cache`);
+    return cachePath;
+  }
+
+  get checkFilePath() {
+    const checkFilePath = path.join(this.tempPath, 'last.touch');
+    return checkFilePath;
+  }
+
+  async isCleaningTime() {
+    // By default, clean once a day, or with a floor of one hourly intervals
+    const checkInterval = Math.max(this.maxAge / 7, ONE_HOUR);
+    const checkFilePath = this.checkFilePath;
+    // Check if checkFile is older than the cleaning interval
+    return (!fs.existsSync(checkFilePath) || Date.now() - (await fs.stat(checkFilePath)).mtime >= checkInterval);
+  }
+
+  async clean() {
+    if (!await this.isCleaningTime()) return;
+    // Touch checkFile
+    await fs.writeFile(this.checkFilePath, String(Date.now()));
+    this.grunt.log.ok('Clearing compilation caches...');
+    // Fetch all cache files except checkFile
+    const files = await new Promise((resolve, reject) => globs([
+      `${this.tempPath}/**`,
+      `!${this.checkFilePath}`
+    ], {
+      nodir: true
+    }, (err, files) => err ? reject(err) : resolve(files)));
+    // Fetch file ages
+    const fileAges = [];
+    const now = Date.now();
+    for (const index in files) {
+      const file = files[index];
+      let age = this.maxAge;
+      try {
+        const stat = await fs.stat(file);
+        age = (now - stat.mtime);
+      } catch (err) {}
+      fileAges[index] = { file, age };
+    }
+    // Sort by oldest
+    fileAges.sort((a, b) => b.age - a.age);
+    // Filter by expired
+    const toRemove = fileAges.filter(fileAge => fileAge.age >= this.maxAge);
+    // Delete expired cache files
+    for (const fileAge of toRemove) {
+      try {
+        await fs.unlink(fileAge.file);
+      } catch (err) {
+        this.grunt.log.warn(`Could not clear cache file ${fileAge.file}`);
+      }
+    }
+  }
+
+};

--- a/grunt/tasks/javascript.js
+++ b/grunt/tasks/javascript.js
@@ -1,3 +1,5 @@
+const CacheManager = require('../helpers/CacheManager');
+
 module.exports = function(grunt) {
 
   const convertSlashes = /\\/g;
@@ -18,6 +20,7 @@ module.exports = function(grunt) {
   let cache;
 
   const extensions = ['.js', '.jsx'];
+  const cacheManager = new CacheManager(grunt);
 
   const restoreCache = async (cachePath, basePath) => {
     if (isDisableCache || cache || !fs.existsSync(cachePath)) return;
@@ -125,11 +128,12 @@ module.exports = function(grunt) {
     grunt.log.ok(`Strict mode (config.json:build.strictMode): ${isStrictMode}`);
     const done = this.async();
     const options = this.options({});
-    const cachePath = buildConfig.cachepath ?? options.cachePath;
+    const cachePath = buildConfig.cachepath ?? cacheManager.cachePath;
     const isSourceMapped = Boolean(options.generateSourceMaps);
     const basePath = path.resolve(cwd + '/' + options.baseUrl).replace(convertSlashes, '/') + '/';
     try {
       await restoreCache(cachePath, basePath);
+      await cacheManager.clean();
       const pluginsPath = path.resolve(cwd, options.pluginsPath).replace(convertSlashes, '/');
 
       // Make src/plugins.js to attach the plugins dynamically

--- a/grunt/tasks/javascript.js
+++ b/grunt/tasks/javascript.js
@@ -128,9 +128,9 @@ module.exports = function(grunt) {
     grunt.log.ok(`Strict mode (config.json:build.strictMode): ${isStrictMode}`);
     const done = this.async();
     const options = this.options({});
-    const cachePath = buildConfig.cachepath ?? cacheManager.cachePath;
     const isSourceMapped = Boolean(options.generateSourceMaps);
     const basePath = path.resolve(cwd + '/' + options.baseUrl).replace(convertSlashes, '/') + '/';
+    const cachePath = buildConfig.cachepath ?? cacheManager.cachePath(cwd, options.out);
     try {
       await restoreCache(cachePath, basePath);
       await cacheManager.clean();
@@ -410,6 +410,9 @@ window.__AMD = function(id, value) {
 
       done();
     } catch (err) {
+      try {
+        await fs.unlink(cachePath);
+      } catch (err) {}
       logPrettyError(err, cachePath, basePath);
       done(false);
     }


### PR DESCRIPTION
fixes #3363 

### New
* Allow adapt_framework to store javascript compilation cache files in the operating system temp folder, cleaning up files, once a day, if they are older than a week. Reduces subsequent compilation times sustantially. Initial compilation remains unchanged. Files are cached in `$TMPDIR/adapt_framework/`.


