### PR TITLE
New: Breakpoints derived from schema defaults

### DIFF
--- a/grunt/helpers/Framework.js
+++ b/grunt/helpers/Framework.js
@@ -185,6 +185,23 @@ class Framework {
     return this;
   }
 
+  /** @returns {Framework} */
+  applyScreenSizeDefaults({
+    includedFilter = this.includedFilter,
+    useOutputData = this.useOutputData
+  } = {}) {
+    const schemas = this.getSchemas({
+      includedFilter
+    });
+    const configSchema = schemas.getConfigSchema();
+    const data = this.getData(useOutputData);
+    const { file, item: config } = data.getConfigFileItem();
+    config.screenSize = configSchema.applyDefaults(config.screenSize, 'screenSize');
+    file.changed();
+    data.save();
+    return this;
+  }
+
 }
 
 module.exports = Framework;

--- a/grunt/tasks/less.js
+++ b/grunt/tasks/less.js
@@ -30,7 +30,7 @@ module.exports = function(grunt) {
       try {
         const configjson = JSON.parse(grunt.file.read(options.config)
           .toString());
-        screenSize = configjson.screenSize || screenSize;
+        screenSize = configjson?.screenSize || screenSize;
       } catch (e) {}
 
       const screensizeEmThreshold = 300;

--- a/grunt/tasks/less.js
+++ b/grunt/tasks/less.js
@@ -30,7 +30,7 @@ module.exports = function(grunt) {
       try {
         const configjson = JSON.parse(grunt.file.read(options.config)
           .toString());
-        screenSize = { ...screenSize, ...configjson.screenSize };
+        screenSize = configjson.screenSize || screenSize;
       } catch (e) {}
 
       const screensizeEmThreshold = 300;

--- a/grunt/tasks/less.js
+++ b/grunt/tasks/less.js
@@ -20,19 +20,19 @@ module.exports = function(grunt) {
     if (options.src && options.config) {
       const framework = Helpers.getFramework({ useOutputData: true });
       framework.applyScreenSizeDefaults();
-      let screenSize = {
-        xsmall: 0,
-        small: 520,
-        medium: 760,
-        large: 900,
-        xlarge: 2147483647
-      };
+      let screenSize;
       try {
         const configjson = JSON.parse(grunt.file.read(options.config)
           .toString());
-        screenSize = configjson?.screenSize || screenSize;
+        screenSize = configjson?.screenSize;
       } catch (e) {}
-
+      if (!screenSize) {
+        const error = new Error('No screenSize defined in config.json');
+        const errorString = error.toString();
+        console.error(errorString);
+        grunt.fail.fatal(errorString);
+        return;
+      }
       const screensizeEmThreshold = 300;
       const baseFontSize = 16;
       for (const [name, value] of Object.entries(screenSize)) {

--- a/grunt/tasks/less.js
+++ b/grunt/tasks/less.js
@@ -1,52 +1,56 @@
 module.exports = function(grunt) {
-  var convertSlashes = /\\/g;
+  const convertSlashes = /\\/g;
+  const Helpers = require('../helpers')(grunt);
 
   grunt.registerMultiTask('less', 'Compile LESS files to CSS', function() {
-    var less = require('less');
-    var _ = require('underscore');
-    var path = require('path');
-    var Visitors = require('./less/visitors');
-    var done = this.async();
-    var options = this.options({});
+    const less = require('less');
+    const _ = require('underscore');
+    const path = require('path');
+    const Visitors = require('./less/visitors');
+    const done = this.async();
+    const options = this.options({});
 
-    var rootPath = path.join(path.resolve(options.baseUrl), '../')
+    const rootPath = path.join(path.resolve(options.baseUrl), '../')
       .replace(convertSlashes, '/');
-    var cwd = process.cwd();
+    const cwd = process.cwd();
 
-    var imports = '';
-    var src = '';
+    let imports = '';
+    let src = '';
 
     if (options.src && options.config) {
-      var screenSize = {
-        'small': 520,
-        'medium': 760,
-        'large': 900
+      const framework = Helpers.getFramework({ useOutputData: true });
+      framework.applyScreenSizeDefaults();
+      let screenSize = {
+        xsmall: 0,
+        small: 520,
+        medium: 760,
+        large: 900,
+        xlarge: 2147483647
       };
       try {
-        var configjson = JSON.parse(grunt.file.read(options.config)
+        const configjson = JSON.parse(grunt.file.read(options.config)
           .toString());
-        screenSize = configjson.screenSize || screenSize;
+        screenSize = { ...screenSize, ...configjson.screenSize };
       } catch (e) {}
 
-      var screensizeEmThreshold = 300;
-      var baseFontSize = 16;
-
-      // Check to see if the screen size value is larger than the em threshold
-      // If value is larger than em threshold, convert value (assumed px) to ems
-      // Otherwise assume value is in ems
-      var largeEmBreakpoint = screenSize.large > screensizeEmThreshold ?
-        screenSize.large / baseFontSize :
-        screenSize.large;
-      var mediumEmBreakpoint = screenSize.medium > screensizeEmThreshold ?
-        screenSize.medium / baseFontSize :
-        screenSize.medium;
-      var smallEmBreakpoint = screenSize.small > screensizeEmThreshold ?
-        screenSize.small / baseFontSize :
-        screenSize.small;
-
-      imports += `\n@adapt-device-large: ${largeEmBreakpoint}em;`;
-      imports += `\n@adapt-device-medium: ${mediumEmBreakpoint}em;`;
-      imports += `\n@adapt-device-small: ${smallEmBreakpoint}em;\n`;
+      const screensizeEmThreshold = 300;
+      const baseFontSize = 16;
+      for (const [name, value] of Object.entries(screenSize)) {
+        // Check to see if the screen size value is larger than the em threshold
+        // If value is larger than em threshold, convert value (assumed px) to ems
+        // Otherwise assume value is in ems
+        screenSize[name] = value > screensizeEmThreshold
+          ? value / baseFontSize
+          : value;
+      }
+      // Add less variables
+      imports += Object.entries(screenSize).map(([name, value]) => {
+        return `\n@adapt-device-${name}: ${value}em;`;
+      }).join('');
+      // Add css variables
+      imports += `\n:root {\n ${Object.entries(screenSize).map(([name, value]) => {
+        return `\n  --adapt-device-${name}: ${value}em;`;
+      }).join('')}\n}`;
     }
 
     if (options.mandatory) {
@@ -58,7 +62,7 @@ module.exports = function(grunt) {
         }, src)
           .forEach(function(lessPath) {
             lessPath = path.normalize(lessPath);
-            var trimmed = lessPath.substr(rootPath.length);
+            const trimmed = lessPath.substr(rootPath.length);
             imports += "@import '" + trimmed + "';\n";
           });
       }
@@ -74,24 +78,24 @@ module.exports = function(grunt) {
         }, src)
           .forEach(function(lessPath) {
             lessPath = path.normalize(lessPath);
-            var trimmed = lessPath.substr(rootPath.length);
+            const trimmed = lessPath.substr(rootPath.length);
             imports += "@import '" + trimmed + "';\n";
           });
       }
     }
 
-    var sourcemaps;
+    let sourcemaps;
     if (options.sourcemaps) {
       sourcemaps = {
-        'sourceMap': {
-          'sourceMapFileInline': false,
-          'outputSourceFiles': true,
-          'sourceMapBasepath': 'src',
-          'sourceMapURL': options.mapFilename
+        sourceMap: {
+          sourceMapFileInline: false,
+          outputSourceFiles: true,
+          sourceMapBasepath: 'src',
+          sourceMapURL: options.mapFilename
         }
       };
     } else {
-      var sourceMapPath = path.join(options.dest, options.mapFilename);
+      const sourceMapPath = path.join(options.dest, options.mapFilename);
       if (grunt.file.exists(sourceMapPath)) {
         grunt.file.delete(sourceMapPath, {
           force: true
@@ -104,11 +108,11 @@ module.exports = function(grunt) {
       }
     }
 
-    var visitors = new Visitors(options);
+    const visitors = new Visitors(options);
 
-    var lessOptions = _.extend({
-      'compress': options.compress,
-      'plugins': [
+    const lessOptions = _.extend({
+      compress: options.compress,
+      plugins: [
         visitors
       ]
     }, sourcemaps);


### PR DESCRIPTION
fixes [#362](https://github.com/adaptlearning/adapt-contrib-core/issues/362)

The process now applies defaults from the schema to the config.json where missing, then reads the values from the config and produces less and css variables from the name/values pairs in the config. Breakpoints are therefore no longer hardcoded.

### New
* Breakpoints are derived from schema defaults and config


