### PR TITLE
Fix: Update jsconfig.json for es2022 and jsx

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,11 +1,15 @@
 {
   "include": [
     "src/core/js/**/*.js",
-    "src/*/*/js/**/*.js"
+    "src/*/*/js/**/*.js",
+    "src/core/js/**/*.jsx",
+    "src/*/*/js/**/*.jsx",
+    "src/core/templates/**/*.jsx",
+    "src/*/*/templates/**/*.jsx"
   ],
   "compilerOptions": {
     "module": "amd",
-    "target": "es2015",
+    "target": "es2022",
     "baseUrl": "src/"
   },
   "exclude": [


### PR DESCRIPTION
fixes #3419 

API autocomplete and deprecated highlighting should now work in jsx in Adapt in VSCode and other supporting editors.

![image](https://github.com/adaptlearning/adapt_framework/assets/7974663/3798065e-6ac1-4570-911e-9c22e805dc44)


### Fix
* Update jsconfig.json for es2022 and jsx
