### PR TITLE
Fix: Remove paths from build.min.js (fixes #3461)

### DIFF
--- a/grunt/tasks/build-config.js
+++ b/grunt/tasks/build-config.js
@@ -30,7 +30,14 @@ module.exports = function(grunt) {
     });
 
     // remove path specific variables
-    const hideAttributes = ['outputdir', 'sourcedir', 'root'];
+    const hideAttributes = [
+      'cachepath',
+      'configdir',
+      'outputdir',
+      'root',
+      'sourcedir',
+      'tempdir'
+    ];
     hideAttributes.forEach(function(attrName) {
       delete buildConfig[attrName];
     });


### PR DESCRIPTION
fixes #3461 

### Fix
* Removed paths from build.min.js 