### PR TITLE
Fix: Apply screenSize defaults after json copy

### DIFF
--- a/grunt/tasks/less.js
+++ b/grunt/tasks/less.js
@@ -1,6 +1,5 @@
 module.exports = function(grunt) {
   const convertSlashes = /\\/g;
-  const Helpers = require('../helpers')(grunt);
 
   grunt.registerMultiTask('less', 'Compile LESS files to CSS', function() {
     const less = require('less');
@@ -18,8 +17,6 @@ module.exports = function(grunt) {
     let src = '';
 
     if (options.src && options.config) {
-      const framework = Helpers.getFramework({ useOutputData: true });
-      framework.applyScreenSizeDefaults();
       let screenSize;
       try {
         const configjson = JSON.parse(grunt.file.read(options.config)

--- a/grunt/tasks/schema-defaults.js
+++ b/grunt/tasks/schema-defaults.js
@@ -3,5 +3,6 @@ module.exports = function(grunt) {
   grunt.registerTask('schema-defaults', 'Manufactures the course.json _globals defaults', function() {
     const framework = Helpers.getFramework({ useOutputData: true });
     framework.applyGlobalsDefaults();
+    framework.applyScreenSizeDefaults();
   });
 };


### PR DESCRIPTION
fixes #3412 

### Fix
* Apply screenSize defaults after json copy rather than with less compile, as the json copy can overwrite the defaults from src/course > build/course
