### PR TITLE
Fix: Default to secure connection for bower registry

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,4 @@
 {
     "directory": "src/plugins",
-    "registry": "http://adapt-bower-repository.herokuapp.com/"
+    "registry": "https://adapt-bower-repository.herokuapp.com/"
 }


### PR DESCRIPTION
fixes https://github.com/adaptlearning/adapt_authoring/issues/2763

### Fix
* Set default bower registry to secure http protocol
