### PR TITLE
New: Add vanilla favicon support (fixes: #306)

### DIFF
--- a/src/course/en/course.json
+++ b/src/course/en/course.json
@@ -163,7 +163,7 @@
   },
   "_vanilla": {
       "_favIcon": {
-          "_src": ""
+          "_src": "https://www.adaptlearning.org/wp-content/uploads/2018/02/cropped-nav_logo_gold-192x192.png"
       }
   }
 }

--- a/src/course/en/course.json
+++ b/src/course/en/course.json
@@ -160,5 +160,10 @@
       "yes": "Yes",
       "no": "No"
     }
+  },
+  "_vanilla": {
+      "_favIcon": {
+          "_src": ""
+      }
   }
 }


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt-contrib-core/issues/306
theme adjustment here: https://github.com/adaptlearning/adapt-contrib-vanilla/pull/396

### New
* Added favicon support

### Example icon
Source url: https://www.adaptlearning.org/wp-content/uploads/2018/02/cropped-nav_logo_gold-192x192.png
Zip: [cropped-nav_logo_gold-192x192.zip](https://github.com/adaptlearning/adapt-contrib-vanilla/files/10863945/cropped-nav_logo_gold-192x192.zip)


### References
* https://en.wikipedia.org/wiki/Favicon
* https://developer.mozilla.org/en-US/docs/Glossary/Favicon
* https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#icon
* https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html#//apple_ref/doc/uid/TP40002051-CH3-SW4
