### PR TITLE
Update: Update assessment article properties in sample course (fix #3626 #3627)

### DIFF
--- a/src/course/en/articles.json
+++ b/src/course/en/articles.json
@@ -37,7 +37,7 @@
       "_includeInTotalScore": true,
       "_assessmentWeight": 1,
       "_isResetOnRevisit": true,
-      "_attempts": "infinite",
+      "_attempts": -1,
       "_allowResetIfPassed": false,
       "_scrollToOnReset": false,
       "_banks": {
@@ -58,6 +58,7 @@
     },
     "_trickle": {
       "_isEnabled": true,
+      "_onChildren": true,
       "_button": {
         "_isEnabled": true,
         "startText": "Continue"


### PR DESCRIPTION
Fix #3626 #3627

### Update
* Sets `_assessment._attempts` to the default value of `-1` instead of an invalid string value
* Sets `_trickle._onChildren` to true to match the behavior when the value is not explicitly set