### PR TITLE
Fix: Add _theme and _menu attributes to config.json (fixes #3602)

### DIFF
--- a/src/course/config.json
+++ b/src/course/config.json
@@ -2,6 +2,8 @@
   "_defaultLanguage": "en",
   "_defaultDirection": "ltr",
   "_questionWeight": 1,
+  "_theme": "adapt-contrib-vanilla",
+  "_menu": "adapt-contrib-boxMenu",
   "_logging": {
     "_isEnabled": true,
     "_level": "debug",


### PR DESCRIPTION
Fix #3602 

### Fix
* Adds `_theme` and `_menu` attributes to _config.json_. Without these, courses can break when importing into AAT v1.