### PR TITLE
Fix: Wrapping Cypress run in try/catch to exit more gracefully (3502)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "adapt_framework",
-    "version": "5.33.13",
+    "version": "5.35.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "adapt_framework",
-            "version": "5.33.13",
+            "version": "5.35.0",
             "hasInstallScript": true,
             "license": "GPL-3.0",
             "dependencies": {

--- a/test.js
+++ b/test.js
@@ -77,7 +77,7 @@ async function gruntServer() {
 };
 
 async function waitForGruntServer() {
-  return waitForExec('node', './node_modules/wait-on/bin/wait-on', 'http://localhost:9001');
+  return waitForExec('node', './node_modules/wait-on/bin/wait-on', 'http://127.0.0.1:9001');
 };
 
 async function cypressRun() {
@@ -165,12 +165,19 @@ ${Object.values(commands).map(({ name, description }) => `    ${name.padEnd(21, 
     async start() {
       const gruntServerRun = await gruntServer();
       await waitForGruntServer();
-      const cypressCode = await cypressRun();
 
-      if (cypressCode > 0) {
-        console.log(`Cypress failed with code '${cypressCode}'`);
-        process.exit(1);
+      try {
+        const cypressCode = await cypressRun();
+
+        if (cypressCode > 0) {
+          console.log(`Cypress failed with code '${cypressCode}'`);
+          process.exit(1);
+        }
+      } catch (cypressErr) {
+        console.log('Cypress tests failure');
+        console.log(cypressErr);
       }
+
       gruntServerRun.kill();
     }
   },


### PR DESCRIPTION
Fixes #3502

### Fix
* Wrapping Cypress run in try/catch to exit more gracefully
* Updated wait-on url to fix breaking listener when run in Node18