### PR TITLE
Update: Match less:dev filters to production build task (fixes #3802)

### DIFF
--- a/grunt/config/less.js
+++ b/grunt/config/less.js
@@ -82,11 +82,13 @@ module.exports = function(grunt, options) {
   return {
     dev: {
       options: devOptions,
-      // newer configuration
       files: {
         '<%= outputdir %>adapt.css': [
-          '<%= sourcedir %>/core/less/**/*.less',
-          '<%= sourcedir %>/*/*/less/**/*.less'
+          '<%= sourcedir %>core/less/**/*.less',
+          '<%= sourcedir %>components/*/less/**/*.less',
+          '<%= sourcedir %>extensions/*/less/**/*.less',
+          '<%= sourcedir %>menu/<%= menu %>/**/*.less',
+          '<%= sourcedir %>theme/<%= theme %>/**/*.less'
         ]
       }
     },


### PR DESCRIPTION
### Fixes #3802

### Update

- Update `less:dev`'s source list to match the `compile` task — scope `menu` and `theme` globs to the active plugin via `<%= menu %>` / `<%= theme %>`, and add `components`/`extensions` as wildcards