### PR TITLE
New: Add build cache path log (fixes #3504)

### DIFF
--- a/grunt/tasks/javascript.js
+++ b/grunt/tasks/javascript.js
@@ -124,13 +124,16 @@ module.exports = function(grunt) {
     const Helpers = require('../helpers')(grunt);
     const buildConfig = Helpers.generateConfigData();
     const isStrictMode = buildConfig.strictMode;
-    grunt.log.ok(`Cache disabled (--disable-cache): ${isDisableCache}`);
     grunt.log.ok(`Strict mode (config.json:build.strictMode): ${isStrictMode}`);
+    grunt.log.ok(`Cache disabled (--disable-cache): ${isDisableCache}`);
     const done = this.async();
     const options = this.options({});
     const isSourceMapped = Boolean(options.generateSourceMaps);
     const basePath = path.resolve(cwd + '/' + options.baseUrl).replace(convertSlashes, '/') + '/';
     const cachePath = buildConfig.cachepath ?? cacheManager.cachePath(cwd, options.out);
+    if (!isDisableCache) {
+      grunt.log.ok(`Cache path: ${cachePath}`);
+    }
     try {
       await restoreCache(cachePath, basePath);
       await cacheManager.clean();


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
#3504 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Update
* Re-ordered the existing logs to group the cache logs

### New
* Added an extra log to the `javascript` task to print cache path (if enabled)

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Run any grunt task which includes the `javascript` task (any `build` will do)

[//]: # (Mention any other dependencies)


