### PR TITLE
Fix: ensure this.outputPath/sourcePath trailing slash isn't removed (fixes #3675)

### DIFF
--- a/grunt/helpers/Framework.js
+++ b/grunt/helpers/Framework.js
@@ -42,9 +42,9 @@ class Framework {
     /** @type {string} */
     this.rootPath = rootPath.replace(/\\/g, '/');
     /** @type {string} */
-    this.outputPath = path.resolve(this.rootPath, outputPath).replace(/\\/g, '/');
+    this.outputPath = path.resolve(this.rootPath, outputPath).replace(/\\/g, '/').replace(/\/?$/, '/');
     /** @type {string} */
-    this.sourcePath = path.resolve(this.rootPath, sourcePath).replace(/\\/g, '/');
+    this.sourcePath = path.resolve(this.rootPath, sourcePath).replace(/\\/g, '/').replace(/\/?$/, '/');
     /** @type {string} */
     this.courseDir = courseDir;
     /** @type {function} */


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
When changing from path.join to path.resolve the path is now being normalized and trailing slashes being removed.
#3675 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* ensure this.outputPath/sourcePath trailing slash isn't removed (fixes #3675)


