### PR TITLE
Fix: Remove values for _feedback._altTitle in sample course (fixes #3566)

### DIFF
--- a/src/course/en/components.json
+++ b/src/course/en/components.json
@@ -399,7 +399,7 @@
     ],
     "_feedback": {
       "title": "Feedback",
-      "altTitle": "Feedback",
+      "altTitle": "",
       "correct": "Correct feedback text.<br><br>That’s correct. The first large assessment to consist solely of the multiple choice question type was the Army Alpha test, used from <strong>1917</strong> to evaluate U.S. military recruits in the First World War.<br><br>Source: <a href='http://en.wikipedia.org/wiki/Multiple_choice' target='_blank'>Wikipedia</a><br><br><i>Component facts: <b>Multiple Choice Questions (or MCQs)</b> are a tried and tested method for presenting learners with a simple text-based question. Component is either single or spanned.</i>",
       "_incorrect": {
         "notFinal": "",
@@ -503,7 +503,7 @@
     ],
     "_feedback": {
       "title": "Feedback",
-      "altTitle": "Alt feedback text",
+      "altTitle": "",
       "correct": "Correct feedback text.<br><br>That’s correct. <strong>Option 2</strong> is what we were looking for!",
       "_incorrect": {
         "final": "Incorrect feedback text.<br><br>Sorry, that’s not right. In fact <strong>Option 2</strong> is what we were looking for (the clue was in the instruction text!)."
@@ -561,7 +561,7 @@
     ],
     "_feedback": {
       "title": "Feedback",
-      "altTitle": "Feedback",
+      "altTitle": "",
       "correct": "Correct answer feedback.<br><br>That’s correct. The Adapt open source project was established by Kineo, Learning Pool and Sponge. At the time of writing, there were a total of nine <a href='https://www.adaptlearning.org/index.php/collaborators/' target='_blank'>official collaborators</a>.<br><br><i>Component facts: <b>Text input</b> components let learners enter their own answers, which is great for questions that require a bit more flexibility, like those with answers that could be written as both full words and numbers.</i>",
       "_partlyCorrect": {
         "notFinal": "",
@@ -705,7 +705,7 @@
     ],
     "_feedback": {
       "title": "Feedback",
-      "altTitle": "Feedback",
+      "altTitle": "",
       "correct": "Correct answer feedback.<br><br>Yes, that’s right. Adapt was established as an Open Source project in 2013. The Web Accessibility Initiative (WAI) published the WCAG 2.0 guidelines in 2008 and Hebrew is the only language of the four shown which reads right to left.<br><br><i>Component facts: The <b>Matching</b> component lets you match a series of questions or statements with the corresponding options from the dropdown box. Component is either single or spanned.</i>",
       "_partlyCorrect": {
         "notFinal": "",
@@ -757,7 +757,7 @@
     },
     "_feedback": {
       "title": "Feedback",
-      "altTitle": "Feedback",
+      "altTitle": "",
       "correct": "Correct answer feedback.<br><br>Yes, that’s right. According to Miller’s paper 7 +/- 2 chunks of information was the limited capacity of working memory. Various theories from the field of cognitive psychology such as Miller’s <a href='http://en.wikipedia.org/wiki/The_Magical_Number_Seven,_Plus_or_Minus_Two' target='_blank'>magical number</a>, <a href='http://en.wikipedia.org/wiki/Chunking_%28psychology%29#Chunking_as_the_learning_of_long-term_memory_structures' target='_blank'>chunking</a>, <a href='http://en.wikipedia.org/wiki/Forgetting_curve' target='_blank'>the forgetting curve</a> and <a href='http://en.wikipedia.org/wiki/Spaced_repetition' target='_blank'>spaced repetition</a> have all influenced learning theory over the last 50 years or so.<br><br><i>Component facts: The correct answer for a <b>Slider</b> component can be an exact number or a range. In this instance we have set the correct answer to a range of 5-9 due to the correct answer being seven plus or minus two. Component is either single or spanned.</i>",
       "_incorrect": {
         "notFinal": "",


### PR DESCRIPTION
Fixes #3566 

### Fix
* Removes values for `_feedback._altTitle` in sample course. Keeps the property in place.

### Related
https://github.com/adaptlearning/adapt-contrib-core/pull/551
