### PR TITLE
New: customscriptsdir added to migrations grunt task (fixes #3677)

### DIFF
--- a/grunt/tasks/migration.js
+++ b/grunt/tasks/migration.js
@@ -32,6 +32,7 @@ module.exports = function(grunt) {
     const next = this.async();
     const buildConfig = Helpers.generateConfigData();
     const fileNameIncludes = grunt.option('file');
+    const customScriptsDir = grunt.option('customscriptsdir');
 
     (async function() {
       const migrations = await import('adapt-migrations');
@@ -80,13 +81,16 @@ module.exports = function(grunt) {
       logger.debug(`Using ${toFramework.useOutputData ? toFramework.outputPath : toFramework.sourcePath} folder for course data...`);
       const plugins = toFramework.getPlugins().getAllPackageJSONFileItems().map(fileItem => fileItem.item);
       const migrationScripts = Array.from(await new Promise(resolve => {
-        globs([
-          '*/*/migrations/**/*.js',
-          'core/migrations/**/*.js'
-        ], { cwd: path.join(cwd, './src/'), absolute: true }, (err, files) => resolve(err ? null : files));
+        const globPatterns = [
+          'src/*/*/migrations/**/*.js',
+          'src/core/migrations/**/*.js'
+        ];
+        if (customScriptsDir) globPatterns.push(`${customScriptsDir}/*.js`);
+
+        globs(globPatterns, { cwd, absolute: true }, (err, files) => resolve(err ? null : files));
       })).filter(filePath => {
         if (!fileNameIncludes) return true;
-        return minimatch(filePath, '**/' + fileNameIncludes) || filePath.includes(fileNameIncludes);
+        return new RegExp(`(^|\\W)${fileNameIncludes}(\\W|$)`).test(filePath);
       });
 
       if (!migrationScripts.length) {

--- a/grunt/tasks/migration.js
+++ b/grunt/tasks/migration.js
@@ -1,3 +1,5 @@
+const { match } = require('assert');
+
 module.exports = function(grunt) {
 
   const Helpers = require('../helpers')(grunt);
@@ -26,6 +28,11 @@ module.exports = function(grunt) {
     delete clone.__path__;
     delete clone.__jsonext__;
     return clone;
+  }
+
+  function matchFileNameIncludes(filePath, fileNameIncludes) {
+    const regex = new RegExp(`(^|\\/)${fileNameIncludes}(\\W|$)`);
+    return regex.test(filePath);
   }
 
   grunt.registerTask('migration', 'Migrate from one version to another', function(mode) {
@@ -86,11 +93,10 @@ module.exports = function(grunt) {
           'src/core/migrations/**/*.js'
         ];
         if (customScriptsDir) globPatterns.push(`${customScriptsDir}/*.js`);
-
         globs(globPatterns, { cwd, absolute: true }, (err, files) => resolve(err ? null : files));
       })).filter(filePath => {
         if (!fileNameIncludes) return true;
-        return new RegExp(`(^|\\W)${fileNameIncludes}(\\W|$)`).test(filePath);
+        return matchFileNameIncludes(filePath, fileNameIncludes);
       });
 
       if (!migrationScripts.length) {


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)
Adding the customscriptdir is to allow a custom folder to be specified, this allows us to load custom migration scripts for the authoring tool. 

Changed the filNameIncludes from .includes to RegExp, this is to make it more accurate when targetting a specific file. For example when using .includes the flag --file=text will also pull through textInput. 

[//]: # (Link the PR to the original issue)
#3677 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* match fileNameIncludes changed to RegExp

### New
* customscriptsdir added to migrations grunt task (#3677)


