### PR TITLE
Fix: Support for node v23.0.0 (fixes #3618)

### DIFF
--- a/grunt/helpers/data/Language.js
+++ b/grunt/helpers/data/Language.js
@@ -38,7 +38,7 @@ class Language {
     /** @type {string} */
     this.jsonext = jsonext;
     /** @type {string} */
-    this.path = languagePath.replace(/\\/g, '/');
+    this.path = path.normalize(languagePath).replace(/\\/g, '/');
     /** @type {string} */
     this.name = this.path.split('/').filter(Boolean).pop();
     /** @type {string} */


### PR DESCRIPTION
fixes #3618 


### Fix
* Correct double `//` using [`path.normalize`](https://nodejs.org/api/path.html#pathnormalizepath) which resolves incorrect truncation of file names here:
https://github.com/adaptlearning/adapt_framework/blob/49825341361c0e1bb3ac28344fe030b7380efefd/grunt/helpers/data/Language.js#L69
