### PR TITLE
Fix: Allow replace task to run specified as dev/prod

### DIFF
--- a/grunt/helpers.js
+++ b/grunt/helpers.js
@@ -224,7 +224,7 @@ module.exports = function(grunt) {
         process.exit();
       }
 
-      const isDevelopmentBuild = process.argv.some(arg => (arg === 'dev' || arg.includes(':dev')));
+      const isDevelopmentBuild = process.argv.some(arg => (arg === 'dev' || arg.includes(':dev') || arg.includes('--dev')));
 
       const data = {
         type: isDevelopmentBuild ? 'development' : 'production',


### PR DESCRIPTION
fixes #3447 

### Fix
* Allow replace task to run specified as dev/prod using the `--dev` flag in the terminal


