### PR TITLE
Fix: Populating testfile globs that are specific to the current test runner

### DIFF
--- a/test.js
+++ b/test.js
@@ -95,6 +95,9 @@ async function populateTestFiles(testFormat) {
     return `**/${plugin}/test/${globSuffix}`;
   });
 
+  // Add the framework level test files
+  testFiles.push(`**/test/${globSuffix}`);
+
   argumentValues.testfiles = testFiles.join(',');
 }
 

--- a/test.js
+++ b/test.js
@@ -81,7 +81,7 @@ async function waitForGruntServer() {
   return waitForExec('node', './node_modules/wait-on/bin/wait-on', 'http://127.0.0.1:9001');
 };
 
-async function populateTestFiles() {
+async function populateTestFiles(testFormat) {
   // accept the user-specified file(s)
   if (argumentValues.testfiles) return;
 
@@ -89,22 +89,24 @@ async function populateTestFiles() {
   const config = JSON.parse(fs.readFileSync(path.join(argumentValues.outputdir, 'course', 'config.json')));
   const plugins = config?.build?.includes || [];
 
+  const globSuffix = testFormat === 'e2e' ? 'e2e/*.cy.js' : 'unit/*.js';
+
   const testFiles = plugins.map(plugin => {
-    return `**/${plugin}/**/*.cy.js`;
+    return `**/${plugin}/test/${globSuffix}`;
   });
 
   argumentValues.testfiles = testFiles.join(',');
 }
 
 async function cypressRun() {
-  await populateTestFiles();
+  await populateTestFiles('e2e');
   return asyncSpawn('node', './node_modules/cypress/bin/cypress', 'run', '--spec', `${argumentValues.testfiles}`, '--config', `{"fixturesFolder": "${argumentValues.outputdir}"}`);
 };
 
 async function jestRun() {
   config.testEnvironmentOptions.outputDir = argumentValues.outputdir;
 
-  await populateTestFiles();
+  await populateTestFiles('unit');
 
   if (argumentValues.testfiles) {
     config.testMatch = argumentValues.testfiles.split(',');


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
Fixes #3608 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Populating testfile globs that are specific to the current test runner