### PR TITLE
Fix: Allow tracking ids without spoor installed (fixes #3464)

### DIFF
--- a/grunt/tasks/tracking-insert.js
+++ b/grunt/tasks/tracking-insert.js
@@ -1,7 +1,6 @@
 module.exports = function(grunt) {
   const Helpers = require('../helpers')(grunt);
   grunt.registerTask('tracking-insert', 'Adds any missing tracking IDs (starting at the highest existing ID)', function() {
-    if (!Helpers.isPluginInstalled('adapt-contrib-spoor')) return;
     const data = Helpers.getFramework().getData();
     data.addTrackingIds();
   });


### PR DESCRIPTION
fixes #3464 

### Fix
* Allow tracking ids without spoor installed
