### PR TITLE
Fix: Add _navigation and _tooltips objects to sample course (fixes #3555)

### DIFF
--- a/src/course/en/course.json
+++ b/src/course/en/course.json
@@ -171,6 +171,17 @@
       "no": "No"
     }
   },
+  "_navigation": {
+    "_isDefaultNavigationDisabled": false,
+    "_navigationAlignment": "top",
+    "_isBottomOnTouchDevices": false,
+    "_showLabel": false,
+    "_showLabelAtWidth": "medium",
+    "_labelPosition": "auto"
+  },
+  "_tooltips": {
+    "_isEnabled": true
+  },
   "_vanilla": {
     "_favIcon": {
       "_src": ""


### PR DESCRIPTION
Fix #3555 

### Fix
* Adds `_navigation` and `_tooltips` objects to the sample [course](https://github.com/adaptlearning/adapt_framework/tree/master/src/course)