### PR TITLE
Fix: Add plugin name to "unknown plugin type" error message (fixes #3526)

### DIFF
--- a/grunt/helpers/plugins/Plugin.js
+++ b/grunt/helpers/plugins/Plugin.js
@@ -104,12 +104,13 @@ class Plugin {
     if (this.name === 'core') {
       return 'component';
     }
+    const packageName = this.packageJSONFile.firstFileItem.item.name;
     const config = this.packageJSONFile.firstFileItem.item;
     const configKeys = Object.keys(config);
     const typeKeyName = ['component', 'extension', 'menu', 'theme'];
     const foundType = configKeys.find(key => typeKeyName.includes(key));
     if (!foundType) {
-      throw new Error('Unknown plugin type');
+      throw new Error(`Unknown plugin type for ${packageName}`);
     }
     return foundType;
   }

--- a/grunt/helpers/plugins/Plugin.js
+++ b/grunt/helpers/plugins/Plugin.js
@@ -104,13 +104,12 @@ class Plugin {
     if (this.name === 'core') {
       return 'component';
     }
-    const packageName = this.packageJSONFile.firstFileItem.item.name;
     const config = this.packageJSONFile.firstFileItem.item;
     const configKeys = Object.keys(config);
     const typeKeyName = ['component', 'extension', 'menu', 'theme'];
     const foundType = configKeys.find(key => typeKeyName.includes(key));
     if (!foundType) {
-      throw new Error(`Unknown plugin type for ${packageName}`);
+      throw new Error(`Unknown plugin type for ${this.name}`);
     }
     return foundType;
   }


### PR DESCRIPTION
Fix #3526

### Fix
* Adds the plugin name to the "unknown plugin type" error message

### Testing
See #3526 