### PR TITLE
Fix: Refactor CacheManager to use cachepath grunt option internally (fixes #3599)

### DIFF
--- a/grunt/helpers/CacheManager.js
+++ b/grunt/helpers/CacheManager.js
@@ -24,8 +24,7 @@ module.exports = class CacheManager {
   }
 
   get tempPath() {
-    const tempPath = path.join(os.tmpdir(), 'adapt_framework');
-    return tempPath;
+    return this.grunt.option('cachepath') ?? path.join(os.tmpdir(), 'adapt_framework');
   }
 
   cachePath(basePath, outputFilePath = process.cwd()) {

--- a/grunt/tasks/javascript.js
+++ b/grunt/tasks/javascript.js
@@ -130,7 +130,7 @@ module.exports = function(grunt) {
     const options = this.options({});
     const isSourceMapped = Boolean(options.generateSourceMaps);
     const basePath = path.resolve(cwd + '/' + options.baseUrl).replace(convertSlashes, '/') + '/';
-    const cachePath = buildConfig.cachepath ?? cacheManager.cachePath(cwd, options.out);
+    const cachePath = cacheManager.cachePath(cwd, options.out);
     if (!isDisableCache) {
       grunt.log.ok(`Cache path: ${cachePath}`);
     }


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes #3599

Added this as a draft for now, as not sure if there was a specific reason for setting a custom cache path in the current way.

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Updates CacheManager's tempPath getter to pick up grunt.option('cachepath') - currently this is set externally outside of the CacheManager (in [tasks/javascript.js](https://github.com/adaptlearning/adapt_framework/blob/master/grunt/tasks/javascript.js#L133))

[//]: # (List appropriate steps for testing if needed)
### Testing
#### Scenario 1
Run a standard grunt build
#### Scenario 2
Run build with **--cachepath** grunt option.
i.e.
```
grunt server-build:dev --cachepath=XXX
```

[//]: # (Mention any other dependencies)


