### PR TITLE
New: Added topOfContentObject aria labels (fixes #3678)

### DIFF
--- a/src/course/en/course.json
+++ b/src/course/en/course.json
@@ -66,7 +66,11 @@
         "locked": "Locked",
         "visited": "Visited",
         "required": "Required",
-        "optional": "Optional"
+        "optional": "Optional",
+        "topOfContentObject": "{{type}} {{displayTitle}}",
+        "course": "Main menu",
+        "menu": "Sub menu",
+        "page": "Page"
       }
     },
     "_extensions": {


### PR DESCRIPTION
fixes #3678
requires https://github.com/adaptlearning/adapt-contrib-core/pull/655

### New
* `_globals._accessibility._ariaLabels.topOfContentObject = '{{type}} {{displayTitle}}'`
* `_globals._accessibility._ariaLabels.course = "Main menu"`
* `_globals._accessibility._ariaLabels.menu = "Sub menu"`
* `_globals._accessibility._ariaLabels.page = "Page"`
