### PR TITLE
Fix: Apply schema defaults as a safeguard for AAT missing defaults

### DIFF
--- a/grunt/tasks/server-build.js
+++ b/grunt/tasks/server-build.js
@@ -10,6 +10,7 @@ module.exports = function(grunt) {
       'build-config',
       'copy',
       'scripts:adaptpostcopy',
+      'schema-defaults',
       'language-data-manifests',
       'less:' + requireMode,
       'handlebars',


### PR DESCRIPTION
fixes #3415 

### Fix
* Apply schema defaults as a safeguard for AAT missing defaults

