### PR TITLE
Chore: Add _enableFilters to _resources in default course (fix #3687)

### DIFF
--- a/src/course/en/course.json
+++ b/src/course/en/course.json
@@ -108,6 +108,7 @@
     "displayTitle": "",
     "body": "",
     "instruction": "",
+    "_enableFilters": true,
     "_filterButtons": {
       "all": "All",
       "document": "Document",


### PR DESCRIPTION
Fix #3687 

### Chore
* Adds `_enableFilters` to `_resources` in default course's _course.json_
