### PR TITLE
Chore: Added drawer extension e2e tests (Issue/3470)

### DIFF
--- a/test/e2e/extensions/drawer.cy.js
+++ b/test/e2e/extensions/drawer.cy.js
@@ -38,7 +38,7 @@ describe('Drawer', () => {
         checkDrawerLength(2)
     });
 
-    it('ahouls display the correct drawer items', () => {
+    it('should display the correct drawer items', () => {
         cy.get('.drawer__item').each(($item, index) => {
             cy.get($item).within(() => {
                 cy.get('.drawer__item-title').should('contain', Course._resources._resourcesItems[index].title)

--- a/test/e2e/extensions/drawer.cy.js
+++ b/test/e2e/extensions/drawer.cy.js
@@ -1,0 +1,63 @@
+import Course from '../../../src/course/en/course.json'
+
+describe('Drawer', () => {
+    const checkDrawerLength = (count) => {
+        cy.get('.drawer__item').not('.u-display-none').should('have.length', count)
+      }
+
+    beforeEach(() => {
+        cy.visit('/');
+        cy.get('button[data-event="toggleDrawer"]').click()
+    })
+
+    it('should appear on the right hand side in menu view', () => {
+        cy.get('.drawer').should('have.css', 'right').and('match', /0px/)
+    });
+
+    it('should appear on the right hand side in course view', () => {
+        cy.get('button.drawer__close-btn').click()
+        cy.get('button').contains('View').first().click()
+        cy.get('button[data-event="toggleDrawer"]').click()
+        cy.get('.drawer').should('have.css', 'right').and('match', /0px/)
+    });
+
+    it(`should show ${Course._resources._resourcesItems.length} items`, () => {
+        checkDrawerLength(4)
+    });
+
+    it('should display the correct amount of items in each tab', () => {
+        cy.get('button.is-selected[id="resources__show-all"]').should('exist')
+
+        cy.get('button[id="resources__show-document"]').should('exist').click()
+        checkDrawerLength(1)
+
+        cy.get('button[id="resources__show-media"]').should('exist').click()
+        checkDrawerLength(1)
+
+        cy.get('button[id="resources__show-link"]').should('exist').click()
+        checkDrawerLength(2)
+    });
+
+    it('ahouls display the correct drawer items', () => {
+        cy.get('.drawer__item').each(($item, index) => {
+            cy.get($item).within(() => {
+                cy.get('.drawer__item-title').should('contain', Course._resources._resourcesItems[index].title)
+                cy.get('.drawer__item-body').should('contain', Course._resources._resourcesItems[index].description)
+                cy.get('a').should('have.attr', 'target', '_blank').should('have.attr', 'href', Course._resources._resourcesItems[index]._link)
+            })
+        })
+    });
+
+    it('should be able to close the drawer by clicking X', () => {
+        cy.get('button.drawer__close-btn').click()
+        
+        cy.get('.drawer').should('have.attr', 'aria-expanded', 'false')
+    });
+    
+    it('should be able to close the drawer by hitting ESC', () => {
+        cy.get('.drawer').type('{esc}')
+
+        cy.get('.drawer').should('have.attr', 'aria-expanded', 'false')
+    });
+  });
+  

--- a/test/e2e/extensions/drawer.cy.js
+++ b/test/e2e/extensions/drawer.cy.js
@@ -16,7 +16,7 @@ describe('Drawer', () => {
 
     it('should appear on the right hand side in course view', () => {
         cy.get('button.drawer__close-btn').click()
-        cy.get('button').contains('View').first().click()
+        cy.get('.menu-item .menu-item__button-container button').contains('View').first().click()
         cy.get('button[data-event="toggleDrawer"]').click()
         cy.get('.drawer').should('have.css', 'right').and('match', /0px/)
     });


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
addresses adaptlearning/adapt-contrib-resources#111 

