### PR TITLE
Fix: Deprecated config for _shouldSubmitScore (fixes #3740)

### DIFF
--- a/src/course/config.json
+++ b/src/course/config.json
@@ -55,12 +55,12 @@
   "_completionCriteria": {
     "_requireContentCompleted": false,
     "_requireAssessmentCompleted": true,
-    "_submitOnEveryAssessmentAttempt": true
+    "_submitOnEveryAssessmentAttempt": true,
+    "_shouldSubmitScore": true
   },
   "_spoor": {
     "_isEnabled": true,
     "_tracking": {
-      "_shouldSubmitScore": true,
       "_shouldStoreResponses": true,
       "_shouldStoreAttempts": false,
       "_shouldRecordInteractions": true,


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Added '_shouldSubmitScore' to completion criteria and removed it from tracking.
* Fixes #3740 

[//]: # (List appropriate steps for testing if needed)
### Testing
1. Install vanilla Adapt.
2. Check for warning message calling out depreciated configuration as indicated in #3740 

[//]: # (Mention any other dependencies)


